### PR TITLE
Fix typos causing panic on userdata change, ForceNew on change

### DIFF
--- a/nutanix/resource_nutanix_virtual_machine.go
+++ b/nutanix/resource_nutanix_virtual_machine.go
@@ -555,11 +555,13 @@ func resourceNutanixVirtualMachine() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"guest_customization_cloud_init_meta_data": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"guest_customization_cloud_init_custom_key_values": {
 				Type:     schema.TypeMap,
@@ -575,6 +577,7 @@ func resourceNutanixVirtualMachine() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"install_type": {
@@ -594,6 +597,7 @@ func resourceNutanixVirtualMachine() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"should_fail_on_script_failure": {
 				Type:     schema.TypeBool,
@@ -1110,12 +1114,12 @@ func resourceNutanixVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 	}
 
 	if d.HasChange("guest_customization_cloud_init_user_data") {
-		_, n := d.GetChange("guest_customization_user_data")
+		_, n := d.GetChange("guest_customization_cloud_init_user_data")
 		cloudInit.UserData = utils.StringPtr(n.(string))
 	}
 
 	if d.HasChange("guest_customization_cloud_init_meta_data") {
-		_, n := d.GetChange("guest_customization_meta_data")
+		_, n := d.GetChange("guest_customization_cloud_init_meta_data")
 		cloudInit.MetaData = utils.StringPtr(n.(string))
 	}
 


### PR DESCRIPTION
Closes #67, new plan when `cloud_init`/`user_data` modified:

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

-/+ nutanix_virtual_machine.node (new resource required)
      id:                                                        "0a6dfac0-4e5b-4125-ab16-7578b5befe67" => <computed> (forces new resource)
      api_version:                                               "3.1" => <computed>
      availability_zone_reference.%:                             "0" => <computed>
      boot_device_disk_address.%:                                "0" => <computed>
      boot_device_mac_address:                                   "" => <computed>
      boot_device_order_list.#:                                  "0" => <computed>
      categories.%:                                              "0" => <computed>
      cluster_name:                                              "spkubecluster.seibels.com" => <computed>
      cluster_uuid:                                              "00057bbc-838f-512a-0000-000000019a64" => "00057bbc-838f-512a-0000-000000019a64"
      description:                                               "" => <computed>
      disk_list.#:                                               "3" => "2"
      disk_list.0.data_source_reference.%:                       "2" => "2"
      disk_list.0.data_source_reference.kind:                    "image" => "image"
      disk_list.0.data_source_reference.uuid:                    "e5531e12-ce9d-47f5-b123-6e65aaf37c42" => "e5531e12-ce9d-47f5-b123-6e65aaf37c42"
      disk_list.0.device_properties.#:                           "1" => "1"
      disk_list.0.device_properties.0.device_type:               "DISK" => "DISK"
      disk_list.0.device_properties.0.disk_address.%:            "2" => "2"
      disk_list.0.device_properties.0.disk_address.adapter_type: "SCSI" => "SCSI"
      disk_list.0.device_properties.0.disk_address.device_index: "0" => "0"
      disk_list.0.disk_size_bytes:                               "8589934592" => <computed>
      disk_list.0.disk_size_mib:                                 "8192" => <computed>
      disk_list.0.uuid:                                          "22f95aa4-4a3d-4347-b275-49d90edd32b1" => <computed>
      disk_list.0.volume_group_reference.%:                      "0" => <computed>
      disk_list.1.data_source_reference.%:                       "0" => <computed>
      disk_list.1.device_properties.#:                           "1" => "1"
      disk_list.1.device_properties.0.device_type:               "DISK" => "DISK"
      disk_list.1.device_properties.0.disk_address.%:            "2" => "2"
      disk_list.1.device_properties.0.disk_address.adapter_type: "SCSI" => "SCSI"
      disk_list.1.device_properties.0.disk_address.device_index: "1" => "1"
      disk_list.1.disk_size_bytes:                               "104857600000" => <computed>
      disk_list.1.disk_size_mib:                                 "100000" => "100000"
      disk_list.1.uuid:                                          "431a6469-7904-4c74-a3d6-894ef6128d0b" => <computed>
      disk_list.1.volume_group_reference.%:                      "0" => <computed>
      enable_script_exec:                                        "false" => <computed>
      gpu_list.#:                                                "0" => <computed>
      guest_customization_cloud_init_custom_key_values.%:        "0" => <computed>
      guest_customization_cloud_init_meta_data:                  "" => <computed>
      guest_customization_cloud_init_user_data:                  "oldBase64=" => "newBase64==" (forces new resource)
      guest_customization_is_overridable:                        "false" => <computed>
      guest_customization_sysprep.%:                             "0" => <computed>
      guest_customization_sysprep_custom_key_values.%:           "0" => <computed>
      guest_os_id:                                               "" => <computed>
      hardware_clock_timezone:                                   "UTC" => <computed>
      host_reference.%:                                          "3" => <computed>
      hypervisor_type:                                           "" => <computed>
      memory_size_mib:                                           "8192" => "8192"
      metadata.%:                                                "6" => <computed>
      name:                                                      "userdata-test-0" => "userdata-test-0"
      ngt_credentials.%:                                         "0" => <computed>
      ngt_enabled_capability_list.#:                             "0" => <computed>
      nic_list.#:                                                "1" => "1"
      nic_list.0.ip_endpoint_list.#:                             "1" => <computed>
      nic_list.0.is_connected:                                   "true" => "true"
      nic_list.0.mac_address:                                    "50:6b:8d:2e:ae:72" => <computed>
      nic_list.0.model:                                          "" => <computed>
      nic_list.0.network_function_chain_reference.%:             "0" => <computed>
      nic_list.0.network_function_nic_type:                      "" => <computed>
      nic_list.0.nic_type:                                       "NORMAL_NIC" => <computed>
      nic_list.0.subnet_name:                                    "POC-VM" => <computed>
      nic_list.0.subnet_uuid:                                    "b20e8d8c-efed-448e-9c1c-0060654094a2" => "b20e8d8c-efed-448e-9c1c-0060654094a2"
      nic_list.0.uuid:                                           "53a8531a-faa2-4d5e-af70-095414c83e1f" => <computed>
      nic_list_status.#:                                         "1" => <computed>
      num_sockets:                                               "1" => "1"
      num_vcpus_per_socket:                                      "2" => "2"
      num_vnuma_nodes:                                           "0" => <computed>
      nutanix_guest_tools.%:                                     "0" => <computed>
      owner_reference.%:                                         "3" => <computed>
      parent_reference.%:                                        "0" => <computed>
      power_state:                                               "ON" => <computed>
      power_state_mechanism:                                     "HARD" => <computed>
      project_reference.%:                                       "3" => <computed>
      should_fail_on_script_failure:                             "false" => <computed>
      state:                                                     "COMPLETE" => <computed>
      vga_console_enabled:                                       "true" => <computed>


Plan: 1 to add, 0 to change, 1 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.
```