### PR TITLE
Set network_function_chain_reference only if the struct is not nil

### DIFF
--- a/nutanix/resource_nutanix_subnet.go
+++ b/nutanix/resource_nutanix_subnet.go
@@ -348,14 +348,14 @@ func resourceNutanixSubnetCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if err := getSubnetResources(d, subnet); err != nil {
-		return fmt.Errorf("Error retrieving Nutanix Subnet resources %+v", err)
+		return fmt.Errorf("error retrieving Nutanix Subnet resources %+v", err)
 	}
 
 	spec.Description = utils.StringPtr(d.Get("description").(string))
 
 	subnetUUID, err := resourceNutanixSubnetExists(conn, d.Get("name").(string))
 	if err != nil {
-		return fmt.Errorf("Error checkinf if subnet already exists %+v", err)
+		return fmt.Errorf("error checkinf if subnet already exists %+v", err)
 	}
 
 	if subnetUUID != nil {
@@ -369,7 +369,7 @@ func resourceNutanixSubnetCreate(d *schema.ResourceData, meta interface{}) error
 
 	resp, err := conn.V3.CreateSubnet(request)
 	if err != nil {
-		return fmt.Errorf("Error creating Nutanix Subnet %s: %+v", utils.StringValue(spec.Name), err)
+		return fmt.Errorf("error creating Nutanix Subnet %s: %+v", utils.StringValue(spec.Name), err)
 	}
 
 	d.SetId(*resp.Metadata.UUID)
@@ -410,7 +410,7 @@ func resourceNutanixSubnetRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := conn.V3.GetSubnet(d.Id())
 	if err != nil {
-		return fmt.Errorf("Error subnet id (%s): %+v", d.Id(), err)
+		return fmt.Errorf("error subnet id (%s): %+v", d.Id(), err)
 	}
 
 	m, c := setRSEntityMetadata(resp.Metadata)
@@ -479,19 +479,19 @@ func resourceNutanixSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err := d.Set("dhcp_server_address", dhcpSA); err != nil {
-		return fmt.Errorf("Error setting attribute for subnet id (%s) dhcp_server_address: %s", d.Id(), err)
+		return fmt.Errorf("error setting attribute for subnet id (%s) dhcp_server_address: %s", d.Id(), err)
 	}
 	if err := d.Set("ip_config_pool_list_ranges", ipcpl); err != nil {
-		return fmt.Errorf("Error setting attribute for subnet id (%s) ip_config_pool_list_ranges: %s", d.Id(), err)
+		return fmt.Errorf("error setting attribute for subnet id (%s) ip_config_pool_list_ranges: %s", d.Id(), err)
 	}
 	if err := d.Set("dhcp_options", dOptions); err != nil {
-		return fmt.Errorf("Error setting attribute for subnet id (%s) dhcp_options: %s", d.Id(), err)
+		return fmt.Errorf("error setting attribute for subnet id (%s) dhcp_options: %s", d.Id(), err)
 	}
 	if err := d.Set("dhcp_domain_name_server_list", dnsList); err != nil {
-		return fmt.Errorf("Error setting attribute for subnet id (%s) dhcp_domain_name_server_list: %s", d.Id(), err)
+		return fmt.Errorf("error setting attribute for subnet id (%s) dhcp_domain_name_server_list: %s", d.Id(), err)
 	}
 	if err := d.Set("dhcp_domain_search_list", dsList); err != nil {
-		return fmt.Errorf("Error setting attribute for subnet id (%s) dhcp_domain_search_list: %s", d.Id(), err)
+		return fmt.Errorf("error setting attribute for subnet id (%s) dhcp_domain_search_list: %s", d.Id(), err)
 	}
 
 	d.Set("cluster_reference_name", utils.StringValue(resp.Status.ClusterReference.Name))
@@ -538,7 +538,7 @@ func resourceNutanixSubnetUpdate(d *schema.ResourceData, meta interface{}) error
 	response, err := conn.V3.GetSubnet(d.Id())
 
 	if err != nil {
-		return fmt.Errorf("Error retrieving for subnet id (%s) :%s", d.Id(), err)
+		return fmt.Errorf("error retrieving for subnet id (%s) :%s", d.Id(), err)
 	}
 
 	if response.Metadata != nil {
@@ -674,7 +674,7 @@ func resourceNutanixSubnetUpdate(d *schema.ResourceData, meta interface{}) error
 
 	resp, errUpdate := conn.V3.UpdateSubnet(d.Id(), request)
 	if errUpdate != nil {
-		return fmt.Errorf("Error updating subnet id %s): %s", d.Id(), errUpdate)
+		return fmt.Errorf("error updating subnet id %s): %s", d.Id(), errUpdate)
 	}
 
 	// stateConf := &resource.StateChangeConf{
@@ -714,7 +714,7 @@ func resourceNutanixSubnetDelete(d *schema.ResourceData, meta interface{}) error
 	resp, err := conn.V3.DeleteSubnet(d.Id())
 
 	if err != nil {
-		return fmt.Errorf("Error deleting subnet id %s): %s", d.Id(), err)
+		return fmt.Errorf("error deleting subnet id %s): %s", d.Id(), err)
 	}
 
 	// stateConf := &resource.StateChangeConf{

--- a/nutanix/resource_nutanix_subnet.go
+++ b/nutanix/resource_nutanix_subnet.go
@@ -348,15 +348,14 @@ func resourceNutanixSubnetCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if err := getSubnetResources(d, subnet); err != nil {
-		return err
+		return fmt.Errorf("Error retrieving Nutanix Subnet resources %+v", err)
 	}
 
 	spec.Description = utils.StringPtr(d.Get("description").(string))
 
 	subnetUUID, err := resourceNutanixSubnetExists(conn, d.Get("name").(string))
-
 	if err != nil {
-		return err
+		return fmt.Errorf("Error checkinf if subnet already exists %+v", err)
 	}
 
 	if subnetUUID != nil {
@@ -370,7 +369,7 @@ func resourceNutanixSubnetCreate(d *schema.ResourceData, meta interface{}) error
 
 	resp, err := conn.V3.CreateSubnet(request)
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating Nutanix Subnet %s: %+v", utils.StringValue(spec.Name), err)
 	}
 
 	d.SetId(*resp.Metadata.UUID)
@@ -397,7 +396,7 @@ func resourceNutanixSubnetCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("error waiting for subnet (%s) to create: %s", d.Id(), err)
+		return fmt.Errorf("error waiting for subnet id (%s) to create: %s", d.Id(), err)
 	}
 
 	// Setting Description because in Get request is not present.
@@ -411,7 +410,7 @@ func resourceNutanixSubnetRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := conn.V3.GetSubnet(d.Id())
 	if err != nil {
-		return err
+		return fmt.Errorf("Error subnet id (%s): %+v", d.Id(), err)
 	}
 
 	m, c := setRSEntityMetadata(resp.Metadata)
@@ -480,34 +479,46 @@ func resourceNutanixSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err := d.Set("dhcp_server_address", dhcpSA); err != nil {
-		return nil
+		return fmt.Errorf("Error setting attribute for subnet id (%s) dhcp_server_address: %s", d.Id(), err)
 	}
 	if err := d.Set("ip_config_pool_list_ranges", ipcpl); err != nil {
-		return nil
+		return fmt.Errorf("Error setting attribute for subnet id (%s) ip_config_pool_list_ranges: %s", d.Id(), err)
 	}
 	if err := d.Set("dhcp_options", dOptions); err != nil {
-		return nil
+		return fmt.Errorf("Error setting attribute for subnet id (%s) dhcp_options: %s", d.Id(), err)
 	}
 	if err := d.Set("dhcp_domain_name_server_list", dnsList); err != nil {
-		return nil
+		return fmt.Errorf("Error setting attribute for subnet id (%s) dhcp_domain_name_server_list: %s", d.Id(), err)
 	}
 	if err := d.Set("dhcp_domain_search_list", dsList); err != nil {
-		return nil
+		return fmt.Errorf("Error setting attribute for subnet id (%s) dhcp_domain_search_list: %s", d.Id(), err)
 	}
 
 	d.Set("cluster_reference_name", utils.StringValue(resp.Status.ClusterReference.Name))
 	d.Set("api_version", utils.StringValue(resp.APIVersion))
-	d.Set("name", utils.StringValue(resp.Status.Name))
-	// d.Set("description", utils.StringValue(resp.Status.Description))
-	d.Set("state", utils.StringValue(resp.Status.State))
-	d.Set("vswitch_name", utils.StringValue(resp.Status.Resources.VswitchName))
-	d.Set("subnet_type", utils.StringValue(resp.Status.Resources.SubnetType))
+
+	if status := resp.Status; status != nil {
+		d.Set("name", utils.StringValue(status.Name))
+		d.Set("state", utils.StringValue(status.State))
+
+		if res := status.Resources; res != nil {
+
+			d.Set("vswitch_name", utils.StringValue(res.VswitchName))
+			d.Set("subnet_type", utils.StringValue(res.SubnetType))
+
+			d.Set("vlan_id", utils.Int64Value(res.VlanID))
+
+			if res.NetworkFunctionChainReference != nil {
+				d.Set("network_function_chain_reference", getReferenceValues(res.NetworkFunctionChainReference))
+			}
+		}
+
+	}
+
 	d.Set("default_gateway_ip", dgIP)
 	d.Set("prefix_length", pl)
 	d.Set("subnet_ip", sIP)
 	d.Set("dhcp_server_address_port", port)
-	d.Set("vlan_id", utils.Int64Value(resp.Status.Resources.VlanID))
-	d.Set("network_function_chain_reference", getReferenceValues(resp.Status.Resources.NetworkFunctionChainReference))
 
 	d.SetId(*resp.Metadata.UUID)
 
@@ -527,7 +538,7 @@ func resourceNutanixSubnetUpdate(d *schema.ResourceData, meta interface{}) error
 	response, err := conn.V3.GetSubnet(d.Id())
 
 	if err != nil {
-		return err
+		return fmt.Errorf("Error retrieving for subnet id (%s) :%s", d.Id(), err)
 	}
 
 	if response.Metadata != nil {
@@ -663,7 +674,7 @@ func resourceNutanixSubnetUpdate(d *schema.ResourceData, meta interface{}) error
 
 	resp, errUpdate := conn.V3.UpdateSubnet(d.Id(), request)
 	if errUpdate != nil {
-		return errUpdate
+		return fmt.Errorf("Error updating subnet id %s): %s", d.Id(), errUpdate)
 	}
 
 	// stateConf := &resource.StateChangeConf{
@@ -703,7 +714,7 @@ func resourceNutanixSubnetDelete(d *schema.ResourceData, meta interface{}) error
 	resp, err := conn.V3.DeleteSubnet(d.Id())
 
 	if err != nil {
-		return err
+		return fmt.Errorf("Error deleting subnet id %s): %s", d.Id(), err)
 	}
 
 	// stateConf := &resource.StateChangeConf{

--- a/nutanix/resource_nutanix_subnet.go
+++ b/nutanix/resource_nutanix_subnet.go
@@ -497,6 +497,8 @@ func resourceNutanixSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("cluster_reference_name", utils.StringValue(resp.Status.ClusterReference.Name))
 	d.Set("api_version", utils.StringValue(resp.APIVersion))
 
+	nfcr := make(map[string]interface{})
+
 	if status := resp.Status; status != nil {
 		d.Set("name", utils.StringValue(status.Name))
 		d.Set("state", utils.StringValue(status.State))
@@ -509,12 +511,12 @@ func resourceNutanixSubnetRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("vlan_id", utils.Int64Value(res.VlanID))
 
 			if res.NetworkFunctionChainReference != nil {
-				d.Set("network_function_chain_reference", getReferenceValues(res.NetworkFunctionChainReference))
+				nfcr = getReferenceValues(res.NetworkFunctionChainReference)
 			}
 		}
 
 	}
-
+	d.Set("network_function_chain_reference", nfcr)
 	d.Set("default_gateway_ip", dgIP)
 	d.Set("prefix_length", pl)
 	d.Set("subnet_ip", sIP)


### PR DESCRIPTION
Currently, it sets `network_function_chain_reference` attribute even if the struct is `nil`. Changed it to ignore the attribute if the response is nil. 