### PR TITLE
Reduce the amount of API requests and improvements

### DIFF
--- a/client/v3/v3_service.go
+++ b/client/v3/v3_service.go
@@ -1013,8 +1013,8 @@ func (op Operations) ListAllImage() (*ImageListIntentResponse, error) {
 }
 
 // ListAllCluster ...
-func (op Operations) ListAllCluster() (*ClusterListIntentResponse, error) {
-	entities := make([]*ClusterIntentResource, 0)
+func (op Operations) ListAllCluster(filter string) (*ClusterListIntentResponse, error) {
+	entities := make([]*ClusterIntentResponse, 0)
 
 	resp, err := op.ListCluster(&DSMetadata{
 		Kind:   utils.StringPtr("cluster"),

--- a/client/v3/v3_service.go
+++ b/client/v3/v3_service.go
@@ -56,11 +56,11 @@ type Service interface {
 	GetVolumeGroup(uuid string) (*VolumeGroupResponse, error)
 	DeleteVolumeGroup(uuid string) error
 	CreateVolumeGroup(request *VolumeGroupInput) (*VolumeGroupResponse, error)
-	ListAllVM() (*VMListIntentResponse, error)
-	ListAllSubnet() (*SubnetListIntentResponse, error)
-	ListAllNetworkSecurityRule() (*NetworkSecurityRuleListIntentResponse, error)
-	ListAllImage() (*ImageListIntentResponse, error)
-	ListAllCluster() (*ClusterListIntentResponse, error)
+	ListAllVM(filter string) (*VMListIntentResponse, error)
+	ListAllSubnet(filter string) (*SubnetListIntentResponse, error)
+	ListAllNetworkSecurityRule(filter string) (*NetworkSecurityRuleListIntentResponse, error)
+	ListAllImage(filter string) (*ImageListIntentResponse, error)
+	ListAllCluster(filter string) (*ClusterListIntentResponse, error)
 	GetTask(taskUUID string) (*TasksResponse, error)
 }
 
@@ -850,10 +850,11 @@ func hasNext(ri *int64) bool {
 }
 
 // ListAllVM ...
-func (op Operations) ListAllVM() (*VMListIntentResponse, error) {
+func (op Operations) ListAllVM(filter string) (*VMListIntentResponse, error) {
 	entities := make([]*VMIntentResource, 0)
 
 	resp, err := op.ListVM(&DSMetadata{
+		Filter: &filter,
 		Kind:   utils.StringPtr("vm"),
 		Length: utils.Int64Ptr(itemsPerPage),
 	})
@@ -869,6 +870,7 @@ func (op Operations) ListAllVM() (*VMListIntentResponse, error) {
 	if totalEntities > itemsPerPage {
 		for hasNext(&remaining) {
 			resp, err = op.ListVM(&DSMetadata{
+				Filter: &filter,
 				Kind:   utils.StringPtr("vm"),
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
@@ -890,10 +892,11 @@ func (op Operations) ListAllVM() (*VMListIntentResponse, error) {
 }
 
 // ListAllSubnet ...
-func (op Operations) ListAllSubnet() (*SubnetListIntentResponse, error) {
+func (op Operations) ListAllSubnet(filter string) (*SubnetListIntentResponse, error) {
 	entities := make([]*SubnetIntentResponse, 0)
 
 	resp, err := op.ListSubnet(&DSMetadata{
+		Filter: &filter,
 		Kind:   utils.StringPtr("subnet"),
 		Length: utils.Int64Ptr(itemsPerPage),
 	})
@@ -909,6 +912,7 @@ func (op Operations) ListAllSubnet() (*SubnetListIntentResponse, error) {
 	if totalEntities > itemsPerPage {
 		for hasNext(&remaining) {
 			resp, err = op.ListSubnet(&DSMetadata{
+				Filter: &filter,
 				Kind:   utils.StringPtr("subnet"),
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
@@ -931,10 +935,11 @@ func (op Operations) ListAllSubnet() (*SubnetListIntentResponse, error) {
 }
 
 // ListAllNetworkSecurityRule ...
-func (op Operations) ListAllNetworkSecurityRule() (*NetworkSecurityRuleListIntentResponse, error) {
+func (op Operations) ListAllNetworkSecurityRule(filter string) (*NetworkSecurityRuleListIntentResponse, error) {
 	entities := make([]*NetworkSecurityRuleIntentResource, 0)
 
 	resp, err := op.ListNetworkSecurityRule(&DSMetadata{
+		Filter: &filter,
 		Kind:   utils.StringPtr("network_security_rule"),
 		Length: utils.Int64Ptr(itemsPerPage),
 	})
@@ -950,6 +955,7 @@ func (op Operations) ListAllNetworkSecurityRule() (*NetworkSecurityRuleListInten
 	if totalEntities > itemsPerPage {
 		for hasNext(&remaining) {
 			resp, err = op.ListNetworkSecurityRule(&DSMetadata{
+				Filter: &filter,
 				Kind:   utils.StringPtr("network_security_rule"),
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
@@ -972,10 +978,11 @@ func (op Operations) ListAllNetworkSecurityRule() (*NetworkSecurityRuleListInten
 }
 
 // ListAllImage ...
-func (op Operations) ListAllImage() (*ImageListIntentResponse, error) {
+func (op Operations) ListAllImage(filter string) (*ImageListIntentResponse, error) {
 	entities := make([]*ImageIntentResponse, 0)
 
 	resp, err := op.ListImage(&DSMetadata{
+		Filter: &filter,
 		Kind:   utils.StringPtr("image"),
 		Length: utils.Int64Ptr(itemsPerPage),
 	})
@@ -991,6 +998,7 @@ func (op Operations) ListAllImage() (*ImageListIntentResponse, error) {
 	if totalEntities > itemsPerPage {
 		for hasNext(&remaining) {
 			resp, err = op.ListImage(&DSMetadata{
+				Filter: &filter,
 				Kind:   utils.StringPtr("image"),
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),
@@ -1017,6 +1025,7 @@ func (op Operations) ListAllCluster(filter string) (*ClusterListIntentResponse, 
 	entities := make([]*ClusterIntentResponse, 0)
 
 	resp, err := op.ListCluster(&DSMetadata{
+		Filter: &filter,
 		Kind:   utils.StringPtr("cluster"),
 		Length: utils.Int64Ptr(itemsPerPage),
 	})
@@ -1032,6 +1041,7 @@ func (op Operations) ListAllCluster(filter string) (*ClusterListIntentResponse, 
 	if totalEntities > itemsPerPage {
 		for hasNext(&remaining) {
 			resp, err = op.ListCluster(&DSMetadata{
+				Filter: &filter,
 				Kind:   utils.StringPtr("cluster"),
 				Length: utils.Int64Ptr(itemsPerPage),
 				Offset: utils.Int64Ptr(offset),

--- a/client/v3/v3_service_test.go
+++ b/client/v3/v3_service_test.go
@@ -1391,8 +1391,8 @@ func TestOperations_ListCluster(t *testing.T) {
 	})
 
 	list := &ClusterListIntentResponse{}
-	list.Entities = make([]*ClusterIntentResource, 1)
-	list.Entities[0] = &ClusterIntentResource{}
+	list.Entities = make([]*ClusterIntentResponse, 1)
+	list.Entities[0] = &ClusterIntentResponse{}
 	list.Entities[0].Metadata = &Metadata{
 		UUID: utils.StringPtr("cfde831a-4e87-4a75-960f-89b0148aa2cc"),
 		Kind: utils.StringPtr("cluster"),

--- a/client/v3/v3_structs.go
+++ b/client/v3/v3_structs.go
@@ -1028,16 +1028,8 @@ type ImageListIntentResponse struct {
 // ClusterListIntentResponse ...
 type ClusterListIntentResponse struct {
 	APIVersion *string                  `json:"api_version"`
-	Entities   []*ClusterIntentResource `json:"entities,omitempty"`
+	Entities   []*ClusterIntentResponse `json:"entities,omitempty"`
 	Metadata   *ListMetadataOutput      `json:"metadata"`
-}
-
-// ClusterIntentResource ...
-type ClusterIntentResource struct {
-	APIVersion *string           `json:"api_version,omitempty"`
-	Metadata   *Metadata         `json:"metadata"`
-	Spec       *Cluster          `json:"spec,omitempty"`
-	Status     *ClusterDefStatus `json:"status,omitempty"`
 }
 
 // ClusterIntentResponse ...

--- a/nutanix/data_source_nutanix_clusters.go
+++ b/nutanix/data_source_nutanix_clusters.go
@@ -604,7 +604,8 @@ func dataSourceNutanixClustersRead(d *schema.ResourceData, meta interface{}) err
 	// Get client connection
 	conn := meta.(*Client).API
 
-	resp, err := conn.V3.ListAllCluster()
+	var filter string
+	resp, err := conn.V3.ListAllCluster(filter)
 
 	if err != nil {
 		return err

--- a/nutanix/data_source_nutanix_image.go
+++ b/nutanix/data_source_nutanix_image.go
@@ -279,7 +279,8 @@ func findImageByUUID(conn *v3.Client, uuid string) (*v3.ImageIntentResponse, err
 }
 
 func findImageByName(conn *v3.Client, name string) (*v3.ImageIntentResponse, error) {
-	resp, err := conn.V3.ListAllImage()
+	filter := fmt.Sprintf("name==%s", name)
+	resp, err := conn.V3.ListAllImage(filter)
 	if err != nil {
 		return nil, err
 	}

--- a/nutanix/data_source_nutanix_subnet.go
+++ b/nutanix/data_source_nutanix_subnet.go
@@ -284,7 +284,8 @@ func findSubnetByUUID(conn *v3.Client, uuid string) (*v3.SubnetIntentResponse, e
 }
 
 func findSubnetByName(conn *v3.Client, name string) (*v3.SubnetIntentResponse, error) {
-	resp, err := conn.V3.ListAllSubnet()
+	filter := fmt.Sprintf("subnet_name==%s", name)
+	resp, err := conn.V3.ListAllSubnet(filter)
 	if err != nil {
 		return nil, err
 	}

--- a/nutanix/resource_nutanix_image.go
+++ b/nutanix/resource_nutanix_image.go
@@ -290,7 +290,7 @@ func resourceNutanixImageCreate(d *schema.ResourceData, meta interface{}) error 
 	// Make request to the API
 	resp, err := conn.V3.CreateImage(request)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating Nutanix Image %s: %+v", utils.StringValue(spec.Name), err)
 	}
 
 	UUID := *resp.Metadata.UUID

--- a/nutanix/resource_nutanix_image.go
+++ b/nutanix/resource_nutanix_image.go
@@ -604,26 +604,6 @@ func getImageResource(d *schema.ResourceData, image *v3.ImageResources) error {
 	return nil
 }
 
-func resourceNutanixImageExists(conn *v3.Client, name string) (*string, error) {
-	log.Printf("[DEBUG] Get Image Existence : %s", name)
-
-	imageEntities := &v3.DSMetadata{}
-	var imageUUID *string
-
-	imageList, err := conn.V3.ListImage(imageEntities)
-
-	if err != nil {
-		return nil, err
-	}
-
-	for _, image := range imageList.Entities {
-		if image.Status.Name == utils.StringPtr(name) {
-			imageUUID = image.Metadata.UUID
-		}
-	}
-	return imageUUID, nil
-}
-
 func resourceImageInstanceStateUpgradeV0(is map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 	log.Printf("[DEBUG] Entering resourceImageInstanceStateUpgradeV0")
 	return resourceNutanixCategoriesMigrateState(is, meta)

--- a/nutanix/resource_nutanix_image.go
+++ b/nutanix/resource_nutanix_image.go
@@ -287,15 +287,6 @@ func resourceNutanixImageCreate(d *schema.ResourceData, meta interface{}) error 
 	request.Metadata = metadata
 	request.Spec = spec
 
-	imageUUID, err := resourceNutanixImageExists(conn, n.(string))
-	if err != nil {
-		return fmt.Errorf("failed to read image with name(%s): %+v", n.(string), err)
-	}
-
-	if imageUUID != nil {
-		return fmt.Errorf("image already exists with name %s  in the given cluster, UUID %s", d.Get("name").(string), *imageUUID)
-	}
-
 	// Make request to the API
 	resp, err := conn.V3.CreateImage(request)
 	if err != nil {

--- a/nutanix/resource_nutanix_network_security_rule.go
+++ b/nutanix/resource_nutanix_network_security_rule.go
@@ -809,26 +809,6 @@ func resourceNutanixNetworkSecurityRuleDelete(d *schema.ResourceData, meta inter
 	return nil
 }
 
-func resourceNutanixNetworkSecurityRuleExists(conn *v3.Client, name string) (*string, error) {
-	log.Printf("[DEBUG] Get Network Security Rule Existence : %s", name)
-
-	var nsrUUID *string
-
-	filter := fmt.Sprintf("name==%s", name)
-	networkSecurityRuleList, err := conn.V3.ListAllNetworkSecurityRule(filter)
-
-	if err != nil {
-		return nil, err
-	}
-
-	for _, nsr := range networkSecurityRuleList.Entities {
-		if nsr.Metadata.Name == utils.StringPtr(name) {
-			nsrUUID = nsr.Metadata.UUID
-		}
-	}
-	return nsrUUID, nil
-}
-
 func getNetworkSecurityRuleResources(d *schema.ResourceData, networkSecurityRule *v3.NetworkSecurityRuleResources) error {
 	isolationRule := &v3.NetworkSecurityRuleIsolationRule{}
 	appRule := &v3.NetworkSecurityRuleResourcesRule{}

--- a/nutanix/resource_nutanix_network_security_rule.go
+++ b/nutanix/resource_nutanix_network_security_rule.go
@@ -814,7 +814,8 @@ func resourceNutanixNetworkSecurityRuleExists(conn *v3.Client, name string) (*st
 
 	var nsrUUID *string
 
-	networkSecurityRuleList, err := conn.V3.ListAllNetworkSecurityRule()
+	filter := fmt.Sprintf("name==%s", name)
+	networkSecurityRuleList, err := conn.V3.ListAllNetworkSecurityRule(filter)
 
 	if err != nil {
 		return nil, err

--- a/nutanix/resource_nutanix_network_security_rule.go
+++ b/nutanix/resource_nutanix_network_security_rule.go
@@ -494,18 +494,6 @@ func resourceNutanixNetworkSecurityRuleCreate(d *schema.ResourceData, meta inter
 		spec.Description = utils.StringPtr(desc.(string))
 	}
 
-	networkSecurityRueUUID, err := resourceNutanixNetworkSecurityRuleExists(conn, d.Get("name").(string))
-
-	if err != nil {
-		return err
-	}
-
-	if networkSecurityRueUUID != nil {
-		return fmt.Errorf(
-			"network security rule already with name %s exists in the given cluster, UUID %s",
-			d.Get("name").(string), *networkSecurityRueUUID)
-	}
-
 	// set request
 
 	spec.Resources = networkSecurityRule

--- a/nutanix/resource_nutanix_network_security_rule.go
+++ b/nutanix/resource_nutanix_network_security_rule.go
@@ -508,7 +508,7 @@ func resourceNutanixNetworkSecurityRuleCreate(d *schema.ResourceData, meta inter
 	resp, err := conn.V3.CreateNetworkSecurityRule(request)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating Nutanix Network Security Rule %s: %+v", utils.StringValue(spec.Name), err)
 	}
 
 	d.SetId(*resp.Metadata.UUID)

--- a/nutanix/resource_nutanix_subnet.go
+++ b/nutanix/resource_nutanix_subnet.go
@@ -697,7 +697,8 @@ func resourceNutanixSubnetDelete(d *schema.ResourceData, meta interface{}) error
 func resourceNutanixSubnetExists(conn *v3.Client, name string) (*string, error) {
 	var subnetUUID *string
 
-	subnetList, err := conn.V3.ListAllSubnet()
+	filter := fmt.Sprintf("name==%s", name)
+	subnetList, err := conn.V3.ListAllSubnet(filter)
 
 	if err != nil {
 		return nil, err

--- a/nutanix/resource_nutanix_subnet.go
+++ b/nutanix/resource_nutanix_subnet.go
@@ -341,15 +341,6 @@ func resourceNutanixSubnetCreate(d *schema.ResourceData, meta interface{}) error
 
 	spec.Description = utils.StringPtr(d.Get("description").(string))
 
-	subnetUUID, err := resourceNutanixSubnetExists(conn, d.Get("name").(string))
-	if err != nil {
-		return fmt.Errorf("error checking if subnet already exists %+v", err)
-	}
-
-	if subnetUUID != nil {
-		return fmt.Errorf("subnet already with name %s exists in the given cluster, UUID %s", d.Get("name").(string), *subnetUUID)
-	}
-
 	spec.Name = utils.StringPtr(n.(string))
 	spec.Resources = subnet
 	request.Metadata = metadata

--- a/nutanix/resource_nutanix_virtual_machine.go
+++ b/nutanix/resource_nutanix_virtual_machine.go
@@ -1449,18 +1449,13 @@ func resourceNutanixVirtualMachineDelete(d *schema.ResourceData, meta interface{
 func resourceNutanixVirtualMachineExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	conn := meta.(*Client).API
 
-	resp, err := conn.V3.ListAllVM()
+	_, err := conn.V3.GetVM(d.Id())
 
 	if err != nil {
 		return false, err
 	}
 
-	for i := range resp.Entities {
-		if *resp.Entities[i].Metadata.UUID == d.Id() {
-			return true, nil
-		}
-	}
-	return false, nil
+	return true, nil
 }
 
 func getVMResources(d *schema.ResourceData, vm *v3.VMResources) error {


### PR DESCRIPTION
* add filter to ListAll*() function
    The filter allows us to, e.g. filter by name and dramaticly reduce the
    number of API requests as there is very little need to paginate anymore

* improve error messages
* remove unnecessary check for existence of resource  
    nutanix allows creating the same resource with the same name multiple
    times so we should allow this too.
    This also save us from doing some expensive API calls.

* get VM by ID for resourceNutanixVirtualMachineExists
    we have the ID available so it is not needed to loop through all the VMs

* remove ClusterIntentResource in favor of ClusterIntentResponse  
    ClusterIntentResource was only used in two places and is the exact same
    struct as ClusterIntentResponse.