### PR TITLE
Move schemas to the resource function

### DIFF
--- a/nutanix/data_source_nutanix_cluster.go
+++ b/nutanix/data_source_nutanix_cluster.go
@@ -11,8 +11,592 @@ import (
 
 func dataSourceNutanixCluster() *schema.Resource {
 	return &schema.Resource{
-		Read:   dataSourceNutanixClusterRead,
-		Schema: getDataSourceClusterSchema(),
+		Read: dataSourceNutanixClusterRead,
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"metadata": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"last_update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec_hash": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"categories": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"project_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"owner_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"api_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			// COMPUTED
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"nodes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"gpu_driver_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"client_auth": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ca_chain": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"authorized_public_key_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"software_map_ncc": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"software_map_nos": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"encryption_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ssl_key_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ssl_key_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ssl_key_signing_info": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"city": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"common_name_suffix": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"country_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"common_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"organization": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"email_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"ssl_key_expire_datetime": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"supported_information_verbosity": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certification_signing_info": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"city": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"common_name_suffix": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"country_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"common_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"organization": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"email_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"operation_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ca_certificate_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ca_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"certificate": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"enabled_feature_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"is_available": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"build": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"commit_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"full_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"commit_date": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"short_commit_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"build_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"timezone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_arch": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"management_server_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"drs_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"status_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"masquerading_port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"masquerading_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"external_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"http_proxy_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"credentials": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"username": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"password": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"proxy_type_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"address": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"fqdn": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"port": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ipv6": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"smtp_server_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"smtp_server_email_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"smtp_server_credentials": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"username": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"password": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"smtp_server_proxy_type_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"smtp_server_address": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fqdn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ipv6": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"ntp_server_ip_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"external_subnet": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"external_data_services_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"internal_subnet": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_server_nameserver": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_server_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_server_credentials": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"username": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"password": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"nfs_subnet_whitelist": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"name_server_ip_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"http_proxy_whitelist": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"target": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"target_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"analysis_vm_efficiency_map": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bully_vm_num": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"constrained_vm_num": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"dead_vm_num": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"inefficient_vm_num": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"overprovisioned_vm_num": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -407,592 +991,4 @@ func dataSourceNutanixClusterRead(d *schema.ResourceData, meta interface{}) erro
 	d.SetId(*v.Metadata.UUID)
 
 	return nil
-}
-
-func getDataSourceClusterSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"cluster_id": {
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		"metadata": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"last_update_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"creation_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"spec_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"spec_hash": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"categories": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"value": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"project_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"owner_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"api_version": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"name": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-
-		// COMPUTED
-		"state": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"nodes": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"ip": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"gpu_driver_version": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"client_auth": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"status": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"ca_chain": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"authorized_public_key_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"key": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"software_map_ncc": {
-			Type:     schema.TypeMap,
-			Computed: true,
-		},
-		"software_map_nos": {
-			Type:     schema.TypeMap,
-			Computed: true,
-		},
-		"encryption_status": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"ssl_key_type": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"ssl_key_name": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"ssl_key_signing_info": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"city": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"common_name_suffix": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"state": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"country_code": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"common_name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"organization": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"email_address": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"ssl_key_expire_datetime": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"service_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"supported_information_verbosity": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"certification_signing_info": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"city": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"common_name_suffix": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"state": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"country_code": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"common_name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"organization": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"email_address": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"operation_mode": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"ca_certificate_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"ca_name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"certificate": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"enabled_feature_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"is_available": {
-			Type:     schema.TypeBool,
-			Computed: true,
-		},
-		"build": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"commit_id": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"full_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"commit_date": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"short_commit_id": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"build_type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"timezone": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"cluster_arch": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"management_server_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"ip": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"drs_enabled": {
-						Type:     schema.TypeBool,
-						Computed: true,
-					},
-					"status_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"masquerading_port": {
-			Type:     schema.TypeInt,
-			Computed: true,
-		},
-		"masquerading_ip": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"external_ip": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"http_proxy_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"credentials": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"username": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"password": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"proxy_type_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"address": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"ip": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"fqdn": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"port": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"ipv6": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"smtp_server_type": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"smtp_server_email_address": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"smtp_server_credentials": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"username": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"password": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"smtp_server_proxy_type_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"smtp_server_address": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"ip": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"fqdn": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"port": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"ipv6": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"ntp_server_ip_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"external_subnet": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"external_data_services_ip": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"internal_subnet": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"domain_server_nameserver": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"domain_server_name": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"domain_server_credentials": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"username": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"password": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"nfs_subnet_whitelist": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"name_server_ip_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"http_proxy_whitelist": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"target": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"target_type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"analysis_vm_efficiency_map": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"bully_vm_num": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"constrained_vm_num": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"dead_vm_num": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"inefficient_vm_num": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"overprovisioned_vm_num": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-	}
 }

--- a/nutanix/data_source_nutanix_clusters.go
+++ b/nutanix/data_source_nutanix_clusters.go
@@ -13,7 +13,599 @@ func dataSourceNutanixClusters() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceNutanixClustersRead,
 
