### PR TITLE
Feature/cluster datasource name

### DIFF
--- a/nutanix/data_source_nutanix_cluster_test.go
+++ b/nutanix/data_source_nutanix_cluster_test.go
@@ -1,6 +1,7 @@
 package nutanix
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -40,6 +41,19 @@ func TestAccNutanixClusterByNameDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccNutanixClusterByNameNotExistingDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccClusterByNameNotExistingDataSourceConfig,
+				ExpectError: regexp.MustCompile("Did not find cluster with name *"),
+			},
+		},
+	})
+}
+
 const testAccClusterDataSourceConfig = `
 data "nutanix_clusters" "clusters" {}
 
@@ -54,4 +68,12 @@ data "nutanix_clusters" "clusters" {}
 
 data "nutanix_cluster" "cluster" {
 	name = data.nutanix_clusters.clusters.entities.0.name
+}`
+
+const testAccClusterByNameNotExistingDataSourceConfig = `
+data "nutanix_clusters" "clusters" {}
+
+
+data "nutanix_cluster" "cluster" {
+	name = "ThisDoesNotExist"
 }`

--- a/nutanix/data_source_nutanix_cluster_test.go
+++ b/nutanix/data_source_nutanix_cluster_test.go
@@ -22,10 +22,36 @@ func TestAccNutanixClusterDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccNutanixClusterByNameDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterByNameDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.nutanix_cluster.cluster", "id"),
+					resource.TestCheckResourceAttrSet(
+						"data.nutanix_cluster.cluster", "name"),
+				),
+			},
+		},
+	})
+}
+
 const testAccClusterDataSourceConfig = `
 data "nutanix_clusters" "clusters" {}
 
 
 data "nutanix_cluster" "cluster" {
-	cluster_id = data.nutanix_clusters.clusters.entities.1.metadata.uuid
+	cluster_id = data.nutanix_clusters.clusters.entities.0.metadata.uuid
+}`
+
+const testAccClusterByNameDataSourceConfig = `
+data "nutanix_clusters" "clusters" {}
+
+
+data "nutanix_cluster" "cluster" {
+	name = data.nutanix_clusters.clusters.entities.0.name
 }`

--- a/nutanix/data_source_nutanix_cluster_test.go
+++ b/nutanix/data_source_nutanix_cluster_test.go
@@ -23,32 +23,47 @@ func TestAccNutanixClusterDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccNutanixClusterByNameDataSource_basic(t *testing.T) {
+func TestAccNutanixClusterDataSource_ByName(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterByNameDataSourceConfig,
+				Config: testAccClusterDataSourceConfigByName,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"data.nutanix_cluster.cluster", "id"),
 					resource.TestCheckResourceAttrSet(
 						"data.nutanix_cluster.cluster", "name"),
+					resource.TestCheckResourceAttrSet(
+						"data.nutanix_cluster.cluster", "cluster_id"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccNutanixClusterByNameNotExistingDataSource_basic(t *testing.T) {
+func TestAccNutanixClusterDataSource_ByNameNotExisting(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccClusterByNameNotExistingDataSourceConfig,
-				ExpectError: regexp.MustCompile("Did not find cluster with name *"),
+				Config:      testAccClusterDataSourceConfigByNameNotExisting,
+				ExpectError: regexp.MustCompile("did not find cluster with name *"),
+			},
+		},
+	})
+}
+
+func TestAccNutanixClusterDataSource_NameUuidConflict(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccClusterDataSourceConfigNameUUIDConflict,
+				ExpectError: regexp.MustCompile(" * conflicts with *"),
 			},
 		},
 	})
@@ -62,7 +77,7 @@ data "nutanix_cluster" "cluster" {
 	cluster_id = data.nutanix_clusters.clusters.entities.0.metadata.uuid
 }`
 
-const testAccClusterByNameDataSourceConfig = `
+const testAccClusterDataSourceConfigByName = `
 data "nutanix_clusters" "clusters" {}
 
 
@@ -70,10 +85,19 @@ data "nutanix_cluster" "cluster" {
 	name = data.nutanix_clusters.clusters.entities.0.name
 }`
 
