### PR TITLE
Fix for #128 Changed parameter for subnet filter

### DIFF
--- a/nutanix/data_source_nutanix_subnet.go
+++ b/nutanix/data_source_nutanix_subnet.go
@@ -284,7 +284,7 @@ func findSubnetByUUID(conn *v3.Client, uuid string) (*v3.SubnetIntentResponse, e
 }
 
 func findSubnetByName(conn *v3.Client, name string) (*v3.SubnetIntentResponse, error) {
-	filter := fmt.Sprintf("subnet_name==%s", name)
+	filter := fmt.Sprintf("name==%s", name)
 	resp, err := conn.V3.ListAllSubnet(filter)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
fix #128 

The filter for subnets was incorrect. Filtering on name is not via `subnet_name` but `name`.