-		Schema: getDataSourceClustersSchema(),
+		Schema: map[string]*schema.Schema{
+			"api_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"entities": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"metadata": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"last_update_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"creation_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"spec_version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"spec_hash": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"categories": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"project_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"owner_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"api_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						// COMPUTED
+						"state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"nodes": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"gpu_driver_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"client_auth": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"status": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ca_chain": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"authorized_public_key_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"software_map_ncc": {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
+						"software_map_nos": {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
+						"encryption_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ssl_key_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ssl_key_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ssl_key_signing_info": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"city": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"common_name_suffix": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"state": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"country_code": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"common_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"organization": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"email_address": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"ssl_key_expire_datetime": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"service_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"supported_information_verbosity": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"certification_signing_info": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"city": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"common_name_suffix": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"state": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"country_code": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"common_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"organization": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"email_address": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"operation_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ca_certificate_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ca_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"certificate": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"enabled_feature_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"is_available": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"build": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"commit_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"full_version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"commit_date": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"short_commit_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"build_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"timezone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_arch": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"management_server_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"drs_enabled": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"status_list": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"masquerading_port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"masquerading_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"external_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"http_proxy_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"credentials": {
+										Type:     schema.TypeMap,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"username": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"password": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"proxy_type_list": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"address": {
+										Type:     schema.TypeMap,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"ip": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"fqdn": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"port": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"ipv6": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"smtp_server_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"smtp_server_email_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"smtp_server_credentials": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"username": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"password": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"smtp_server_proxy_type_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"smtp_server_address": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"fqdn": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"port": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ipv6": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"ntp_server_ip_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"external_subnet": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"external_data_services_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"internal_subnet": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain_server_nameserver": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain_server_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain_server_credentials": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"username": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"password": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"nfs_subnet_whitelist": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"name_server_ip_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"http_proxy_whitelist": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"target": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"target_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"analysis_vm_efficiency_map": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"bully_vm_num": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"constrained_vm_num": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"dead_vm_num": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"inefficient_vm_num": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"overprovisioned_vm_num": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -287,600 +879,4 @@ func dataSourceNutanixClustersRead(d *schema.ResourceData, meta interface{}) err
 	d.SetId(resource.UniqueId())
 
 	return nil
-}
-
-func getDataSourceClustersSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"api_version": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"entities": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"metadata": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"last_update_time": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"creation_time": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"spec_version": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"spec_hash": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"categories": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"value": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-							},
-						},
-					},
-					"project_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"owner_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"api_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-
-					// COMPUTED
-					"state": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"nodes": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"ip": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"version": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"type": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"gpu_driver_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"client_auth": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"status": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"ca_chain": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"authorized_public_key_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"key": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"software_map_ncc": {
-						Type:     schema.TypeMap,
-						Computed: true,
-					},
-					"software_map_nos": {
-						Type:     schema.TypeMap,
-						Computed: true,
-					},
-					"encryption_status": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"ssl_key_type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"ssl_key_name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"ssl_key_signing_info": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"city": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"common_name_suffix": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"state": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"country_code": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"common_name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"organization": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"email_address": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"ssl_key_expire_datetime": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"service_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"supported_information_verbosity": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"certification_signing_info": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"city": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"common_name_suffix": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"state": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"country_code": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"common_name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"organization": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"email_address": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"operation_mode": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"ca_certificate_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"ca_name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"certificate": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"enabled_feature_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"is_available": {
-						Type:     schema.TypeBool,
-						Computed: true,
-					},
-					"build": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"commit_id": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"full_version": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"commit_date": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"version": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"short_commit_id": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"build_type": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"timezone": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"cluster_arch": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"management_server_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"ip": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"drs_enabled": {
-									Type:     schema.TypeBool,
-									Computed: true,
-								},
-								"status_list": {
-									Type:     schema.TypeList,
-									Computed: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-								"type": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"masquerading_port": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-					"masquerading_ip": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"external_ip": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"http_proxy_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"credentials": {
-									Type:     schema.TypeMap,
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"username": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-											"password": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-										},
-									},
-								},
-								"proxy_type_list": {
-									Type:     schema.TypeList,
-									Computed: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-								"address": {
-									Type:     schema.TypeMap,
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"ip": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-											"fqdn": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-											"port": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-											"ipv6": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					"smtp_server_type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"smtp_server_email_address": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"smtp_server_credentials": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"username": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"password": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"smtp_server_proxy_type_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"smtp_server_address": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"ip": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"fqdn": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"port": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"ipv6": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"ntp_server_ip_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"external_subnet": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"external_data_services_ip": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"internal_subnet": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"domain_server_nameserver": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"domain_server_name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"domain_server_credentials": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"username": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"password": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"nfs_subnet_whitelist": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"name_server_ip_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"http_proxy_whitelist": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"target": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"target_type": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"analysis_vm_efficiency_map": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"bully_vm_num": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"constrained_vm_num": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"dead_vm_num": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"inefficient_vm_num": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"overprovisioned_vm_num": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
 }

--- a/nutanix/data_source_nutanix_image.go
+++ b/nutanix/data_source_nutanix_image.go
@@ -10,8 +10,215 @@ import (
 
 func dataSourceNutanixImage() *schema.Resource {
 	return &schema.Resource{
-		Read:   dataSourceNutanixImageRead,
-		Schema: getDataSourceImageSchema(),
+		Read: dataSourceNutanixImageRead,
+		Schema: map[string]*schema.Schema{
+			"image_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"api_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"metadata": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"last_update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec_hash": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"categories": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"owner_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"project_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"availability_zone_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"cluster_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"cluster_reference_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"retrieval_uri_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"image_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"checksum": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"checksum_algorithm": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"checksum_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"source_uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"product_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"product_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"architecture": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"size_bytes": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
 	}
 }
 
@@ -77,215 +284,4 @@ func dataSourceNutanixImageRead(d *schema.ResourceData, meta interface{}) error 
 	d.SetId(resource.UniqueId())
 
 	return nil
-}
-
-func getDataSourceImageSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"image_id": {
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		"api_version": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"metadata": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"last_update_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"creation_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"spec_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"spec_hash": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"categories": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"value": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"owner_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"project_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"name": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"state": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"description": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"availability_zone_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"cluster_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"cluster_reference_name": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"retrieval_uri_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"image_type": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"checksum": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"checksum_algorithm": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"checksum_value": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"source_uri": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"version": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"product_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"product_name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"architecture": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"size_bytes": {
-			Type:     schema.TypeInt,
-			Computed: true,
-		},
-	}
 }

--- a/nutanix/data_source_nutanix_images.go
+++ b/nutanix/data_source_nutanix_images.go
@@ -8,8 +8,255 @@ import (
 
 func dataSourceNutanixImages() *schema.Resource {
 	return &schema.Resource{
-		Read:   dataSourceNutanixImagesRead,
-		Schema: getDataSourceImagesSchema(),
+		Read: dataSourceNutanixImagesRead,
+		Schema: map[string]*schema.Schema{
+			"metadata": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"sort_attribute": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"filter": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"length": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"sort_order": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"offset": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"api_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"entities": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"metadata": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"last_update_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"creation_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"spec_version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"spec_hash": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"api_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"categories": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"owner_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"project_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zone_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"cluster_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"cluster_reference_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"retrieval_uri_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"image_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"checksum": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"checksum_algorithm": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"checksum_value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"source_uri": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"product_version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"product_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"architecture": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size_bytes": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -57,255 +304,4 @@ func dataSourceNutanixImagesRead(d *schema.ResourceData, meta interface{}) error
 	d.SetId(resource.UniqueId())
 
 	return nil
-}
-
-func getDataSourceImagesSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"metadata": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"sort_attribute": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"filter": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"length": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"sort_order": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"offset": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-				},
-			},
-		},
-		"api_version": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"entities": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"metadata": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"last_update_time": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"creation_time": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"spec_version": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"spec_hash": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"api_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"categories": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"value": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-							},
-						},
-					},
-					"owner_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"project_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"state": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"description": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"availability_zone_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"cluster_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"cluster_reference_name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"retrieval_uri_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"image_type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"checksum": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"checksum_algorithm": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"checksum_value": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"source_uri": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"version": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"product_version": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"product_name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"architecture": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"size_bytes": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-				},
-			},
-		},
-	}
 }

--- a/nutanix/data_source_nutanix_network_security_rule.go
+++ b/nutanix/data_source_nutanix_network_security_rule.go
@@ -12,8 +12,813 @@ import (
 
 func dataSourceNutanixNetworkSecurityRule() *schema.Resource {
 	return &schema.Resource{
-		Read:   dataSourceNutanixNetworkSecurityRuleRead,
-		Schema: getDataSourceNetworkSecurityRuleSchema(),
+		Read: dataSourceNutanixNetworkSecurityRuleRead,
+		Schema: map[string]*schema.Schema{
+			"network_security_rule_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"api_version": {
+				Type: schema.TypeString,
+
+				Computed: true,
+			},
+			"metadata": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"last_update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec_hash": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"categories": {
+				Type: schema.TypeList,
+
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"owner_reference": {
+				Type: schema.TypeMap,
+
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type: schema.TypeString,
+						},
+						"uuid": {
+							Type: schema.TypeString,
+						},
+						"name": {
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+			"project_reference": {
+				Type: schema.TypeMap,
+
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type: schema.TypeString,
+						},
+						"uuid": {
+							Type: schema.TypeString,
+						},
+						"name": {
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type: schema.TypeString,
+
+				Computed: true,
+			},
+			"quarantine_rule_action": {
+				Type: schema.TypeString,
+
+				Computed: true,
+			},
+			"quarantine_rule_outbound_allow_list": {
+				Type: schema.TypeList,
+
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protocol": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"ip_subnet": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"ip_subnet_prefix_length": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"tcp_port_range_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_port": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"start_port": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+								},
+							},
+						},
+						"udp_port_range_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_port": {
+										Type: schema.TypeInt,
+
+										Computed: true,
+									},
+									"start_port": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+								},
+							},
+						},
+						"filter_kind_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"filter_type": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"filter_params": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"values": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"peer_specification_type": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+
+						"expiration_time": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"network_function_chain_reference": {
+							Type: schema.TypeMap,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"name": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+								},
+							},
+						},
+						"icmp_type_code_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"code": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"type": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"quarantine_rule_target_group_default_internal_policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"quarantine_rule_target_group_peer_specification_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"quarantine_rule_target_group_filter_kind_list": {
+				Type: schema.TypeList,
+
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"quarantine_rule_target_group_filter_type": {
+				Type: schema.TypeString,
+
+				Computed: true,
+			},
+			"quarantine_rule_target_group_filter_params": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"quarantine_rule_inbound_allow_list": {
+				Type: schema.TypeList,
+
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protocol": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"ip_subnet": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"ip_subnet_prefix_length": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"tcp_port_range_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_port": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"start_port": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+								},
+							},
+						},
+						"udp_port_range_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_port": {
+										Type: schema.TypeInt,
+
+										Computed: true,
+									},
+									"start_port": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+								},
+							},
+						},
+						"filter_kind_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"filter_type": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"filter_params": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"values": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"peer_specification_type": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+
+						"expiration_time": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"network_function_chain_reference": {
+							Type: schema.TypeMap,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"name": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+								},
+							},
+						},
+						"icmp_type_code_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"code": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"app_rule_action": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"app_rule_outbound_allow_list": {
+				Type: schema.TypeList,
+
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protocol": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"ip_subnet": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"ip_subnet_prefix_length": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"tcp_port_range_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_port": {
+										Type: schema.TypeInt,
+
+										Computed: true,
+									},
+									"start_port": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+								},
+							},
+						},
+						"udp_port_range_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_port": {
+										Type: schema.TypeInt,
+
+										Computed: true,
+									},
+									"start_port": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+								},
+							},
+						},
+						"filter_kind_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"filter_type": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"filter_params": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"values": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"peer_specification_type": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+
+						"expiration_time": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"network_function_chain_reference": {
+							Type: schema.TypeMap,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"name": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+								},
+							},
+						},
+						"icmp_type_code_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"code": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"type": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"app_rule_target_group_default_internal_policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"app_rule_target_group_peer_specification_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"app_rule_target_group_filter_kind_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"app_rule_target_group_filter_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"app_rule_target_group_filter_params": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"app_rule_inbound_allow_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protocol": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"ip_subnet": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"ip_subnet_prefix_length": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"tcp_port_range_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_port": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"start_port": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+								},
+							},
+						},
+						"udp_port_range_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_port": {
+										Type: schema.TypeInt,
+
+										Computed: true,
+									},
+									"start_port": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+								},
+							},
+						},
+						"filter_kind_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"filter_type": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"filter_params": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"values": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"peer_specification_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"expiration_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"network_function_chain_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"name": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+								},
+							},
+						},
+						"icmp_type_code_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"code": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"type": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"isolation_rule_action": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"isolation_rule_first_entity_filter_kind_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"isolation_rule_first_entity_filter_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"isolation_rule_first_entity_filter_params": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"isolation_rule_second_entity_filter_kind_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"isolation_rule_second_entity_filter_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"isolation_rule_second_entity_filter_params": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -466,813 +1271,4 @@ func dataSourceNutanixNetworkSecurityRuleRead(d *schema.ResourceData, meta inter
 	d.SetId(*resp.Metadata.UUID)
 
 	return nil
