### PR TITLE
Add configuration for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
 language: go
 go: 
-  - 1.10
+  - "1.10"
 
 go_import_path: github.com/terraform-providers/terraform-provider-nutanix
 
+before_install:
+  - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+  - dep status
+  - dep ensure
+
 install:
-- bash scripts/gogetcookie.sh
-- curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+  - export GOPATH="${TRAVIS_BUILD_DIR}/vendor:$GOPATH"
+  - make build 
+
+before_script:
+  - make vet
 
 script:
-- make vendor-status
-- make testacc
+  - make testacc

--- a/nutanix/data_source_nutanix_clusters_test.go
+++ b/nutanix/data_source_nutanix_clusters_test.go
@@ -24,13 +24,6 @@ func TestAccOutscaleClustersDataSource_basic(t *testing.T) {
 
 // Lookup based on InstanceID
 const testAccClustersDataSourceConfig = `
-provider "nutanix" {
-  username = "admin"
-  password = "Nutanix/1234"
-  endpoint = "10.5.81.134"
-  insecure = true
-  port     = 9440
-}
 data "nutanix_clusters" "basic_web" {
 	metadata = {
 		length = 3

--- a/nutanix/data_source_nutanix_virtual_machine_test.go
+++ b/nutanix/data_source_nutanix_virtual_machine_test.go
@@ -30,14 +30,6 @@ func TestAccNutanixVMDataSource_basic(t *testing.T) {
 
 func testAccVMDataSourceConfig(r int) string {
 	return fmt.Sprintf(`
-provider "nutanix" {
-  username = "admin"
-  password = "Nutanix/1234"
-  endpoint = "10.5.81.134"
-  insecure = true
-  port     = 9440
-}
-
 variable clusterid {
   default = "000567f3-1921-c722-471d-0cc47ac31055"
 }

--- a/nutanix/data_source_nutanix_virtual_machines_test.go
+++ b/nutanix/data_source_nutanix_virtual_machines_test.go
@@ -24,14 +24,6 @@ func TestAccOutscaleVMSSDataSource_basic(t *testing.T) {
 
 // Lookup based on InstanceID
 const testAccVMSSDataSourceConfig = `
-provider "nutanix" {
-  username = "admin"
-  password = "Nutanix/1234"
-  endpoint = "10.5.81.134"
-  insecure = true
-  port     = 9440
-}
-
 variable clusterid {
   default = "000567f3-1921-c722-471d-0cc47ac31055"
 }

--- a/nutanix/resource_nutanix_virtual_machine_test.go
+++ b/nutanix/resource_nutanix_virtual_machine_test.go
@@ -74,14 +74,6 @@ func testAccCheckNutanixVirtualMachineDestroy(s *terraform.State) error {
 
 func testAccNutanixVMConfig(r int) string {
 	return fmt.Sprint(`
-provider "nutanix" {
-  username = "admin"
-  password = "Nutanix/1234"
-  endpoint = "10.5.81.139"
-  insecure = true
-  port     = 9440
-}
-
 variable clusterid {
   default = "000567f3-1921-c722-471d-0cc47ac31055"
 }


### PR DESCRIPTION
closes #38 

Here is the new Travis config that currently works.
 
The following step is to add environmental variables for Nutanix provider

```bash
NUTANIX_ENDPOINT=1.1.1.1
NUTANIX_PORT=0000
NUTANIX_INSECURE=true
NUTANIX_PASSWORD=password
NUTANIX_USERNAME=username
```


