### PR TITLE
added VMNic.IsConnected to preFillResUpdateRequest

### DIFF
--- a/nutanix/resource_nutanix_virtual_machine.go
+++ b/nutanix/resource_nutanix_virtual_machine.go
@@ -1762,6 +1762,7 @@ func preFillResUpdateRequest(res *v3.VMResources, response *v3.VMIntentResponse)
 				SubnetReference:               v.SubnetReference,
 				NetworkFunctionNicType:        v.NetworkFunctionNicType,
 				NetworkFunctionChainReference: v.NetworkFunctionChainReference,
+				IsConnected:                   v.IsConnected,
 			}
 
 		}


### PR DESCRIPTION
fixes #33 
fixes #41 

One of the VMNic properties wasn't getting copied over in `preFillResUpdateRequest`
This is a required param in the v3 API so `changePowerState` and any in-place updates to VMs were failing.