-}
-
-func getDataSourceNetworkSecurityRuleSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"network_security_rule_id": {
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		"api_version": {
-			Type: schema.TypeString,
-
-			Computed: true,
-		},
-		"metadata": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"last_update_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"creation_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"spec_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"spec_hash": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"categories": {
-			Type: schema.TypeList,
-
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"value": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"owner_reference": {
-			Type: schema.TypeMap,
-
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type: schema.TypeString,
-					},
-					"uuid": {
-						Type: schema.TypeString,
-					},
-					"name": {
-						Type: schema.TypeString,
-					},
-				},
-			},
-		},
-		"project_reference": {
-			Type: schema.TypeMap,
-
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type: schema.TypeString,
-					},
-					"uuid": {
-						Type: schema.TypeString,
-					},
-					"name": {
-						Type: schema.TypeString,
-					},
-				},
-			},
-		},
-		"name": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"description": {
-			Type: schema.TypeString,
-
-			Computed: true,
-		},
-		"quarantine_rule_action": {
-			Type: schema.TypeString,
-
-			Computed: true,
-		},
-		"quarantine_rule_outbound_allow_list": {
-			Type: schema.TypeList,
-
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"protocol": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"ip_subnet": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"ip_subnet_prefix_length": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"tcp_port_range_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"end_port": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"start_port": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-							},
-						},
-					},
-					"udp_port_range_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"end_port": {
-									Type: schema.TypeInt,
-
-									Computed: true,
-								},
-								"start_port": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-							},
-						},
-					},
-					"filter_kind_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"filter_type": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"filter_params": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"values": {
-									Type:     schema.TypeList,
-									Required: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-							},
-						},
-					},
-					"peer_specification_type": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-
-					"expiration_time": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"network_function_chain_reference": {
-						Type: schema.TypeMap,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"name": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-							},
-						},
-					},
-					"icmp_type_code_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"code": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"type": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"quarantine_rule_target_group_default_internal_policy": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"quarantine_rule_target_group_peer_specification_type": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"quarantine_rule_target_group_filter_kind_list": {
-			Type: schema.TypeList,
-
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"quarantine_rule_target_group_filter_type": {
-			Type: schema.TypeString,
-
-			Computed: true,
-		},
-		"quarantine_rule_target_group_filter_params": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"values": {
-						Type:     schema.TypeList,
-						Required: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-				},
-			},
-		},
-		"quarantine_rule_inbound_allow_list": {
-			Type: schema.TypeList,
-
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"protocol": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"ip_subnet": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"ip_subnet_prefix_length": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"tcp_port_range_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"end_port": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"start_port": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-							},
-						},
-					},
-					"udp_port_range_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"end_port": {
-									Type: schema.TypeInt,
-
-									Computed: true,
-								},
-								"start_port": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-							},
-						},
-					},
-					"filter_kind_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"filter_type": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"filter_params": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"values": {
-									Type:     schema.TypeList,
-									Required: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-							},
-						},
-					},
-					"peer_specification_type": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-
-					"expiration_time": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"network_function_chain_reference": {
-						Type: schema.TypeMap,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"name": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-							},
-						},
-					},
-					"icmp_type_code_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"code": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"type": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"app_rule_action": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"app_rule_outbound_allow_list": {
-			Type: schema.TypeList,
-
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"protocol": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"ip_subnet": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"ip_subnet_prefix_length": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"tcp_port_range_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"end_port": {
-									Type: schema.TypeInt,
-
-									Computed: true,
-								},
-								"start_port": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-							},
-						},
-					},
-					"udp_port_range_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"end_port": {
-									Type: schema.TypeInt,
-
-									Computed: true,
-								},
-								"start_port": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-							},
-						},
-					},
-					"filter_kind_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"filter_type": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"filter_params": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"values": {
-									Type:     schema.TypeList,
-									Required: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-							},
-						},
-					},
-					"peer_specification_type": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-
-					"expiration_time": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"network_function_chain_reference": {
-						Type: schema.TypeMap,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"name": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-							},
-						},
-					},
-					"icmp_type_code_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"code": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"type": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"app_rule_target_group_default_internal_policy": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"app_rule_target_group_peer_specification_type": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"app_rule_target_group_filter_kind_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"app_rule_target_group_filter_type": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"app_rule_target_group_filter_params": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"values": {
-						Type:     schema.TypeList,
-						Required: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-				},
-			},
-		},
-		"app_rule_inbound_allow_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"protocol": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"ip_subnet": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"ip_subnet_prefix_length": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"tcp_port_range_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"end_port": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"start_port": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-							},
-						},
-					},
-					"udp_port_range_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"end_port": {
-									Type: schema.TypeInt,
-
-									Computed: true,
-								},
-								"start_port": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-							},
-						},
-					},
-					"filter_kind_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"filter_type": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"filter_params": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"values": {
-									Type:     schema.TypeList,
-									Required: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-							},
-						},
-					},
-					"peer_specification_type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-
-					"expiration_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"network_function_chain_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"name": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-							},
-						},
-					},
-					"icmp_type_code_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"code": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"type": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"isolation_rule_action": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"isolation_rule_first_entity_filter_kind_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"isolation_rule_first_entity_filter_type": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"isolation_rule_first_entity_filter_params": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"values": {
-						Type:     schema.TypeList,
-						Required: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-				},
-			},
-		},
-		"isolation_rule_second_entity_filter_kind_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"isolation_rule_second_entity_filter_type": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"isolation_rule_second_entity_filter_params": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"values": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-				},
-			},
-		},
-	}
 }

--- a/nutanix/data_source_nutanix_network_security_rules.go
+++ b/nutanix/data_source_nutanix_network_security_rules.go
@@ -13,7 +13,856 @@ func dataSourceNutanixNetworkSecurityRules() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceNutanixNetworkSecurityRulesRead,
 
