### PR TITLE
fix issue #126

### DIFF
--- a/nutanix/data_source_nutanix_network_security_rule.go
+++ b/nutanix/data_source_nutanix_network_security_rule.go
@@ -132,11 +132,11 @@ func dataSourceNutanixNetworkSecurityRule() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"end_port": {
-										Type:     schema.TypeString,
+										Type:     schema.TypeInt,
 										Computed: true,
 									},
 									"start_port": {
-										Type:     schema.TypeString,
+										Type:     schema.TypeInt,
 										Computed: true,
 									},
 								},
@@ -152,7 +152,7 @@ func dataSourceNutanixNetworkSecurityRule() *schema.Resource {
 										Computed: true,
 									},
 									"start_port": {
-										Type:     schema.TypeString,
+										Type:     schema.TypeInt,
 										Computed: true,
 									},
 								},
@@ -292,11 +292,11 @@ func dataSourceNutanixNetworkSecurityRule() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"end_port": {
-										Type:     schema.TypeString,
+										Type:     schema.TypeInt,
 										Computed: true,
 									},
 									"start_port": {
-										Type:     schema.TypeString,
+										Type:     schema.TypeInt,
 										Computed: true,
 									},
 								},
@@ -312,7 +312,7 @@ func dataSourceNutanixNetworkSecurityRule() *schema.Resource {
 										Computed: true,
 									},
 									"start_port": {
-										Type:     schema.TypeString,
+										Type:     schema.TypeInt,
 										Computed: true,
 									},
 								},
@@ -424,7 +424,7 @@ func dataSourceNutanixNetworkSecurityRule() *schema.Resource {
 										Computed: true,
 									},
 									"start_port": {
-										Type:     schema.TypeString,
+										Type:     schema.TypeInt,
 										Computed: true,
 									},
 								},
@@ -440,7 +440,7 @@ func dataSourceNutanixNetworkSecurityRule() *schema.Resource {
 										Computed: true,
 									},
 									"start_port": {
-										Type:     schema.TypeString,
+										Type:     schema.TypeInt,
 										Computed: true,
 									},
 								},
@@ -579,11 +579,11 @@ func dataSourceNutanixNetworkSecurityRule() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"end_port": {
-										Type:     schema.TypeString,
+										Type:     schema.TypeInt,
 										Computed: true,
 									},
 									"start_port": {
-										Type:     schema.TypeString,
+										Type:     schema.TypeInt,
 										Computed: true,
 									},
 								},
@@ -599,7 +599,7 @@ func dataSourceNutanixNetworkSecurityRule() *schema.Resource {
 										Computed: true,
 									},
 									"start_port": {
-										Type:     schema.TypeString,
+										Type:     schema.TypeInt,
 										Computed: true,
 									},
 								},

--- a/nutanix/data_source_nutanix_network_security_rule_test.go
+++ b/nutanix/data_source_nutanix_network_security_rule_test.go
@@ -56,6 +56,31 @@ func TestAccNutanixNetworkSecurityRuleDataSource_isolation(t *testing.T) {
 	})
 }
 
