### PR TITLE
fix #112: Improve error handling on incorrect API calls

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -232,7 +232,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) error
 
 // CheckResponse checks errors if exist errors in request
 func CheckResponse(r *http.Response) error {
-	if c := r.StatusCode; c >= 200 && c <= 299 && r.Request.Method == http.MethodDelete {
+	if c := r.StatusCode; c >= 200 && c <= 299 {
 		return nil
 	}
 


### PR DESCRIPTION
Validation for Delete Method used as a filter for all the server responses was removed, allowing us to pass all the responses with code 200 despite if they contain any internal error so it now allows us to remove resources in TF when they crash.


Let me know if you have a comment or concern, thanks

closes #112 #83 