-		Schema: getDataSourceNetworkSecurityRulesSchema(),
+		Schema: map[string]*schema.Schema{
+			"metadata": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"sort_attribute": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"filter": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"length": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"sort_order": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"offset": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"api_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"entities": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"network_security_rule_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"api_version": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"metadata": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"last_update_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"creation_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"spec_version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"spec_hash": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"categories": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"owner_reference": {
+							Type: schema.TypeMap,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type: schema.TypeString,
+									},
+									"uuid": {
+										Type: schema.TypeString,
+									},
+									"name": {
+										Type: schema.TypeString,
+									},
+								},
+							},
+						},
+						"project_reference": {
+							Type: schema.TypeMap,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type: schema.TypeString,
+									},
+									"uuid": {
+										Type: schema.TypeString,
+									},
+									"name": {
+										Type: schema.TypeString,
+									},
+								},
+							},
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"quarantine_rule_action": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"quarantine_rule_outbound_allow_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"protocol": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"ip_subnet": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"ip_subnet_prefix_length": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"tcp_port_range_list": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"end_port": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+												"start_port": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+											},
+										},
+									},
+									"udp_port_range_list": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"end_port": {
+													Type: schema.TypeInt,
+
+													Computed: true,
+												},
+												"start_port": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+											},
+										},
+									},
+									"filter_kind_list": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"filter_type": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"filter_params": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"values": {
+													Type:     schema.TypeList,
+													Required: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+									"peer_specification_type": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+
+									"expiration_time": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"network_function_chain_reference": {
+										Type: schema.TypeMap,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"kind": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"uuid": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"name": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+											},
+										},
+									},
+									"icmp_type_code_list": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"code": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+												"type": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"quarantine_rule_target_group_default_internal_policy": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"quarantine_rule_target_group_peer_specification_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"quarantine_rule_target_group_filter_kind_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"quarantine_rule_target_group_filter_type": {
+							Type: schema.TypeString,
+
+							Computed: true,
+						},
+						"quarantine_rule_target_group_filter_params": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"values": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"quarantine_rule_inbound_allow_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"protocol": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"ip_subnet": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"ip_subnet_prefix_length": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"tcp_port_range_list": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"end_port": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+												"start_port": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+											},
+										},
+									},
+									"udp_port_range_list": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"end_port": {
+													Type: schema.TypeInt,
+
+													Computed: true,
+												},
+												"start_port": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+											},
+										},
+									},
+									"filter_kind_list": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"filter_type": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"filter_params": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"values": {
+													Type:     schema.TypeList,
+													Required: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+									"peer_specification_type": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+
+									"expiration_time": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"network_function_chain_reference": {
+										Type: schema.TypeMap,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"kind": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"uuid": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"name": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+											},
+										},
+									},
+									"icmp_type_code_list": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"code": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+												"type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"app_rule_action": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"app_rule_outbound_allow_list": {
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"protocol": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"ip_subnet": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"ip_subnet_prefix_length": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"tcp_port_range_list": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"end_port": {
+													Type: schema.TypeInt,
+
+													Computed: true,
+												},
+												"start_port": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+											},
+										},
+									},
+									"udp_port_range_list": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"end_port": {
+													Type: schema.TypeInt,
+
+													Computed: true,
+												},
+												"start_port": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+											},
+										},
+									},
+									"filter_kind_list": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"filter_type": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"filter_params": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"values": {
+													Type:     schema.TypeList,
+													Required: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+									"peer_specification_type": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+
+									"expiration_time": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"network_function_chain_reference": {
+										Type: schema.TypeMap,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"kind": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"uuid": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"name": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+											},
+										},
+									},
+									"icmp_type_code_list": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"code": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+												"type": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"app_rule_target_group_default_internal_policy": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"app_rule_target_group_peer_specification_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"app_rule_target_group_filter_kind_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"app_rule_target_group_filter_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"app_rule_target_group_filter_params": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"values": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"app_rule_inbound_allow_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"protocol": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"ip_subnet": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"ip_subnet_prefix_length": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"tcp_port_range_list": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"end_port": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+												"start_port": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+											},
+										},
+									},
+									"udp_port_range_list": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"end_port": {
+													Type: schema.TypeInt,
+
+													Computed: true,
+												},
+												"start_port": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+											},
+										},
+									},
+									"filter_kind_list": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"filter_type": {
+										Type: schema.TypeString,
+
+										Computed: true,
+									},
+									"filter_params": {
+										Type: schema.TypeList,
+
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"values": {
+													Type:     schema.TypeList,
+													Required: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+									"peer_specification_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+
+									"expiration_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"network_function_chain_reference": {
+										Type:     schema.TypeMap,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"kind": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"uuid": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+												"name": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+											},
+										},
+									},
+									"icmp_type_code_list": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"code": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+												"type": {
+													Type: schema.TypeString,
+
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"isolation_rule_action": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"isolation_rule_first_entity_filter_kind_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"isolation_rule_first_entity_filter_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"isolation_rule_first_entity_filter_params": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"values": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"isolation_rule_second_entity_filter_kind_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"isolation_rule_second_entity_filter_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"isolation_rule_second_entity_filter_params": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"values": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -371,857 +1220,4 @@ func dataSourceNutanixNetworkSecurityRulesRead(d *schema.ResourceData, meta inte
 	d.SetId(resource.UniqueId())
 
 	return nil
-}
-
-func getDataSourceNetworkSecurityRulesSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"metadata": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"sort_attribute": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"filter": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"length": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"sort_order": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"offset": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-				},
-			},
-		},
-		"api_version": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"entities": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"network_security_rule_id": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"api_version": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"metadata": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"last_update_time": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"creation_time": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"spec_version": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"spec_hash": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"categories": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"value": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-							},
-						},
-					},
-					"owner_reference": {
-						Type: schema.TypeMap,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type: schema.TypeString,
-								},
-								"uuid": {
-									Type: schema.TypeString,
-								},
-								"name": {
-									Type: schema.TypeString,
-								},
-							},
-						},
-					},
-					"project_reference": {
-						Type: schema.TypeMap,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type: schema.TypeString,
-								},
-								"uuid": {
-									Type: schema.TypeString,
-								},
-								"name": {
-									Type: schema.TypeString,
-								},
-							},
-						},
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"description": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"quarantine_rule_action": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"quarantine_rule_outbound_allow_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"protocol": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"ip_subnet": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"ip_subnet_prefix_length": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"tcp_port_range_list": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"end_port": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-											"start_port": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-										},
-									},
-								},
-								"udp_port_range_list": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"end_port": {
-												Type: schema.TypeInt,
-
-												Computed: true,
-											},
-											"start_port": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-										},
-									},
-								},
-								"filter_kind_list": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-								"filter_type": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"filter_params": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"name": {
-												Type:     schema.TypeString,
-												Required: true,
-											},
-											"values": {
-												Type:     schema.TypeList,
-												Required: true,
-												Elem:     &schema.Schema{Type: schema.TypeString},
-											},
-										},
-									},
-								},
-								"peer_specification_type": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-
-								"expiration_time": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"network_function_chain_reference": {
-									Type: schema.TypeMap,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"kind": {
-												Type:     schema.TypeString,
-												Required: true,
-											},
-											"uuid": {
-												Type:     schema.TypeString,
-												Required: true,
-											},
-											"name": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-										},
-									},
-								},
-								"icmp_type_code_list": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"code": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-											"type": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					"quarantine_rule_target_group_default_internal_policy": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"quarantine_rule_target_group_peer_specification_type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"quarantine_rule_target_group_filter_kind_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"quarantine_rule_target_group_filter_type": {
-						Type: schema.TypeString,
-
-						Computed: true,
-					},
-					"quarantine_rule_target_group_filter_params": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"values": {
-									Type:     schema.TypeList,
-									Required: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-							},
-						},
-					},
-					"quarantine_rule_inbound_allow_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"protocol": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"ip_subnet": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"ip_subnet_prefix_length": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"tcp_port_range_list": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"end_port": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-											"start_port": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-										},
-									},
-								},
-								"udp_port_range_list": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"end_port": {
-												Type: schema.TypeInt,
-
-												Computed: true,
-											},
-											"start_port": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-										},
-									},
-								},
-								"filter_kind_list": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-								"filter_type": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"filter_params": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"name": {
-												Type:     schema.TypeString,
-												Required: true,
-											},
-											"values": {
-												Type:     schema.TypeList,
-												Required: true,
-												Elem:     &schema.Schema{Type: schema.TypeString},
-											},
-										},
-									},
-								},
-								"peer_specification_type": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-
-								"expiration_time": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"network_function_chain_reference": {
-									Type: schema.TypeMap,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"kind": {
-												Type:     schema.TypeString,
-												Required: true,
-											},
-											"uuid": {
-												Type:     schema.TypeString,
-												Required: true,
-											},
-											"name": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-										},
-									},
-								},
-								"icmp_type_code_list": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"code": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-											"type": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					"app_rule_action": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"app_rule_outbound_allow_list": {
-						Type: schema.TypeList,
-
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"protocol": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"ip_subnet": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"ip_subnet_prefix_length": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"tcp_port_range_list": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"end_port": {
-												Type: schema.TypeInt,
-
-												Computed: true,
-											},
-											"start_port": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-										},
-									},
-								},
-								"udp_port_range_list": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"end_port": {
-												Type: schema.TypeInt,
-
-												Computed: true,
-											},
-											"start_port": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-										},
-									},
-								},
-								"filter_kind_list": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-								"filter_type": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"filter_params": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"name": {
-												Type:     schema.TypeString,
-												Required: true,
-											},
-											"values": {
-												Type:     schema.TypeList,
-												Required: true,
-												Elem:     &schema.Schema{Type: schema.TypeString},
-											},
-										},
-									},
-								},
-								"peer_specification_type": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-
-								"expiration_time": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"network_function_chain_reference": {
-									Type: schema.TypeMap,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"kind": {
-												Type:     schema.TypeString,
-												Required: true,
-											},
-											"uuid": {
-												Type:     schema.TypeString,
-												Required: true,
-											},
-											"name": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-										},
-									},
-								},
-								"icmp_type_code_list": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"code": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-											"type": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					"app_rule_target_group_default_internal_policy": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"app_rule_target_group_peer_specification_type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"app_rule_target_group_filter_kind_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"app_rule_target_group_filter_type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"app_rule_target_group_filter_params": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"values": {
-									Type:     schema.TypeList,
-									Required: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-							},
-						},
-					},
-					"app_rule_inbound_allow_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"protocol": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"ip_subnet": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"ip_subnet_prefix_length": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"tcp_port_range_list": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"end_port": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-											"start_port": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-										},
-									},
-								},
-								"udp_port_range_list": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"end_port": {
-												Type: schema.TypeInt,
-
-												Computed: true,
-											},
-											"start_port": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-										},
-									},
-								},
-								"filter_kind_list": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-								"filter_type": {
-									Type: schema.TypeString,
-
-									Computed: true,
-								},
-								"filter_params": {
-									Type: schema.TypeList,
-
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"name": {
-												Type:     schema.TypeString,
-												Required: true,
-											},
-											"values": {
-												Type:     schema.TypeList,
-												Required: true,
-												Elem:     &schema.Schema{Type: schema.TypeString},
-											},
-										},
-									},
-								},
-								"peer_specification_type": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-
-								"expiration_time": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"network_function_chain_reference": {
-									Type:     schema.TypeMap,
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"kind": {
-												Type:     schema.TypeString,
-												Required: true,
-											},
-											"uuid": {
-												Type:     schema.TypeString,
-												Required: true,
-											},
-											"name": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-										},
-									},
-								},
-								"icmp_type_code_list": {
-									Type:     schema.TypeList,
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"code": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-											"type": {
-												Type: schema.TypeString,
-
-												Computed: true,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					"isolation_rule_action": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"isolation_rule_first_entity_filter_kind_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"isolation_rule_first_entity_filter_type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"isolation_rule_first_entity_filter_params": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"values": {
-									Type:     schema.TypeList,
-									Required: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-							},
-						},
-					},
-					"isolation_rule_second_entity_filter_kind_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"isolation_rule_second_entity_filter_type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"isolation_rule_second_entity_filter_params": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"values": {
-									Type:     schema.TypeList,
-									Computed: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
 }

