### PR TITLE
Image upload fail

### DIFF
--- a/nutanix/resource_nutanix_image.go
+++ b/nutanix/resource_nutanix_image.go
@@ -122,6 +122,9 @@ func resourceNutanixImageCreate(d *schema.ResourceData, meta interface{}) error 
 
 		err = conn.V3.UploadImage(UUID, path.(string))
 		if err != nil {
+
+			resourceNutanixImageDelete(d, meta)
+
 			return fmt.Errorf("Failed uploading image: %s", err)
 		}
 	}

--- a/nutanix/resource_nutanix_image.go
+++ b/nutanix/resource_nutanix_image.go
@@ -123,7 +123,10 @@ func resourceNutanixImageCreate(d *schema.ResourceData, meta interface{}) error 
 		err = conn.V3.UploadImage(UUID, path.(string))
 		if err != nil {
 
-			resourceNutanixImageDelete(d, meta)
+			delErr := resourceNutanixImageDelete(d, meta)
+			if delErr != nil {
+				return delErr
+			}
 
 			return fmt.Errorf("Failed uploading image: %s", err)
 		}


### PR DESCRIPTION
If an image upload fails, then destroy the resource.

closes #133 