### PR TITLE
Added new parameter for VM use_hot_add

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cast v1.3.1
 	golang.org/x/sys v0.0.0-20190927073244-c990c680b611 // indirect
+	golang.org/x/tools v0.0.0-20200530233709-52effbd89c51 // indirect
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -736,6 +736,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200102140908-9497f49d5709/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200422022333-3d57cf2e726e h1:3Dzrrxi54Io7Aoyb0PYLsI47K2TxkRQg+cqUn+m04do=
 golang.org/x/tools v0.0.0-20200422022333-3d57cf2e726e/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200530233709-52effbd89c51 h1:Wec8/IO8hAraBf0it7/dPQYOslIrgM938wZYNkLnOYc=
+golang.org/x/tools v0.0.0-20200530233709-52effbd89c51/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/nutanix/resource_nutanix_virtual_machine_test.go
+++ b/nutanix/resource_nutanix_virtual_machine_test.go
@@ -2,7 +2,6 @@ package nutanix
 
 import (
 	"fmt"
-	"github.com/spf13/cast"
 	"strings"
 	"testing"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/spf13/cast"
 )
 
 func TestAccNutanixVirtualMachine_basic(t *testing.T) {

--- a/nutanix/resource_nutanix_virtual_machine_test.go
+++ b/nutanix/resource_nutanix_virtual_machine_test.go
@@ -2,6 +2,7 @@ package nutanix
 
 import (
 	"fmt"
+	"github.com/spf13/cast"
 	"strings"
 	"testing"
 	"time"
@@ -82,6 +83,58 @@ func TestAccNutanixVirtualMachine_WithDisk(t *testing.T) {
 				ImportStateVerify: true,
 			},
 		}})
+}
+
+func TestAccNutanixVirtualMachine_hotadd(t *testing.T) {
+	vmName := acctest.RandomWithPrefix("test-dou-vm")
+	cpus := 1
+	sockets := 1
+	memory := 1024
+	hotAdd := true
+	imageName := acctest.RandomWithPrefix("test-dou-image")
+
+	vmNameUpdated := acctest.RandomWithPrefix("test-dou-vm")
+	cpusUpdated := 2
+	socketsUpdated := 2
+	memoryUpdated := 2048
+	hotAddUpdated := false // To force a reboot
+	resourceName := "nutanix_virtual_machine.vm10"
+	imageNameUpdate := acctest.RandomWithPrefix("test-dou-image")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNutanixVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNutanixVMConfigHotAdd(vmName, cpus, sockets, memory, hotAdd, imageName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNutanixVirtualMachineExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "hardware_clock_timezone", "UTC"),
+					resource.TestCheckResourceAttr(resourceName, "power_state", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "memory_size_mib", cast.ToString(memory)),
+					resource.TestCheckResourceAttr(resourceName, "num_sockets", cast.ToString(sockets)),
+					resource.TestCheckResourceAttr(resourceName, "num_vcpus_per_socket", cast.ToString(cpus)),
+					resource.TestCheckResourceAttr(resourceName, "use_hot_add", cast.ToString(hotAdd)),
+				),
+			},
+			{
+				Config: testAccNutanixVMConfigHotAdd(vmNameUpdated, cpusUpdated, socketsUpdated, memoryUpdated, hotAddUpdated, imageNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "hardware_clock_timezone", "UTC"),
+					resource.TestCheckResourceAttr(resourceName, "power_state", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "memory_size_mib", cast.ToString(memoryUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "num_sockets", cast.ToString(socketsUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "num_vcpus_per_socket", cast.ToString(cpusUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "use_hot_add", cast.ToString(hotAddUpdated))),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"disk_list"},
+			},
+		},
+	})
 }
 
 func TestAccNutanixVirtualMachine_updateFields(t *testing.T) {
@@ -829,4 +882,48 @@ func testAccNutanixVMConfigCloningVM(r int) string {
 			}
 		}
 	`, r)
+}
+
+func testAccNutanixVMConfigHotAdd(vmName string, cpus, sockets, memory int, hotAdd bool, imageName string) string {
+	return fmt.Sprintf(`
+		data "nutanix_clusters" "clusters" {}
+
+		locals {
+			cluster1 = [
+				for cluster in data.nutanix_clusters.clusters.entities :
+				cluster.metadata.uuid if cluster.service_list[0] != "PRISM_CENTRAL"
+			][0]
+		}
+
+		resource "nutanix_image" "cirros-034-disk" {
+			name        = "%[6]s"
+			source_uri  = "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
+			description = "heres a tiny linux image, not an iso, but a real disk!"
+		}
+
+		resource "nutanix_virtual_machine" "vm10" {
+			name         = "%[1]s"
+			cluster_uuid = "${local.cluster1}"
+			num_vcpus_per_socket  = %[2]d
+			num_sockets           = %[3]d
+			memory_size_mib       = %[4]d
+			power_state_mechanism = "ACPI"
+			use_hot_add           = %[5]v
+
+			disk_list {
+				data_source_reference = {
+					kind = "image"
+					uuid = nutanix_image.cirros-034-disk.id
+				}
+
+				device_properties {
+					disk_address = {
+						device_index = 0
+						adapter_type = "SCSI"
+					}
+					device_type = "DISK"
+				}
+			}
+		}
+	`, vmName, cpus, sockets, memory, hotAdd, imageName)
 }

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -70,6 +70,7 @@ The following arguments are supported:
 * `power_state_mechanism`: - (Optional) Indicates the mechanism guiding the VM power state transition. Currently used for the transition to \"OFF\" state. Power state mechanism (ACPI/GUEST/HARD).
 * `vga_console_enabled`: - (Optional) Indicates whether VGA console should be enabled or not.
 * `disk_list` Disks attached to the VM.
+* `use_hot_add`: - (Optional) Use Hot Add when modifying VM resources. Passing value false will result in VM reboots. Default value is `true`.
 
 ### Disk List
 


### PR DESCRIPTION
Fix/enhancement for #86 and #79 

Added a new parameter called `use_hot_Add` in VM, for now it only applies when there a change for `num_vcpus_per_socket` or `memory_size_mib`, if it's specified as false, is going to force a reboot where there's change for `num_vcpus_per_socket` or `memory_size_mib` otherwise not reboot.