+func TestAccNutanixNetworkSecurityRuleDataSource_advanced(t *testing.T) {
+	// Skipped because this test didn't pass in GCP environment
+	if isGCPEnvironment() {
+		t.Skip()
+	}
+
+	r := acctest.RandIntRange(0, 500)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSecurityRuleDataSourceAdvancedConfig(r),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.nutanix_network_security_rule.test", "name", fmt.Sprintf("RULE-1-TIERS-%d", r)),
+					resource.TestCheckResourceAttr(
+						"data.nutanix_network_security_rule.test", "app_rule_action", "MONITOR"),
+				),
+			},
+		},
+	})
+}
+
 func testAccNetworkSecurityRuleDataSourceConfigIsolation(r int) string {
 	return fmt.Sprintf(`
       %s
@@ -162,6 +187,121 @@ resource "nutanix_network_security_rule" "TEST-TIER" {
     filter_params {
       name   = "${nutanix_category_key.test-category-key.id}"
       values = ["${nutanix_category_value.DB.id}"]
+    }
+  }
+}
+
+data "nutanix_network_security_rule" "test" {
+	network_security_rule_id = "${nutanix_network_security_rule.TEST-TIER.id}"
+}
+`, r)
+}
+
+func testAccNetworkSecurityRuleDataSourceAdvancedConfig(r int) string {
+	return fmt.Sprintf(`
+data "nutanix_category_key" "AppType" {
+  name = "AppType"
+}
+
+resource "nutanix_category_value" "DB" {
+  name        = data.nutanix_category_key.AppType.id
+  description = "Test Category Value"
+  value       = "DB-1"
+}
+
+resource "nutanix_category_key" "test-category-key" {
+  name        = "TIER-1"
+  description = "TIER Category Key"
+}
+
+resource "nutanix_category_value" "APP-1" {
+  name        = "${nutanix_category_key.test-category-key.id}"
+  description = "APP Category Value"
+  value       = "APP-1"
+}
+
+resource "nutanix_category_value" "APP-2" {
+  name        = "${nutanix_category_key.test-category-key.id}"
+  description = "APP Category Value"
+  value       = "APP-2"
+}
+
+resource "nutanix_network_security_rule" "TEST-TIER" {
+  name            = "RULE-1-TIERS-%d"
+  description     = "tf-test-ports"
+  app_rule_action = "MONITOR"
+
+  app_rule_inbound_allow_list {
+    ip_subnet               = "0.0.0.0"
+    ip_subnet_prefix_length = "0"
+    peer_specification_type = "IP_SUBNET"
+    protocol                = "TCP"
+    tcp_port_range_list {
+      end_port   = 80
+      start_port = 80
+    }
+    tcp_port_range_list {
+      end_port   = 443
+      start_port = 443
+    }
+  }
+  app_rule_inbound_allow_list {
+    filter_type = "CATEGORIES_MATCH_ALL"
+    filter_params {
+      name = nutanix_category_key.test-category-key.id
+      values = [
+        nutanix_category_value.APP-1.id
+      ]
+    }
+    filter_kind_list        = ["vm"]
+    peer_specification_type = "FILTER"
+    protocol                = "TCP"
+    tcp_port_range_list {
+      end_port   = 22
+      start_port = 22
+    }
+  }
+  app_rule_inbound_allow_list {
+    filter_type = "CATEGORIES_MATCH_ALL"
+    filter_params {
+      name = nutanix_category_key.test-category-key.id
+      values = [
+        nutanix_category_value.APP-2.id
+      ]
+    }
+
+    filter_kind_list        = ["vm"]
+    peer_specification_type = "FILTER"
+    protocol                = "ICMP"
+  }
+
+  app_rule_target_group_default_internal_policy = "ALLOW_ALL"
+  app_rule_target_group_filter_kind_list = [
+    "vm"
+  ]
+  app_rule_target_group_filter_params {
+    name = nutanix_category_key.test-category-key.id
+    values = [
+      nutanix_category_value.APP-1.id
+    ]
+  }
+  app_rule_target_group_filter_params {
+    name = data.nutanix_category_key.AppType.id
+    values = [
+      nutanix_category_value.DB.id
+    ]
+  }
+  app_rule_target_group_filter_type             = "CATEGORIES_MATCH_ALL"
+  app_rule_target_group_peer_specification_type = "FILTER"
+
+  app_rule_outbound_allow_list {
+    ip_subnet               = "10.0.0.0"
+    ip_subnet_prefix_length = "24"
+    peer_specification_type = "IP_SUBNET"
+    protocol                = "UDP"
+    udp_port_range_list {
+      end_port   = 53
+      start_port = 53
     }
   }
 }

--- a/nutanix/resource_nutanix_network_security_rule.go
+++ b/nutanix/resource_nutanix_network_security_rule.go
@@ -543,6 +543,7 @@ func resourceNutanixNetworkSecurityRuleRead(d *schema.ResourceData, meta interfa
 	if errNet != nil {
 		if strings.Contains(fmt.Sprint(errNet), "ENTITY_NOT_FOUND") {
 			d.SetId("")
+			return nil
 		}
 		return errNet
 	}
@@ -840,7 +841,7 @@ func getNetworkSecurityRuleResources(d *schema.ResourceData, networkSecurityRule
 			}
 
 			if ippl, ipok := nr["ip_subnet_prefix_length"]; ipok && ippl.(string) != "" {
-				if i, err := strconv.Atoi(ippl.(string)); err != nil {
+				if i, err := strconv.Atoi(ippl.(string)); err == nil {
 					iPSubnet.PrefixLength = utils.Int64Ptr(int64(i))
 				}
 			}
@@ -853,11 +854,11 @@ func getNetworkSecurityRuleResources(d *schema.ResourceData, networkSecurityRule
 				nrItem.UDPPortRangeList = expandPortRangeList(u)
 			}
 
-			if f, fok := nr["filter_kind_list"]; fok {
+			if f, fok := nr["filter_kind_list"]; fok && len(f.([]interface{})) > 0 {
 				filter.KindList = expandStringList(f.([]interface{}))
 			}
 
-			if ft, ftok := nr["filter_type"]; ftok {
+			if ft, ftok := nr["filter_type"]; ftok && ft != "" {
 				filter.Type = utils.StringPtr(ft.(string))
 			}
 
@@ -903,7 +904,9 @@ func getNetworkSecurityRuleResources(d *schema.ResourceData, networkSecurityRule
 			}
 
 			nrItem.IPSubnet = iPSubnet
-			nrItem.Filter = filter
+			if !reflect.DeepEqual(*filter, v3.CategoryFilter{}) {
+				nrItem.Filter = filter
+			}
 			outbound[k] = nrItem
 		}
 		appRule.OutboundAllowList = outbound
@@ -968,7 +971,7 @@ func getNetworkSecurityRuleResources(d *schema.ResourceData, networkSecurityRule
 			}
 
 			if ippl, ipok := nr["ip_subnet_prefix_length"]; ipok && ippl.(string) != "" {
-				if i, err := strconv.Atoi(ippl.(string)); err != nil {
+				if i, err := strconv.Atoi(ippl.(string)); err == nil {
 					iPSubnet.PrefixLength = utils.Int64Ptr(int64(i))
 				}
 			}
@@ -981,11 +984,11 @@ func getNetworkSecurityRuleResources(d *schema.ResourceData, networkSecurityRule
 				nrItem.UDPPortRangeList = expandPortRangeList(u)
 			}
 
-			if f, fok := nr["filter_kind_list"]; fok {
+			if f, fok := nr["filter_kind_list"]; fok && len(f.([]interface{})) > 0 {
 				filter.KindList = expandStringList(f.([]interface{}))
 			}
 
-			if ft, ftok := nr["filter_type"]; ftok {
+			if ft, ftok := nr["filter_type"]; ftok && ft != "" {
 				filter.Type = utils.StringPtr(ft.(string))
 			}
 
@@ -1031,7 +1034,9 @@ func getNetworkSecurityRuleResources(d *schema.ResourceData, networkSecurityRule
 			}
 
 			nrItem.IPSubnet = iPSubnet
-			nrItem.Filter = filter
+			if !reflect.DeepEqual(*filter, v3.CategoryFilter{}) {
+				nrItem.Filter = filter
+			}
 			inbound[k] = nrItem
 		}
 		appRule.InboundAllowList = inbound


### PR DESCRIPTION
Fix #126 

Fixed: 
  - Security rules idempotency error: Error was thrown when security rule was delete via Prism and running a new Terraform run afterwards
 - Bug where it was not possible to add security rules that contained ports 