--- a/nutanix/data_source_nutanix_subnet.go
+++ b/nutanix/data_source_nutanix_subnet.go
@@ -9,8 +9,285 @@ import (
 
 func dataSourceNutanixSubnet() *schema.Resource {
 	return &schema.Resource{
-		Read:   dataSourceNutanixSubnetRead,
-		Schema: getDataSourceSubnetSchema(),
+		Read: dataSourceNutanixSubnetRead,
+		Schema: map[string]*schema.Schema{
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"api_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"metadata": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"last_update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec_hash": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"categories": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"owner_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"project_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"availability_zone_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"message_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"message": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"reason": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"details": {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"cluster_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"vswitch_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"subnet_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"default_gateway_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"prefix_length": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"subnet_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dhcp_server_address": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fqdn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ipv6": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"dhcp_server_address_port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"ip_config_pool_list_ranges": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"dhcp_options": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"boot_file_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tftp_server_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"dhcp_domain_name_server_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"dhcp_domain_search_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"vlan_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"network_function_chain_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -129,285 +406,4 @@ func dataSourceNutanixSubnetRead(d *schema.ResourceData, meta interface{}) error
 	d.SetId(*resp.Metadata.UUID)
 
 	return nil
-}
-
-func getDataSourceSubnetSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"subnet_id": {
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		"api_version": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"metadata": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"last_update_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"creation_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"spec_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"spec_hash": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"categories": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"value": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"owner_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"project_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"name": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"state": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"description": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"availability_zone_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"message_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"message": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"reason": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"details": {
-						Type:     schema.TypeMap,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"cluster_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"vswitch_name": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"subnet_type": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"default_gateway_ip": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"prefix_length": {
-			Type:     schema.TypeInt,
-			Computed: true,
-		},
-		"subnet_ip": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"dhcp_server_address": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"ip": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"fqdn": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"ipv6": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"dhcp_server_address_port": {
-			Type:     schema.TypeInt,
-			Computed: true,
-		},
-		"ip_config_pool_list_ranges": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"dhcp_options": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"boot_file_name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"domain_name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"tftp_server_name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"dhcp_domain_name_server_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"dhcp_domain_search_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"vlan_id": {
-			Type:     schema.TypeInt,
-			Computed: true,
-		},
-		"network_function_chain_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-	}
 }

--- a/nutanix/data_source_nutanix_subnets.go
+++ b/nutanix/data_source_nutanix_subnets.go
@@ -8,8 +8,294 @@ import (
 
 func dataSourceNutanixSubnets() *schema.Resource {
 	return &schema.Resource{
-		Read:   dataSourceNutanixSubnetsRead,
-		Schema: getDataSourceSubnetsSchema(),
+		Read: dataSourceNutanixSubnetsRead,
+		Schema: map[string]*schema.Schema{
+			"metadata": getDSMetadataSchema(),
+			"api_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"entities": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"api_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"metadata": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"last_update_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"creation_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"spec_version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"spec_hash": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"categories": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"owner_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"project_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zone_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"message_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"message": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"reason": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"details": {
+										Type:     schema.TypeMap,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"cluster_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"cluster_reference_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vswitch_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"subnet_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"default_gateway_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"prefix_length": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"subnet_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"dhcp_server_address": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"fqdn": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ipv6": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"dhcp_server_address_port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"ip_config_pool_list_ranges": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"dhcp_options": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"boot_file_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"domain_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"tftp_server_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"dhcp_domain_name_server_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"dhcp_domain_search_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"vlan_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"network_function_chain_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -110,294 +396,4 @@ func dataSourceNutanixSubnetsRead(d *schema.ResourceData, meta interface{}) erro
 	d.SetId(resource.UniqueId())
 
 	return d.Set("entities", entities)
-}
-
-func getDataSourceSubnetsSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"metadata": getDSMetadataSchema(),
-		"api_version": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"entities": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"api_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"metadata": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"last_update_time": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"creation_time": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"spec_version": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"spec_hash": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"categories": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"value": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-							},
-						},
-					},
-					"owner_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"project_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"state": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"description": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"availability_zone_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"message_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"message": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"reason": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"details": {
-									Type:     schema.TypeMap,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"cluster_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"cluster_reference_name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"vswitch_name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"subnet_type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"default_gateway_ip": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"prefix_length": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-					"subnet_ip": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"dhcp_server_address": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"ip": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"fqdn": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"ipv6": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"dhcp_server_address_port": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-					"ip_config_pool_list_ranges": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"dhcp_options": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"boot_file_name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"domain_name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"tftp_server_name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"dhcp_domain_name_server_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"dhcp_domain_search_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"vlan_id": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-					"network_function_chain_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
 }

--- a/nutanix/data_source_nutanix_virtual_machine.go
+++ b/nutanix/data_source_nutanix_virtual_machine.go
@@ -13,7 +13,608 @@ func dataSourceNutanixVirtualMachine() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceNutanixVirtualMachineRead,
 
-		Schema: getDataSourceVMSchema(),
+		Schema: map[string]*schema.Schema{
+			"vm_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"metadata": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"last_update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec_hash": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"categories": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"project_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"owner_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"api_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"availability_zone_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"cluster_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"cluster_reference_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			// COMPUTED
+			"message_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"message": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"reason": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"details": {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"host_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"hypervisor_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			// RESOURCES ARGUMENTS
+
+			"num_vnuma_nodes": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"nic_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nic_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"floating_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"model": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"network_function_nic_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mac_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ip_endpoint_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"network_function_chain_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"subnet_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"guest_os_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"power_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"nutanix_guest_tools": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"available_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"iso_mount_state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"guest_os_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enabled_capability_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"vss_snapshot_capable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_reachable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"vm_mobility_drivers_installed": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"num_vcpus_per_socket": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"num_sockets": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"gpu_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"frame_buffer_size_mib": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"vendor": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"pci_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fraction": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"num_virtual_display_heads": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"guest_driver_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"device_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"parent_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"memory_size_mib": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"boot_device_order_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"boot_device_disk_address": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"device_index": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"adapter_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"boot_device_mac_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"hardware_clock_timezone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"guest_customization_cloud_init_meta_data": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"guest_customization_cloud_init_user_data": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"guest_customization_cloud_init_custom_key_values": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"guest_customization_is_overridable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"guest_customization_sysprep": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"install_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"unattend_xml": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"guest_customization_sysprep_custom_key_values": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"should_fail_on_script_failure": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"enable_script_exec": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"power_state_mechanism": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vga_console_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"disk_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"disk_size_bytes": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"disk_size_mib": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"device_properties": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"device_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"disk_address": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"device_index": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"adapter_type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"data_source_reference": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+
+						"volume_group_reference": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -151,609 +752,4 @@ func dataSourceNutanixVirtualMachineRead(d *schema.ResourceData, meta interface{
 	d.SetId(*resp.Metadata.UUID)
 
 	return d.Set("disk_list", setDiskList(resp.Status.Resources.DiskList, resp.Status.Resources.GuestCustomization))
-}
-
-func getDataSourceVMSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"vm_id": {
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		"metadata": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"last_update_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"creation_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"spec_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"spec_hash": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"categories": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"value": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"project_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"owner_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"api_version": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"name": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"description": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"availability_zone_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"cluster_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"cluster_reference_name": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		// COMPUTED
-		"message_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"message": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"reason": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"details": {
-						Type:     schema.TypeMap,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"state": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"host_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"hypervisor_type": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-
-		// RESOURCES ARGUMENTS
-
-		"num_vnuma_nodes": {
-			Type:     schema.TypeInt,
-			Computed: true,
-		},
-		"nic_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"nic_type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"floating_ip": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"model": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"network_function_nic_type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"mac_address": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"ip_endpoint_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"ip": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"type": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"network_function_chain_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"subnet_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"guest_os_id": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"power_state": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"nutanix_guest_tools": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"available_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"iso_mount_state": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"state": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"guest_os_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"enabled_capability_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"vss_snapshot_capable": {
-						Type:     schema.TypeBool,
-						Computed: true,
-					},
-					"is_reachable": {
-						Type:     schema.TypeBool,
-						Computed: true,
-					},
-					"vm_mobility_drivers_installed": {
-						Type:     schema.TypeBool,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"num_vcpus_per_socket": {
-			Type:     schema.TypeInt,
-			Computed: true,
-		},
-		"num_sockets": {
-			Type:     schema.TypeInt,
-			Computed: true,
-		},
-		"gpu_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"frame_buffer_size_mib": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-					"vendor": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"pci_address": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"fraction": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-					"mode": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"num_virtual_display_heads": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-					"guest_driver_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"device_id": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"parent_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"memory_size_mib": {
-			Type:     schema.TypeInt,
-			Computed: true,
-		},
-		"boot_device_order_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"boot_device_disk_address": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"device_index": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"adapter_type": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"boot_device_mac_address": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"hardware_clock_timezone": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"guest_customization_cloud_init_meta_data": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"guest_customization_cloud_init_user_data": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"guest_customization_cloud_init_custom_key_values": {
-			Type:     schema.TypeMap,
-			Computed: true,
-		},
-		"guest_customization_is_overridable": {
-			Type:     schema.TypeBool,
-			Computed: true,
-		},
-		"guest_customization_sysprep": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"install_type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"unattend_xml": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"guest_customization_sysprep_custom_key_values": {
-			Type:     schema.TypeMap,
-			Computed: true,
-		},
-		"should_fail_on_script_failure": {
-			Type:     schema.TypeBool,
-			Computed: true,
-		},
-		"enable_script_exec": {
-			Type:     schema.TypeBool,
-			Computed: true,
-		},
-		"power_state_mechanism": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"vga_console_enabled": {
-			Type:     schema.TypeBool,
-			Computed: true,
-		},
-		"disk_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"disk_size_bytes": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-					"disk_size_mib": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-					"device_properties": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"device_type": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"disk_address": {
-									Type:     schema.TypeList,
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"device_index": {
-												Type:     schema.TypeInt,
-												Computed: true,
-											},
-											"adapter_type": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					"data_source_reference": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-
-					"volume_group_reference": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
 }

--- a/nutanix/data_source_nutanix_virtual_machines.go
+++ b/nutanix/data_source_nutanix_virtual_machines.go
@@ -19,7 +19,623 @@ func dataSourceNutanixVirtualMachines() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceNutanixVirtualMachinesRead,
 
-		Schema: getDataSourceVMSSchema(),
+		Schema: map[string]*schema.Schema{
+			//"metadata": getDSMetadataSchema(),
+			"api_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"entities": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"metadata": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"last_update_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"creation_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"spec_version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"spec_hash": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"categories": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"project_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"owner_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"api_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"availability_zone_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"cluster_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"cluster_reference_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						// COMPUTED
+						"message_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"message": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"reason": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"details": {
+										Type:     schema.TypeMap,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"hypervisor_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						// RESOURCES ARGUMENTS
+
+						"num_vnuma_nodes": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"nic_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"nic_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"floating_ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"model": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"network_function_nic_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"mac_address": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ip_endpoint_list": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"ip": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"network_function_chain_reference": {
+										Type:     schema.TypeMap,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"kind": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"uuid": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"subnet_reference": {
+										Type:     schema.TypeMap,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"kind": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"uuid": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"subnet_reference_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"guest_os_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"power_state": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"nutanix_guest_tools": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"available_version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"iso_mount_state": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"state": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"guest_os_version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"enabled_capability_list": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"vss_snapshot_capable": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"is_reachable": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"vm_mobility_drivers_installed": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"num_vcpus_per_socket": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"num_sockets": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"gpu_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"frame_buffer_size_mib": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"vendor": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"pci_address": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"fraction": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"mode": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"num_virtual_display_heads": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"guest_driver_version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"device_id": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"parent_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"memory_size_mib": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"boot_device_order_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"boot_device_disk_address": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"device_index": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"adapter_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"boot_device_mac_address": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"hardware_clock_timezone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"guest_customization_cloud_init_meta_data": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"guest_customization_cloud_init_user_data": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"guest_customization_cloud_init_custom_key_values": {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
+						"guest_customization_is_overridable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"guest_customization_sysprep": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"install_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"unattend_xml": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"guest_customization_sysprep_custom_key_values": {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
+						"should_fail_on_script_failure": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"enable_script_exec": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"power_state_mechanism": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vga_console_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"disk_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"uuid": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"disk_size_bytes": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"disk_size_mib": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"device_properties": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"device_type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"disk_address": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+
+															"device_index": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+															"adapter_type": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"data_source_reference": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"kind": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"uuid": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+
+									"volume_group_reference": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"kind": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"uuid": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -246,626 +862,6 @@ func setNicList(nics []*v3.VMNicOutputStatus) []map[string]interface{} {
 	}
 
 	return nicLists
-}
-
-func getDataSourceVMSSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		//"metadata": getDSMetadataSchema(),
-		"api_version": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"entities": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"metadata": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"last_update_time": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"creation_time": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"spec_version": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"spec_hash": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"categories": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"value": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-							},
-						},
-					},
-					"project_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"owner_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"api_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"description": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"availability_zone_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"cluster_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"cluster_reference_name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-
-					// COMPUTED
-					"message_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"message": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"reason": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"details": {
-									Type:     schema.TypeMap,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"state": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"host_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"hypervisor_type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-
-					// RESOURCES ARGUMENTS
-
-					"num_vnuma_nodes": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-					"nic_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"nic_type": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"floating_ip": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"model": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"network_function_nic_type": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"mac_address": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"ip_endpoint_list": {
-									Type:     schema.TypeList,
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"ip": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-											"type": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-										},
-									},
-								},
-								"network_function_chain_reference": {
-									Type:     schema.TypeMap,
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"kind": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-											"name": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-											"uuid": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-										},
-									},
-								},
-								"subnet_reference": {
-									Type:     schema.TypeMap,
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"kind": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-											"name": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-											"uuid": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-										},
-									},
-								},
-								"subnet_reference_name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"guest_os_id": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"power_state": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"nutanix_guest_tools": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"available_version": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"iso_mount_state": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"state": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"version": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"guest_os_version": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"enabled_capability_list": {
-									Type:     schema.TypeList,
-									Computed: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-								"vss_snapshot_capable": {
-									Type:     schema.TypeBool,
-									Computed: true,
-								},
-								"is_reachable": {
-									Type:     schema.TypeBool,
-									Computed: true,
-								},
-								"vm_mobility_drivers_installed": {
-									Type:     schema.TypeBool,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"num_vcpus_per_socket": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-					"num_sockets": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-					"gpu_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"frame_buffer_size_mib": {
-									Type:     schema.TypeInt,
-									Computed: true,
-								},
-								"vendor": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"pci_address": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"fraction": {
-									Type:     schema.TypeInt,
-									Computed: true,
-								},
-								"mode": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"num_virtual_display_heads": {
-									Type:     schema.TypeInt,
-									Computed: true,
-								},
-								"guest_driver_version": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"device_id": {
-									Type:     schema.TypeInt,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"parent_reference": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"memory_size_mib": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-					"boot_device_order_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"boot_device_disk_address": {
-						Type:     schema.TypeMap,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"device_index": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-								"adapter_type": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"boot_device_mac_address": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"hardware_clock_timezone": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"guest_customization_cloud_init_meta_data": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"guest_customization_cloud_init_user_data": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"guest_customization_cloud_init_custom_key_values": {
-						Type:     schema.TypeMap,
-						Computed: true,
-					},
-					"guest_customization_is_overridable": {
-						Type:     schema.TypeBool,
-						Computed: true,
-					},
-					"guest_customization_sysprep": {
-						Type:     schema.TypeMap,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"install_type": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"unattend_xml": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"guest_customization_sysprep_custom_key_values": {
-						Type:     schema.TypeMap,
-						Computed: true,
-					},
-					"should_fail_on_script_failure": {
-						Type:     schema.TypeBool,
-						Computed: true,
-					},
-					"enable_script_exec": {
-						Type:     schema.TypeBool,
-						Computed: true,
-					},
-					"power_state_mechanism": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"vga_console_enabled": {
-						Type:     schema.TypeBool,
-						Computed: true,
-					},
-					"disk_list": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"uuid": {
-									Type:     schema.TypeString,
-									Computed: true,
-								},
-								"disk_size_bytes": {
-									Type:     schema.TypeInt,
-									Computed: true,
-								},
-								"disk_size_mib": {
-									Type:     schema.TypeInt,
-									Computed: true,
-								},
-								"device_properties": {
-									Type:     schema.TypeList,
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"device_type": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-											"disk_address": {
-												Type:     schema.TypeList,
-												Computed: true,
-												Elem: &schema.Resource{
-													Schema: map[string]*schema.Schema{
-
-														"device_index": {
-															Type:     schema.TypeInt,
-															Computed: true,
-														},
-														"adapter_type": {
-															Type:     schema.TypeString,
-															Computed: true,
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-								"data_source_reference": {
-									Type:     schema.TypeList,
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"kind": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-											"name": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-											"uuid": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-										},
-									},
-								},
-
-								"volume_group_reference": {
-									Type:     schema.TypeList,
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"kind": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-											"name": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-											"uuid": {
-												Type:     schema.TypeString,
-												Computed: true,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
 }
 
 func getDSMetadataSchema() *schema.Schema {

--- a/nutanix/resource_nutanix_category_key.go
+++ b/nutanix/resource_nutanix_category_key.go
@@ -18,7 +18,26 @@ func resourceNutanixCategoryKey() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		Schema: getCategoryKeySchema(),
+		Schema: map[string]*schema.Schema{
+			"system_defined": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"api_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
 	}
 }
 
@@ -93,27 +112,4 @@ func resourceNutanixCategoryKeyDelete(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId("")
 	return nil
-}
-
-func getCategoryKeySchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"system_defined": {
-			Type:     schema.TypeBool,
-			Computed: true,
-		},
-		"description": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"api_version": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"name": {
-			Type:     schema.TypeString,
-			Required: true,
-		},
-	}
 }

--- a/nutanix/resource_nutanix_category_value.go
+++ b/nutanix/resource_nutanix_category_value.go
@@ -18,7 +18,31 @@ func resourceNutanixCategoryValue() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		Schema: getCategoryValueSchema(),
+		Schema: map[string]*schema.Schema{
+			"value": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"system_defined": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"api_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
 	}
 }
 
@@ -107,32 +131,4 @@ func resourceNutanixCategoryValueDelete(d *schema.ResourceData, meta interface{}
 
 	d.SetId("")
 	return nil
-}
-
-func getCategoryValueSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"value": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"system_defined": {
-			Type:     schema.TypeBool,
-			Computed: true,
-		},
-		"description": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"api_version": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"name": {
-			Type:     schema.TypeString,
-			Required: true,
-		},
-	}
 }

--- a/nutanix/resource_nutanix_image.go
+++ b/nutanix/resource_nutanix_image.go
@@ -30,7 +30,224 @@ func resourceNutanixImage() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		Schema: getImageSchema(),
+		Schema: map[string]*schema.Schema{
+			"api_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"metadata": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"last_update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec_hash": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"categories": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"owner_reference": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"project_reference": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"availability_zone_reference": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"cluster_reference": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"retrieval_uri_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"image_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"checksum": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"checksum_algorithm": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"checksum_value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"source_uri": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"source_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"product_version": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"product_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"architecture": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"size_bytes": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
 	}
 }
 
