### PR TITLE
Fix #78: Cannot specify target container when adding disks to a virtual machine resource

### DIFF
--- a/client/v3/v3_structs.go
+++ b/client/v3/v3_structs.go
@@ -195,6 +195,20 @@ type VMDiskDeviceProperties struct {
 	DiskAddress *DiskAddress `json:"disk_address,omitempty" mapstructure:"disk_address,omitempty"`
 }
 
+// StorageContainerReference references to a kind. Either one of (kind, uuid) or url needs to be specified.
+type StorageContainerReference struct {
+	URL  string `json:"url,omitempty"`
+	Kind string `json:"kind,omitempty"`
+	UUID string `json:"uuid,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// VMStorageConfig specifies the storage configuration parameters for VM disks.
+type VMStorageConfig struct {
+	FlashMode                 string                     `json:"flash_mode,omitempty"`
+	StorageContainerReference *StorageContainerReference `json:"storage_container_reference,omitempty"`
+}
+
 // VMDisk VirtualMachine Disk (VM Disk).
 type VMDisk struct {
 	DataSourceReference *Reference `json:"data_source_reference,omitempty" mapstructure:"data_source_reference,omitempty"`
@@ -212,6 +226,9 @@ type VMDisk struct {
 	UUID *string `json:"uuid,omitempty" mapstructure:"uuid,omitempty"`
 
 	VolumeGroupReference *Reference `json:"volume_group_reference,omitempty" mapstructure:"volume_group_reference,omitempty"`
+
+	// This preference specifies the storage configuration parameters for VM disks.
+	StorageConfig *VMStorageConfig `json:"storage_config,omitempty" mapstructure:"storage_config,omitempty"`
 }
 
 // VMResources VM Resources Definition.

--- a/nutanix/data_source_nutanix_virtual_machine.go
+++ b/nutanix/data_source_nutanix_virtual_machine.go
@@ -522,6 +522,43 @@ func dataSourceNutanixVirtualMachine() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"storage_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"flash_mode": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"storage_container_reference": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"url": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"kind": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"uuid": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 						"device_properties": {
 							Type:     schema.TypeList,
 							Computed: true,
@@ -570,7 +607,6 @@ func dataSourceNutanixVirtualMachine() *schema.Resource {
 								},
 							},
 						},
-
 						"volume_group_reference": {
 							Type:     schema.TypeMap,
 							Computed: true,
@@ -665,6 +701,9 @@ func dataSourceNutanixVirtualMachineRead(d *schema.ResourceData, meta interface{
 	if err := d.Set("parent_reference", flattenReferenceValues(resp.Status.Resources.ParentReference)); err != nil {
 		return err
 	}
+	if err := d.Set("disk_list", flattenDiskList(resp.Status.Resources.DiskList)); err != nil {
+		return err
+	}
 
 	diskAddress := make(map[string]interface{})
 	mac := ""
@@ -753,7 +792,7 @@ func dataSourceNutanixVirtualMachineRead(d *schema.ResourceData, meta interface{
 	d.Set("vga_console_enabled", utils.BoolValue(resp.Status.Resources.VgaConsoleEnabled))
 	d.SetId(utils.StringValue(resp.Metadata.UUID))
 
-	return d.Set("disk_list", setDiskList(resp.Status.Resources.DiskList, resp.Status.Resources.GuestCustomization))
+	return nil
 }
 
 func resourceDatasourceVirtualMachineInstanceStateUpgradeV0(is map[string]interface{}, meta interface{}) (map[string]interface{}, error) {

--- a/nutanix/data_source_nutanix_virtual_machine_test.go
+++ b/nutanix/data_source_nutanix_virtual_machine_test.go
@@ -44,6 +44,70 @@ func TestAccNutanixVirtualMachineDataSource_WithDisk(t *testing.T) {
 	})
 }
 
+func TestAccNutanixVirtualMachineDataSource_withDiskContainer(t *testing.T) {
+	datasourceName := "data.nutanix_virtual_machine.nutanix_virtual_machine"
+	vmName := acctest.RandomWithPrefix("test-dou-vm")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVMDataSourceWithDiskContainer(vmName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceName, "vm_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "disk_list.#"),
+					resource.TestCheckResourceAttrSet(datasourceName, "disk_list.0.disk_size_bytes"),
+					resource.TestCheckResourceAttrSet(datasourceName, "disk_list.0.disk_size_mib"),
+					resource.TestCheckResourceAttrSet(datasourceName, "disk_list.0.storage_config.#"),
+					resource.TestCheckResourceAttrSet(datasourceName, "disk_list.0.storage_config.0.storage_container_reference.#"),
+					resource.TestCheckResourceAttrSet(datasourceName, "disk_list.0.storage_config.0.storage_container_reference.0.kind"),
+					resource.TestCheckResourceAttrSet(datasourceName, "disk_list.0.storage_config.0.storage_container_reference.0.uuid"),
+					resource.TestCheckResourceAttrSet(datasourceName, "disk_list.0.storage_config.0.storage_container_reference.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVMDataSourceWithDiskContainer(vmName string) string {
+	return fmt.Sprintf(`
+		data "nutanix_clusters" "clusters" {}
+
+		locals {
+			cluster1 = [
+				for cluster in data.nutanix_clusters.clusters.entities :
+				cluster.metadata.uuid if cluster.service_list[0] != "PRISM_CENTRAL"
+			][0]
+		}
+
+		resource "nutanix_virtual_machine" "vm-disk" {
+			name                 = "%s"
+			cluster_uuid         = local.cluster1
+			num_vcpus_per_socket = 1
+			num_sockets          = 1
+			memory_size_mib      = 186
+
+			disk_list {
+				# disk_size_mib = 300
+				disk_size_bytes = 68157440
+				disk_size_mib   = 65
+
+				storage_config {
+					storage_container_reference {
+						kind = "storage_container"
+						uuid = "2bbe77bc-fd14-4697-8de1-6369757f9219"
+					}
+				}
+			}
+		}
+
+		data "nutanix_virtual_machine" "nutanix_virtual_machine" {
+			vm_id = nutanix_virtual_machine.vm-disk.id
+		}
+	`, vmName)
+}
+
 func testAccVMDataSourceConfig(r int) string {
 	return fmt.Sprintf(`
 data "nutanix_clusters" "clusters" {}
@@ -72,25 +136,25 @@ data "nutanix_virtual_machine" "nutanix_virtual_machine" {
 func testAccVMDataSourceConfigWithDisk(r int) string {
 	return fmt.Sprintf(`
 	data "nutanix_clusters" "clusters" {}
-	
+
 	locals {
 			cluster1 = "${data.nutanix_clusters.clusters.entities.0.service_list.0 == "PRISM_CENTRAL"
 			? data.nutanix_clusters.clusters.entities.1.metadata.uuid : data.nutanix_clusters.clusters.entities.0.metadata.uuid}"
 	}
-	
+
 	resource "nutanix_image" "cirros-034-disk" {
 		name        = "test-image-dou-vm-create-%[1]d"
 		source_uri  = "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
 		description = "heres a tiny linux image, not an iso, but a real disk!"
 	}
-	
+
 	resource "nutanix_virtual_machine" "vm1" {
 	  name = "test-dou-vm-%[1]d"
 	  cluster_uuid = "${local.cluster1}"
 	  num_vcpus_per_socket = 1
 	  num_sockets          = 1
 	  memory_size_mib      = 186
-	
+
 		disk_list {
 			data_source_reference = {
 				kind = "image"

--- a/website/docs/d/virtual_machine.html.markdown
+++ b/website/docs/d/virtual_machine.html.markdown
@@ -109,6 +109,18 @@ The device_properties attribute supports the following.
 * `device_type`: - A Disk type (default: DISK).
 * `disk_address`: - Address of disk to boot from.
 
+### Storage Config
+User inputs of storage configuration parameters for VMs.
+
+* `flash_mode`: - State of the storage policy to pin virtual disks to the hot tier. When specified as a VM attribute, the storage policy applies to all virtual disks of the VM unless overridden by the same attribute specified for a virtual disk.
+
+* `storage_container_reference`: - Reference to a kind. Either one of (kind, uuid) or url needs to be specified.
+* `storage_container_reference.#.url`: - GET query on the URL will provide information on the source.
+* `storage_container_reference.#.kind`: - kind of the container reference
+* `storage_container_reference.#.name`: - name of the container reference
+* `storage_container_reference.#.uuid`: - uiid of the container reference
+
+
 ### Sysprep
 
 The guest_customization_sysprep attribute supports the following:

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -31,6 +31,31 @@ resource "nutanix_virtual_machine" "vm1" {
 }
 ```
 
+## Example Usage with storage config
+```hcl
+data "nutanix_clusters" "clusters" {}
+
+resource "nutanix_virtual_machine" "vm" {
+  name                 = "myVm"
+  cluster_uuid         = data.nutanix_clusters.clusters.entities.0.metadata.uuid
+  num_vcpus_per_socket = 1
+  num_sockets          = 1
+  memory_size_mib      = 186
+
+  disk_list {
+    disk_size_bytes = 68157440
+    disk_size_mib   = 65
+
+    storage_config {
+      storage_container_reference {
+        kind = "storage_container"
+        uuid = "2bbe67bc-fd14-4637-8de1-6379257f4219"
+      }
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -91,6 +116,17 @@ The device_properties attribute supports the following.
 
 * `device_type`: - A Disk type (default: DISK).
 * `disk_address`: - Address of disk to boot from.
+
+### Storage Config
+User inputs of storage configuration parameters for VMs.
+
+* `flash_mode`: - State of the storage policy to pin virtual disks to the hot tier. When specified as a VM attribute, the storage policy applies to all virtual disks of the VM unless overridden by the same attribute specified for a virtual disk.
+
+* `storage_container_reference`: - Reference to a kind. Either one of (kind, uuid) or url needs to be specified.
+* `storage_container_reference.#.url`: - GET query on the URL will provide information on the source.
+* `storage_container_reference.#.kind`: - kind of the container reference
+* `storage_container_reference.#.name`: - name of the container reference
+* `storage_container_reference.#.uuid`: - uiid of the container reference
 
 ### Sysprep
 


### PR DESCRIPTION
The `storage_conntainer` was added as a new attribute into the `disk_list` to reference a container in a VM.

Added:
- The attribute was added to the client to be part of the request to create the corresponding configuration.
- It also was added to the resource and data source.
- Test cases were created for resource and data source to validate it.
- Documentation for resource and data source was added.

### Example Usage
```hcl
data "nutanix_clusters" "clusters" {}

resource "nutanix_virtual_machine" "vm" {
  name                 = "myVm"
  cluster_uuid         = data.nutanix_clusters.clusters.entities.0.metadata.uuid
  num_vcpus_per_socket = 1
  num_sockets          = 1
  memory_size_mib      = 186

  disk_list {
    disk_size_bytes = 68157440
    disk_size_mib   = 65

    storage_config {
      storage_container_reference {
        kind = "storage_container"
        uuid = "2bbe67bc-fd14-4637-8de1-6379257f4219"
      }
    }
  }
}
```

closes #78 