### PR TITLE
Bugfix/power_state_mechanism

### DIFF
--- a/nutanix/resource_nutanix_virtual_machine.go
+++ b/nutanix/resource_nutanix_virtual_machine.go
@@ -1183,10 +1183,16 @@ func resourceNutanixVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 
 	if d.HasChange("disk_list") {
 		preCdromCount, err := CountDiskListCdrom(res.DiskList)
+		if err != nil {
+			return err
+		}
 		if res.DiskList, err = expandDiskList(d, false); err != nil {
 			return err
 		}
 		postCdromCount, err := CountDiskListCdrom(res.DiskList)
+		if err != nil {
+			return err
+		}
 		if preCdromCount != postCdromCount {
 			hotPlugChange = false
 		}

--- a/nutanix/resource_nutanix_virtual_machine_test.go
+++ b/nutanix/resource_nutanix_virtual_machine_test.go
@@ -185,6 +185,31 @@ func TestAccNutanixVirtualMachine_WithSerialPortList(t *testing.T) {
 	})
 }
 
+func TestAccNutanixVirtualMachine_PowerStateMechanism(t *testing.T) {
+	r := acctest.RandInt()
+	resourceName := "nutanix_virtual_machine.vm6"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNutanixVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNutanixVMConfigPowerStateMechanism(r),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNutanixVirtualMachineExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "power_state_mechanism", "ACPI"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"disk_list"},
+			},
+		},
+	})
+}
+
 func testAccCheckNutanixVirtualMachineExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -528,6 +553,27 @@ resource "nutanix_virtual_machine" "vm5" {
 		name  = "Environment"
 		value = "Staging"
 	}
+}
+`, r)
+}
+
+func testAccNutanixVMConfigPowerStateMechanism(r int) string {
+	return fmt.Sprintf(`
+data "nutanix_clusters" "clusters" {}
+
+locals {
+		cluster1 = "${data.nutanix_clusters.clusters.entities.0.service_list.0 == "PRISM_CENTRAL"
+		? data.nutanix_clusters.clusters.entities.1.metadata.uuid : data.nutanix_clusters.clusters.entities.0.metadata.uuid}"
+}
+
+resource "nutanix_virtual_machine" "vm6" {
+  name = "test-dou-%d"
+  cluster_uuid = "${local.cluster1}"
+  
+  num_vcpus_per_socket = 1
+  num_sockets          = 1
+  memory_size_mib      = 186
+  power_state_mechanism = "ACPI"
 }
 `, r)
 }

--- a/nutanix/resource_nutanix_virtual_machine_test.go
+++ b/nutanix/resource_nutanix_virtual_machine_test.go
@@ -210,6 +210,37 @@ func TestAccNutanixVirtualMachine_PowerStateMechanism(t *testing.T) {
 	})
 }
 
+func TestAccNutanixVirtualMachine_CdromGuestCustomisationReboot(t *testing.T) {
+	r := acctest.RandInt()
+	resourceName := "nutanix_virtual_machine.vm7"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNutanixVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNutanixVMConfigCdromGuestCustomisationReboot(r),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNutanixVirtualMachineExists(resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccNutanixVMConfigCdromGuestCustomisationReboot(r),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNutanixVirtualMachineExists(resourceName),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"disk_list"},
+			},
+		},
+	})
+}
+
 func testAccCheckNutanixVirtualMachineExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -574,6 +605,27 @@ resource "nutanix_virtual_machine" "vm6" {
   num_sockets          = 1
   memory_size_mib      = 186
   power_state_mechanism = "ACPI"
+}
+`, r)
+}
+
+func testAccNutanixVMConfigCdromGuestCustomisationReboot(r int) string {
+	return fmt.Sprintf(`
+data "nutanix_clusters" "clusters" {}
+
+locals {
+		cluster1 = "${data.nutanix_clusters.clusters.entities.0.service_list.0 == "PRISM_CENTRAL"
+		? data.nutanix_clusters.clusters.entities.1.metadata.uuid : data.nutanix_clusters.clusters.entities.0.metadata.uuid}"
+}
+
+resource "nutanix_virtual_machine" "vm7" {
+  name = "test-dou-%d"
+  cluster_uuid = "${local.cluster1}"
+  
+  num_vcpus_per_socket = 1
+  num_sockets          = 1
+  memory_size_mib      = 186
+  guest_customization_cloud_init_user_data = base64encode("#cloud-config\nfqdn: test.domain.local")
 }
 `, r)
 }


### PR DESCRIPTION
Fixed following bugs for client:
- Unable to use power_state_mechanism during initial provisioning
- When using guest customization, a CDrom drive is attached to the VM. Running a second Terraform apply causes an error due to the power state of the VM. Removing CDrom drives requires a powered off VM.

Kind regards