### PR TITLE
Set default value of disk_list.device_properties.device_type to DISK

### DIFF
--- a/nutanix/resource_nutanix_virtual_machine.go
+++ b/nutanix/resource_nutanix_virtual_machine.go
@@ -569,7 +569,7 @@ func resourceNutanixVirtualMachine() *schema.Resource {
 									"device_type": {
 										Type:     schema.TypeString,
 										Optional: true,
-										Computed: true,
+										Default:  "DISK",
 									},
 									"disk_address": {
 										Type:     schema.TypeMap,


### PR DESCRIPTION
Set the default value of device_type to DISK as mentioned in the documentation.
I also think this is generally practical.