### PR TITLE
Add HTTP Proxy capability

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 
@@ -51,6 +52,7 @@ type Credentials struct {
 	Endpoint string
 	Port     string
 	Insecure bool
+	ProxyURL string
 }
 
 // NewClient returns a new Nutanix API client.
@@ -59,6 +61,16 @@ func NewClient(credentials *Credentials) (*Client, error) {
 	transCfg := &http.Transport{
 		// nolint:gas
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: credentials.Insecure}, // ignore expired SSL certificates
+	}
+
+	if credentials.ProxyURL != "" {
+		log.Printf("[DEBUG] Using proxy: %s\n", credentials.ProxyURL)
+		proxy, err := url.Parse(credentials.ProxyURL)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing proxy url: %s", err)
+		}
+
+		transCfg.Proxy = http.ProxyURL(proxy)
 	}
 
 	httpClient := http.DefaultClient

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -26,7 +26,7 @@ func setup() {
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
 
-	client, _ = NewClient(&Credentials{"", "username", "password", "", "", true})
+	client, _ = NewClient(&Credentials{"", "username", "password", "", "", true, ""})
 	client.BaseURL, _ = url.Parse(server.URL)
 }
 
@@ -35,7 +35,7 @@ func teardown() {
 }
 
 func TestNewClient(t *testing.T) {
-	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true})
+	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, ""})
 
 	if err != nil {
 		t.Errorf("Unexpected Error: %v", err)
@@ -53,7 +53,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestNewRequest(t *testing.T) {
-	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true})
+	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, ""})
 
 	if err != nil {
 		t.Errorf("Unexpected Error: %v", err)

--- a/nutanix/config.go
+++ b/nutanix/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/terraform-providers/terraform-provider-nutanix/client"
-	"github.com/terraform-providers/terraform-provider-nutanix/client/v3"
+	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
 )
 
 // Version represents api version
@@ -18,6 +18,7 @@ type Config struct {
 	Port        string
 	Insecure    bool
 	WaitTimeout int64
+	ProxyURL    string
 }
 
 // Client ...
@@ -30,6 +31,7 @@ func (c *Config) Client() (*Client, error) {
 		Password: c.Password,
 		Port:     c.Port,
 		Insecure: c.Insecure,
+		ProxyURL: c.ProxyURL,
 	}
 
 	v3, err := v3.NewV3Client(configCreds)

--- a/nutanix/provider.go
+++ b/nutanix/provider.go
@@ -50,6 +50,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("NUTANIX_WAIT_TIMEOUT", nil),
 				Description: descriptions["wait_timeout"],
 			},
+			"proxy_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("NUTANIX_PROXY_URL", nil),
+				Description: descriptions["proxy_url"],
+			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"nutanix_image":           dataSourceNutanixImage(),
@@ -95,6 +101,8 @@ func init() {
 			"cluster lifecycle management operations, such as AOS upgrades.",
 
 		"wait_timeout": "Set if you know that the creation o update of a resource may take long time (minutes)",
+
+		"proxy_url": "Use this to connect Nutanix API through the proxy server.",
 	}
 }
 
@@ -110,6 +118,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Insecure:    d.Get("insecure").(bool),
 		Port:        d.Get("port").(string),
 		WaitTimeout: int64(d.Get("wait_timeout").(int)),
+		ProxyURL:    d.Get("proxy_url").(string),
 	}
 
 	return config.Client()

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -46,7 +46,8 @@ provider "nutanix" {
   endpoint     = "xxxx"
   insecure     = true
   port         = 9440
-  wait_timeout = 10
+  wait_timeout = 10 //Optional
+  proxy_url    =  "xxxx" //Optional
 }
 ```
 
@@ -68,6 +69,7 @@ $ export NUTANIX_INSECURE="xxxx"
 $ export NUTANIX_PORT="xxxx"
 $ export NUTANIX_ENDPOINT="xxxx"
 $ export NUTANIX_WAIT_TIMEOUT = "xxx"
+$ export NUTANIX_PROXY_URL = "xxx"
 
 $ terraform plan
 ```


### PR DESCRIPTION
Closes #26 

To add proxy_url just add to provider definition:

```hcl
provider "nutanix" {
  username     = "xxxx"
  password     = "xxxx"
  endpoint     = "xxxx"
  insecure     = true
  port         = 9440
  wait_timeout = 10 //Optional
  proxy_url    =  "xxxx" //Optional
}
```