-const testAccClusterByNameNotExistingDataSourceConfig = `
+const testAccClusterDataSourceConfigByNameNotExisting = `
 data "nutanix_clusters" "clusters" {}
 
 
 data "nutanix_cluster" "cluster" {
 	name = "ThisDoesNotExist"
+}`
+
+const testAccClusterDataSourceConfigNameUUIDConflict = `
+data "nutanix_clusters" "clusters" {}
+
+
+data "nutanix_cluster" "cluster" {
+	cluster_id = data.nutanix_clusters.clusters.entities.0.metadata.uuid
+	name = data.nutanix_clusters.clusters.entities.0.name
 }`

--- a/nutanix/resource_nutanix_virtual_machine.go
+++ b/nutanix/resource_nutanix_virtual_machine.go
@@ -1183,10 +1183,16 @@ func resourceNutanixVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 
 	if d.HasChange("disk_list") {
 		preCdromCount, err := CountDiskListCdrom(res.DiskList)
+		if err != nil {
+			return err
+		}
 		if res.DiskList, err = expandDiskList(d, false); err != nil {
 			return err
 		}
 		postCdromCount, err := CountDiskListCdrom(res.DiskList)
+		if err != nil {
+			return err
+		}
 		if preCdromCount != postCdromCount {
 			hotPlugChange = false
 		}
@@ -1924,13 +1930,11 @@ func waitForIPRefreshFunc(client *v3.Client, vmUUID string) resource.StateRefres
 }
 
 func CountDiskListCdrom(dl []*v3.VMDisk) (int, error) {
-	log.Printf("=====")
 	counter := 0
 	for _, v := range dl {
 		if *v.DeviceProperties.DeviceType == "CDROM" {
 			counter++
 		}
 	}
-	log.Printf("=====")
 	return counter, nil
 }

--- a/nutanix/resource_nutanix_virtual_machine_test.go
+++ b/nutanix/resource_nutanix_virtual_machine_test.go
@@ -185,6 +185,31 @@ func TestAccNutanixVirtualMachine_WithSerialPortList(t *testing.T) {
 	})
 }
 
+func TestAccNutanixVirtualMachine_PowerStateMechanism(t *testing.T) {
+	r := acctest.RandInt()
+	resourceName := "nutanix_virtual_machine.vm6"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNutanixVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNutanixVMConfigPowerStateMechanism(r),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNutanixVirtualMachineExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "power_state_mechanism", "ACPI"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"disk_list"},
+			},
+		},
+	})
+}
+
 func testAccCheckNutanixVirtualMachineExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -528,6 +553,27 @@ resource "nutanix_virtual_machine" "vm5" {
 		name  = "Environment"
 		value = "Staging"
 	}
+}
+`, r)
+}
+
+func testAccNutanixVMConfigPowerStateMechanism(r int) string {
+	return fmt.Sprintf(`
+data "nutanix_clusters" "clusters" {}
+
+locals {
+		cluster1 = "${data.nutanix_clusters.clusters.entities.0.service_list.0 == "PRISM_CENTRAL"
+		? data.nutanix_clusters.clusters.entities.1.metadata.uuid : data.nutanix_clusters.clusters.entities.0.metadata.uuid}"
+}
+
+resource "nutanix_virtual_machine" "vm6" {
+  name = "test-dou-%d"
+  cluster_uuid = "${local.cluster1}"
+  
+  num_vcpus_per_socket = 1
+  num_sockets          = 1
+  memory_size_mib      = 186
+  power_state_mechanism = "ACPI"
 }
 `, r)
 }

--- a/nutanix/resource_nutanix_virtual_machine_test.go
+++ b/nutanix/resource_nutanix_virtual_machine_test.go
@@ -210,6 +210,37 @@ func TestAccNutanixVirtualMachine_PowerStateMechanism(t *testing.T) {
 	})
 }
 
+func TestAccNutanixVirtualMachine_CdromGuestCustomisationReboot(t *testing.T) {
+	r := acctest.RandInt()
+	resourceName := "nutanix_virtual_machine.vm7"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNutanixVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNutanixVMConfigCdromGuestCustomisationReboot(r),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNutanixVirtualMachineExists(resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccNutanixVMConfigCdromGuestCustomisationReboot(r),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNutanixVirtualMachineExists(resourceName),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"disk_list"},
+			},
+		},
+	})
+}
+
 func testAccCheckNutanixVirtualMachineExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -574,6 +605,27 @@ resource "nutanix_virtual_machine" "vm6" {
   num_sockets          = 1
   memory_size_mib      = 186
   power_state_mechanism = "ACPI"
+}
+`, r)
+}
+
+func testAccNutanixVMConfigCdromGuestCustomisationReboot(r int) string {
+	return fmt.Sprintf(`
+data "nutanix_clusters" "clusters" {}
+
+locals {
+		cluster1 = "${data.nutanix_clusters.clusters.entities.0.service_list.0 == "PRISM_CENTRAL"
+		? data.nutanix_clusters.clusters.entities.1.metadata.uuid : data.nutanix_clusters.clusters.entities.0.metadata.uuid}"
+}
+
+resource "nutanix_virtual_machine" "vm7" {
+  name = "test-dou-%d"
+  cluster_uuid = "${local.cluster1}"
+  
+  num_vcpus_per_socket = 1
+  num_sockets          = 1
+  memory_size_mib      = 186
+  guest_customization_cloud_init_user_data = base64encode("#cloud-config\nfqdn: test.domain.local")
 }
 `, r)
 }


### PR DESCRIPTION
One of my clients requested the possibility to search clusters by name via the data sources. This code adds this functionality to the existing data_source_nutanix_cluster.go file.

Acceptance test included.