@@ -343,227 +560,6 @@ func resourceNutanixImageDelete(d *schema.ResourceData, meta interface{}) error 
 
 	d.SetId("")
 	return nil
-}
-
-func getImageSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"api_version": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"metadata": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"last_update_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"creation_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"spec_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"spec_hash": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"categories": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"value": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"owner_reference": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-				},
-			},
-		},
-		"project_reference": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-				},
-			},
-		},
-		"name": {
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		"state": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"description": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"availability_zone_reference": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"cluster_reference": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"retrieval_uri_list": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"image_type": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"checksum": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"checksum_algorithm": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"checksum_value": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"source_uri": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"source_path": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"version": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"product_version": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"product_name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"architecture": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"size_bytes": {
-			Type:     schema.TypeInt,
-			Computed: true,
-		},
-	}
 }
 
 func getImageResource(d *schema.ResourceData, image *v3.ImageResources) error {

--- a/nutanix/resource_nutanix_network_security_rule.go
+++ b/nutanix/resource_nutanix_network_security_rule.go
@@ -23,7 +23,832 @@ func resourceNutanixNetworkSecurityRule() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		Schema: getNetworkSecurityRuleSchema(),
+		Schema: map[string]*schema.Schema{
+			"api_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"metadata": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"last_update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec_hash": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"categories": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"owner_reference": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"project_reference": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"quarantine_rule_action": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"quarantine_rule_outbound_allow_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"ip_subnet": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"ip_subnet_prefix_length": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"tcp_port_range_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_port": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"start_port": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"udp_port_range_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_port": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Computed: true,
+									},
+									"start_port": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"filter_kind_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"filter_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"filter_params": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"values": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"peer_specification_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+
+						"expiration_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"network_function_chain_reference": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"icmp_type_code_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"code": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"quarantine_rule_target_group_default_internal_policy": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"quarantine_rule_target_group_peer_specification_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"quarantine_rule_target_group_filter_kind_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"quarantine_rule_target_group_filter_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"quarantine_rule_target_group_filter_params": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"quarantine_rule_inbound_allow_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"ip_subnet": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"ip_subnet_prefix_length": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"tcp_port_range_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_port": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"start_port": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"udp_port_range_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_port": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Computed: true,
+									},
+									"start_port": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"filter_kind_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"filter_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"filter_params": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"values": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"peer_specification_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+
+						"expiration_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"network_function_chain_reference": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"icmp_type_code_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"code": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"app_rule_action": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"app_rule_outbound_allow_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"ip_subnet": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"ip_subnet_prefix_length": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"tcp_port_range_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_port": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Computed: true,
+									},
+									"start_port": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"udp_port_range_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_port": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Computed: true,
+									},
+									"start_port": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"filter_kind_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"filter_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"filter_params": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"values": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"peer_specification_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+
+						"expiration_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"network_function_chain_reference": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"icmp_type_code_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"code": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"app_rule_target_group_default_internal_policy": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"app_rule_target_group_peer_specification_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"app_rule_target_group_filter_kind_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"app_rule_target_group_filter_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"app_rule_target_group_filter_params": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"app_rule_inbound_allow_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"ip_subnet": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"ip_subnet_prefix_length": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"tcp_port_range_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_port": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"start_port": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"udp_port_range_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_port": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Computed: true,
+									},
+									"start_port": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"filter_kind_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"filter_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"filter_params": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"values": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"peer_specification_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+
+						"expiration_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"network_function_chain_reference": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"icmp_type_code_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"code": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"isolation_rule_action": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"isolation_rule_first_entity_filter_kind_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"isolation_rule_first_entity_filter_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"isolation_rule_first_entity_filter_params": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"isolation_rule_second_entity_filter_kind_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"isolation_rule_second_entity_filter_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"isolation_rule_second_entity_filter_params": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -1665,833 +2490,4 @@ func expandFilterParams(fp map[string][]string) []map[string]interface{} {
 		}
 	}
 	return fpList
