### PR TITLE
website: # removed

### DIFF
--- a/website/nutanix.erb
+++ b/website/nutanix.erb
@@ -43,9 +43,9 @@
                         <li<%= sidebar_current("docs-nutanix-resource-nutanix-virtual-machine") %>>
                             <a href="/docs/providers/nutanix/r/virtual_machine.html">nutanix_virtual_machine</a>
                         </li>
-                        # <li<%= sidebar_current("docs-nutanix-resource-nutanix-volume-group") %>>
-                        #     <a href="/docs/providers/nutanix/r/volume_group.html">nutanix_volume_group</a>
-                        # </li>
+                        <li<%= sidebar_current("docs-nutanix-resource-nutanix-volume-group") %>>
+                            <a href="/docs/providers/nutanix/r/volume_group.html">nutanix_volume_group</a>
+                        </li>
                         <li<%= sidebar_current("docs-nutanix-resource-nutanix_subnet") %>>
                             <a href="/docs/providers/nutanix/r/subnet.html">nutanix_subnet</a>
                         </li>


### PR DESCRIPTION
Commenting out does not work this way, the link will still be displayed. Instead, it doesn't look so pretty:

![Screenshot from 2019-11-06 15-59-08](https://user-images.githubusercontent.com/4533780/68309220-62caf880-00ae-11ea-96fb-2de16acee7a8.png)

Assume it's a mistake and have it removed.