### PR TITLE
Add retrieving of clusters by name

### DIFF
--- a/client/v3/v3_service.go
+++ b/client/v3/v3_service.go
@@ -1004,7 +1004,7 @@ func (op Operations) ListAllImage() (*ImageListIntentResponse, error) {
 
 // ListAllCluster ...
 func (op Operations) ListAllCluster() (*ClusterListIntentResponse, error) {
-	entities := make([]*ClusterIntentResource, 0)
+	entities := make([]*ClusterIntentResponse, 0)
 
 	resp, err := op.ListCluster(&DSMetadata{
 		Kind:   utils.StringPtr("cluster"),

--- a/client/v3/v3_service_test.go
+++ b/client/v3/v3_service_test.go
@@ -1350,8 +1350,8 @@ func TestOperations_ListCluster(t *testing.T) {
 	})
 
 	list := &ClusterListIntentResponse{}
-	list.Entities = make([]*ClusterIntentResource, 1)
-	list.Entities[0] = &ClusterIntentResource{}
+	list.Entities = make([]*ClusterIntentResponse, 1)
+	list.Entities[0] = &ClusterIntentResponse{}
 	list.Entities[0].Metadata = &Metadata{
 		UUID: utils.StringPtr("cfde831a-4e87-4a75-960f-89b0148aa2cc"),
 		Kind: utils.StringPtr("cluster"),

--- a/client/v3/v3_structs.go
+++ b/client/v3/v3_structs.go
@@ -1022,16 +1022,8 @@ type ImageListIntentResponse struct {
 // ClusterListIntentResponse ...
 type ClusterListIntentResponse struct {
 	APIVersion *string                  `json:"api_version"`
-	Entities   []*ClusterIntentResource `json:"entities,omitempty"`
+	Entities   []*ClusterIntentResponse `json:"entities,omitempty"`
 	Metadata   *ListMetadataOutput      `json:"metadata"`
-}
-
-// ClusterIntentResource ...
-type ClusterIntentResource struct {
-	APIVersion *string           `json:"api_version,omitempty"`
-	Metadata   *Metadata         `json:"metadata"`
-	Spec       *Cluster          `json:"spec,omitempty"`
-	Status     *ClusterDefStatus `json:"status,omitempty"`
 }
 
 // ClusterIntentResponse ...


### PR DESCRIPTION
This PR adds the ability to retrieve clusters by name using the "name" attribute on the "nutanix_cluster" datasource.

It also removes the ClusterIntentResource in favor of ClusterIntentResponse as they are exactly the same.