-}
-
-func getNetworkSecurityRuleSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"api_version": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"metadata": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"last_update_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"creation_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"spec_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"spec_hash": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"categories": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"value": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"owner_reference": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-				},
-			},
-		},
-		"project_reference": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-				},
-			},
-		},
-		"name": {
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		"description": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"quarantine_rule_action": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"quarantine_rule_outbound_allow_list": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"protocol": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"ip_subnet": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"ip_subnet_prefix_length": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"tcp_port_range_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"end_port": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-								"start_port": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"udp_port_range_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"end_port": {
-									Type:     schema.TypeInt,
-									Optional: true,
-									Computed: true,
-								},
-								"start_port": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"filter_kind_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"filter_type": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"filter_params": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"values": {
-									Type:     schema.TypeList,
-									Required: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-							},
-						},
-					},
-					"peer_specification_type": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-
-					"expiration_time": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"network_function_chain_reference": {
-						Type:     schema.TypeMap,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"icmp_type_code_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"code": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-								"type": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"quarantine_rule_target_group_default_internal_policy": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"quarantine_rule_target_group_peer_specification_type": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"quarantine_rule_target_group_filter_kind_list": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"quarantine_rule_target_group_filter_type": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"quarantine_rule_target_group_filter_params": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"values": {
-						Type:     schema.TypeList,
-						Required: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-				},
-			},
-		},
-		"quarantine_rule_inbound_allow_list": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"protocol": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"ip_subnet": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"ip_subnet_prefix_length": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"tcp_port_range_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"end_port": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-								"start_port": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"udp_port_range_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"end_port": {
-									Type:     schema.TypeInt,
-									Optional: true,
-									Computed: true,
-								},
-								"start_port": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"filter_kind_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"filter_type": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"filter_params": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"values": {
-									Type:     schema.TypeList,
-									Required: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-							},
-						},
-					},
-					"peer_specification_type": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-
-					"expiration_time": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"network_function_chain_reference": {
-						Type:     schema.TypeMap,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"icmp_type_code_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"code": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-								"type": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"app_rule_action": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"app_rule_outbound_allow_list": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"protocol": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"ip_subnet": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"ip_subnet_prefix_length": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"tcp_port_range_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"end_port": {
-									Type:     schema.TypeInt,
-									Optional: true,
-									Computed: true,
-								},
-								"start_port": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"udp_port_range_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"end_port": {
-									Type:     schema.TypeInt,
-									Optional: true,
-									Computed: true,
-								},
-								"start_port": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"filter_kind_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"filter_type": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"filter_params": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"values": {
-									Type:     schema.TypeList,
-									Required: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-							},
-						},
-					},
-					"peer_specification_type": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-
-					"expiration_time": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"network_function_chain_reference": {
-						Type:     schema.TypeMap,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"icmp_type_code_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"code": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-								"type": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"app_rule_target_group_default_internal_policy": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"app_rule_target_group_peer_specification_type": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"app_rule_target_group_filter_kind_list": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"app_rule_target_group_filter_type": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"app_rule_target_group_filter_params": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"values": {
-						Type:     schema.TypeList,
-						Required: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-				},
-			},
-		},
-		"app_rule_inbound_allow_list": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"protocol": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"ip_subnet": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"ip_subnet_prefix_length": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"tcp_port_range_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"end_port": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-								"start_port": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"udp_port_range_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"end_port": {
-									Type:     schema.TypeInt,
-									Optional: true,
-									Computed: true,
-								},
-								"start_port": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"filter_kind_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"filter_type": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"filter_params": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"values": {
-									Type:     schema.TypeList,
-									Required: true,
-									Elem:     &schema.Schema{Type: schema.TypeString},
-								},
-							},
-						},
-					},
-					"peer_specification_type": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-
-					"expiration_time": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"network_function_chain_reference": {
-						Type:     schema.TypeMap,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"icmp_type_code_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"code": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-								"type": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"isolation_rule_action": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"isolation_rule_first_entity_filter_kind_list": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"isolation_rule_first_entity_filter_type": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"isolation_rule_first_entity_filter_params": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"values": {
-						Type:     schema.TypeList,
-						Required: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-				},
-			},
-		},
-		"isolation_rule_second_entity_filter_kind_list": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"isolation_rule_second_entity_filter_type": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"isolation_rule_second_entity_filter_params": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"values": {
-						Type:     schema.TypeList,
-						Required: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-				},
-			},
-		},
-	}
 }

