### PR TITLE
Add missing API fields for structs

### DIFF
--- a/client/v3/v3_structs.go
+++ b/client/v3/v3_structs.go
@@ -1616,17 +1616,19 @@ type NetworkSecurityRule struct {
 
 // Metadata Metadata The kind metadata
 type Metadata struct {
-	LastUpdateTime       *time.Time        `json:"last_update_time,omitempty"`  //
-	Kind                 *string           `json:"kind"`                        //
-	UUID                 *string           `json:"uuid,omitempty"`              //
-	ProjectReference     *Reference        `json:"project_reference,omitempty"` // project reference
-	CreationTime         *time.Time        `json:"creation_time,omitempty"`
-	SpecVersion          *int64            `json:"spec_version,omitempty"`
-	SpecHash             *string           `json:"spec_hash,omitempty"`
-	OwnerReference       *Reference        `json:"owner_reference,omitempty"`
-	Categories           map[string]string `json:"categories,omitempty"`
-	Name                 *string           `json:"name,omitempty"`
-	ShouldForceTranslate *bool             `json:"should_force_translate,omitempty"` // Applied on Prism Central only. Indicate whether force to translate the spec of the fanout request to fit the target cluster API schema.
+	LastUpdateTime   *time.Time        `json:"last_update_time,omitempty"`  //
+	Kind             *string           `json:"kind"`                        //
+	UUID             *string           `json:"uuid,omitempty"`              //
+	ProjectReference *Reference        `json:"project_reference,omitempty"` // project reference
+	CreationTime     *time.Time        `json:"creation_time,omitempty"`
+	SpecVersion      *int64            `json:"spec_version,omitempty"`
+	SpecHash         *string           `json:"spec_hash,omitempty"`
+	OwnerReference   *Reference        `json:"owner_reference,omitempty"`
+	Categories       map[string]string `json:"categories,omitempty"`
+	Name             *string           `json:"name,omitempty"`
+
+	// Applied on Prism Central only. Indicate whether force to translate the spec of the fanout request to fit the target cluster API schema.
+	ShouldForceTranslate *bool `json:"should_force_translate,omitempty"`
 }
 
 // NetworkSecurityRuleIntentInput An intentful representation of a network_security_rule
@@ -1638,7 +1640,7 @@ type NetworkSecurityRuleIntentInput struct {
 
 // NetworkSecurityRuleDefStatus ... Network security rule status
 type NetworkSecurityRuleDefStatus struct {
-	Resources        *NetworkSecurityRuleResources `json:"resources,omitmepty"`
+	Resources        *NetworkSecurityRuleResources `json:"resources,omitempty"`
 	State            *string                       `json:"state,omitempty"`
 	ExecutionContext *ExecutionContext             `json:"execution_context,omitempty"`
 	Name             *string                       `json:"name,omitempty"`

--- a/client/v3/v3_structs.go
+++ b/client/v3/v3_structs.go
@@ -245,6 +245,9 @@ type VMResources struct {
 	// NICs attached to the VM.
 	NicList []*VMNic `json:"nic_list,omitempty"`
 
+	// Number of threads per core
+	NumThreads *int64 `json:"num_threads_per_core,omitempty"`
+
 	// Number of vCPU sockets.
 	NumSockets *int64 `json:"num_sockets,omitempty"`
 
@@ -836,6 +839,9 @@ type ImageResources struct {
 
 	// The image version
 	Version *ImageVersionResources `json:"version,omitempty"`
+
+	// Reference to the source image such as 'vm_disk
+	DataSourceReference *Reference `json:"data_source_reference,omitempty"`
 }
 
 // Image An intentful representation of a image spec
@@ -1610,16 +1616,17 @@ type NetworkSecurityRule struct {
 
 // Metadata Metadata The kind metadata
 type Metadata struct {
-	LastUpdateTime   *time.Time        `json:"last_update_time,omitempty"`  //
-	Kind             *string           `json:"kind"`                        //
-	UUID             *string           `json:"uuid,omitempty"`              //
-	ProjectReference *Reference        `json:"project_reference,omitempty"` // project reference
-	CreationTime     *time.Time        `json:"creation_time,omitempty"`
-	SpecVersion      *int64            `json:"spec_version,omitempty"`
-	SpecHash         *string           `json:"spec_hash,omitempty"`
-	OwnerReference   *Reference        `json:"owner_reference,omitempty"`
-	Categories       map[string]string `json:"categories,omitempty"`
-	Name             *string           `json:"name,omitempty"`
+	LastUpdateTime       *time.Time        `json:"last_update_time,omitempty"`  //
+	Kind                 *string           `json:"kind"`                        //
+	UUID                 *string           `json:"uuid,omitempty"`              //
+	ProjectReference     *Reference        `json:"project_reference,omitempty"` // project reference
+	CreationTime         *time.Time        `json:"creation_time,omitempty"`
+	SpecVersion          *int64            `json:"spec_version,omitempty"`
+	SpecHash             *string           `json:"spec_hash,omitempty"`
+	OwnerReference       *Reference        `json:"owner_reference,omitempty"`
+	Categories           map[string]string `json:"categories,omitempty"`
+	Name                 *string           `json:"name,omitempty"`
+	ShouldForceTranslate *bool             `json:"should_force_translate,omitempty"` // Applied on Prism Central only. Indicate whether force to translate the spec of the fanout request to fit the target cluster API schema.
 }
 
 // NetworkSecurityRuleIntentInput An intentful representation of a network_security_rule


### PR DESCRIPTION
I've noticed after working with the Nutanix `v3` [API](https://www.nutanix.dev/reference/prism_central/v3/api/) that some fields were missing.

Added:
1. `NumThreads` in [**VMResources**](https://www.nutanix.dev/reference/prism_central/v3/api/vms/postvms#request-body)
1. `DataSourceReference` in [**ImageResources**](https://www.nutanix.dev/reference/prism_central/v3/api/images/postimages#request-body) - closes #52 
1. `ShouldForceTranslate` in [**Metadata** - used all over](https://www.nutanix.dev/reference/prism_central/v3/api/images/postimages#request-body)
1. Fixed typo for `omitempty`