### PR TITLE
provide better error reporting when invalid nutanix credentials are used

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -236,7 +236,7 @@ func CheckResponse(r *http.Response) error {
 		return nil
 	}
 	
-  // Nutanix returns non-json response with code 401 when
+        // Nutanix returns non-json response with code 401 when
 	// invalid credentials are used
 	if c == 401 {
 		return fmt.Errorf("Invalid Nutanix Credentials")

--- a/client/client.go
+++ b/client/client.go
@@ -235,6 +235,12 @@ func CheckResponse(r *http.Response) error {
 	if c := r.StatusCode; c >= 200 && c <= 299 {
 		return nil
 	}
+	
+  // Nutanix returns non-json response with code 401 when
+	// invalid credentials are used
+	if c == 401 {
+		return fmt.Errorf("Invalid Nutanix Credentials")
+	}
 
 	buf, err := ioutil.ReadAll(r.Body)
 

--- a/client/client.go
+++ b/client/client.go
@@ -236,7 +236,7 @@ func CheckResponse(r *http.Response) error {
 		return nil
 	}
 	
-        // Nutanix returns non-json response with code 401 when
+	// Nutanix returns non-json response with code 401 when
 	// invalid credentials are used
 	if c == 401 {
 		return fmt.Errorf("Invalid Nutanix Credentials")


### PR DESCRIPTION
Related: #44 

Nutanix returns a non-json response with code 401 when invalid credentials are provided. Instead of printing the rather obscure message 

`cannot unmarshal string into GO struct field MessageResource.details of the type map [string]interface{}`

we will now print 

`Invalid Nutanix Credentials`