--- a/nutanix/resource_nutanix_subnet.go
+++ b/nutanix/resource_nutanix_subnet.go
@@ -19,7 +19,295 @@ func resourceNutanixSubnet() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		Schema: getSubnetSchema(),
+		Schema: map[string]*schema.Schema{
+			"api_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"metadata": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"last_update_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"kind": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"spec_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"spec_hash": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"categories": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"owner_reference": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"project_reference": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"availability_zone_reference": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"cluster_reference": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"cluster_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"vswitch_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"subnet_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"default_gateway_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"prefix_length": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"subnet_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"dhcp_server_address": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"fqdn": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"ipv6": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"dhcp_server_address_port": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"ip_config_pool_list_ranges": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"dhcp_options": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"boot_file_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"domain_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"tftp_server_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"dhcp_domain_name_server_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"dhcp_domain_search_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"vlan_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"network_function_chain_reference": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -567,296 +855,4 @@ func getSubnetResources(d *schema.ResourceData, subnet *v3.SubnetResources) erro
 	subnet.IPConfig = ip
 
 	return nil
-}
-
-func getSubnetSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"api_version": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"description": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"metadata": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"last_update_time": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"kind": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"creation_time": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"spec_version": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"spec_hash": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"categories": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"value": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"owner_reference": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-				},
-			},
-		},
-		"project_reference": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-					},
-				},
-			},
-		},
-		"name": {
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		"state": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"availability_zone_reference": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"cluster_reference": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"cluster_name": {
-			Type:     schema.TypeString,
-			Computed: true,
-			Optional: true,
-		},
-		"vswitch_name": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"subnet_type": {
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		"default_gateway_ip": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"prefix_length": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: true,
-		},
-		"subnet_ip": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"dhcp_server_address": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"ip": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"fqdn": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"ipv6": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"dhcp_server_address_port": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: true,
-		},
-		"ip_config_pool_list_ranges": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"dhcp_options": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"boot_file_name": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"domain_name": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"tftp_server_name": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"dhcp_domain_name_server_list": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"dhcp_domain_search_list": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"vlan_id": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			ForceNew: true,
-			Computed: true,
-		},
-		"network_function_chain_reference": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-				},
-			},
-		},
-	}
 }

--- a/nutanix/resource_nutanix_virtual_machine.go
+++ b/nutanix/resource_nutanix_virtual_machine.go
@@ -24,7 +24,645 @@ func resourceNutanixVirtualMachine() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		Schema: getVMSchema(),
+		Schema: map[string]*schema.Schema{
+			"metadata": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"last_update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spec_hash": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"categories": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"project_reference": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"owner_reference": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"api_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"availability_zone_reference": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"cluster_reference": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"cluster_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"host_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"hypervisor_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			// RESOURCES ARGUMENTS
+
+			"num_vnuma_nodes": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"nic_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nic_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"floating_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"model": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"network_function_nic_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"mac_address": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"ip_endpoint_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ip": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"network_function_chain_reference": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"subnet_reference": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"subnet_reference_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"guest_os_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"power_state": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"nutanix_guest_tools": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"available_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"iso_mount_state": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"state": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"guest_os_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enabled_capability_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"vss_snapshot_capable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_reachable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"vm_mobility_drivers_installed": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"num_vcpus_per_socket": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"num_sockets": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"gpu_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"frame_buffer_size_mib": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"vendor": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"pci_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fraction": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"num_virtual_display_heads": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"guest_driver_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"device_id": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"parent_reference": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"memory_size_mib": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"boot_device_order_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"boot_device_disk_address": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"device_index": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"adapter_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"boot_device_mac_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"hardware_clock_timezone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"guest_customization_cloud_init_user_data": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"guest_customization_cloud_init_meta_data": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"guest_customization_cloud_init_custom_key_values": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+			},
+			"guest_customization_is_overridable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"guest_customization_sysprep": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"install_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"unattend_xml": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"guest_customization_sysprep_custom_key_values": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+			},
+			"should_fail_on_script_failure": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"enable_script_exec": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"power_state_mechanism": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"vga_console_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"disk_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"uuid": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"disk_size_bytes": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"disk_size_mib": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"device_properties": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"device_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"disk_address": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"device_index": {
+													Type:     schema.TypeInt,
+													Optional: true,
+													Computed: true,
+												},
+												"adapter_type": {
+													Type:     schema.TypeString,
+													Optional: true,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"data_source_reference": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+
+						"volume_group_reference": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kind": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"uuid": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -1003,647 +1641,5 @@ func preFillPWUpdateRequest(pw *v3.VMPowerStateMechanism, response *v3.VMIntentR
 		pw.GuestTransitionConfig = response.Status.Resources.PowerStateMechanism.GuestTransitionConfig
 	} else {
 		pw = nil
-	}
-}
-
-func getVMSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"metadata": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"last_update_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"creation_time": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"spec_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"spec_hash": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"categories": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"value": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"project_reference": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"owner_reference": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"api_version": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"name": {
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		"description": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"availability_zone_reference": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"cluster_reference": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"cluster_name": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"state": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-		"host_reference": {
-			Type:     schema.TypeMap,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"hypervisor_type": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-
-		// RESOURCES ARGUMENTS
-
-		"num_vnuma_nodes": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: true,
-		},
-		"nic_list": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"nic_type": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"floating_ip": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"model": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"network_function_nic_type": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"mac_address": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"ip_endpoint_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"ip": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-								"type": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-					"network_function_chain_reference": {
-						Type:     schema.TypeMap,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-							},
-						},
-					},
-					"subnet_reference": {
-						Type:     schema.TypeMap,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Required: true,
-								},
-							},
-						},
-					},
-					"subnet_reference_name": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"guest_os_id": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"power_state": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"nutanix_guest_tools": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"available_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"iso_mount_state": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"state": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"guest_os_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"enabled_capability_list": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-					"vss_snapshot_capable": {
-						Type:     schema.TypeBool,
-						Computed: true,
-					},
-					"is_reachable": {
-						Type:     schema.TypeBool,
-						Computed: true,
-					},
-					"vm_mobility_drivers_installed": {
-						Type:     schema.TypeBool,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"num_vcpus_per_socket": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: true,
-		},
-		"num_sockets": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: true,
-		},
-		"gpu_list": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"frame_buffer_size_mib": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-					"vendor": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"pci_address": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"fraction": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-					"mode": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"num_virtual_display_heads": {
-						Type:     schema.TypeInt,
-						Computed: true,
-					},
-					"guest_driver_version": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-					"device_id": {
-						Type:     schema.TypeInt,
-						Optional: true,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"parent_reference": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"kind": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"name": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"uuid": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-		"memory_size_mib": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: true,
-		},
-		"boot_device_order_list": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-		},
-		"boot_device_disk_address": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"device_index": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"adapter_type": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"boot_device_mac_address": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"hardware_clock_timezone": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"guest_customization_cloud_init_user_data": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"guest_customization_cloud_init_meta_data": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"guest_customization_cloud_init_custom_key_values": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"guest_customization_is_overridable": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Computed: true,
-		},
-		"guest_customization_sysprep": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"install_type": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"unattend_xml": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-				},
-			},
-		},
-		"guest_customization_sysprep_custom_key_values": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"should_fail_on_script_failure": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Computed: true,
-		},
-		"enable_script_exec": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Computed: true,
-		},
-		"power_state_mechanism": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"vga_console_enabled": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Computed: true,
-		},
-		"disk_list": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"uuid": {
-						Type:     schema.TypeString,
-						Optional: true,
-						Computed: true,
-					},
-					"disk_size_bytes": {
-						Type:     schema.TypeInt,
-						Optional: true,
-						Computed: true,
-					},
-					"disk_size_mib": {
-						Type:     schema.TypeInt,
-						Optional: true,
-						Computed: true,
-					},
-					"device_properties": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"device_type": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-								"disk_address": {
-									Type:     schema.TypeList,
-									Optional: true,
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: map[string]*schema.Schema{
-											"device_index": {
-												Type:     schema.TypeInt,
-												Optional: true,
-												Computed: true,
-											},
-											"adapter_type": {
-												Type:     schema.TypeString,
-												Optional: true,
-												Computed: true,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					"data_source_reference": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-
-					"volume_group_reference": {
-						Type:     schema.TypeList,
-						Optional: true,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"kind": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-								"name": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-								"uuid": {
-									Type:     schema.TypeString,
-									Optional: true,
-									Computed: true,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
 	}
 }


### PR DESCRIPTION
Addresses on issue  #175 

`Move the schema out of getSchema function and into the resource function. It makes the resource function shorter, but keeping the schema in the resource function keeps your resources more consistent with other providers.`