### PR TITLE
Fix issue #168, unchecked nil assignment

### DIFF
--- a/nutanix/data_source_nutanix_virtual_machine.go
+++ b/nutanix/data_source_nutanix_virtual_machine.go
@@ -710,15 +710,17 @@ func dataSourceNutanixVirtualMachineRead(d *schema.ResourceData, meta interface{
 	b := make([]string, 0)
 
 	if resp.Status.Resources.BootConfig != nil {
-		if resp.Status.Resources.BootConfig.BootDevice.DiskAddress != nil {
-			i := strconv.Itoa(int(utils.Int64Value(resp.Status.Resources.BootConfig.BootDevice.DiskAddress.DeviceIndex)))
-			diskAddress["device_index"] = i
-			diskAddress["adapter_type"] = utils.StringValue(resp.Status.Resources.BootConfig.BootDevice.DiskAddress.AdapterType)
+		if resp.Status.Resources.BootConfig.BootDevice != nil {
+			if resp.Status.Resources.BootConfig.BootDevice.DiskAddress != nil {
+				i := strconv.Itoa(int(utils.Int64Value(resp.Status.Resources.BootConfig.BootDevice.DiskAddress.DeviceIndex)))
+				diskAddress["device_index"] = i
+				diskAddress["adapter_type"] = utils.StringValue(resp.Status.Resources.BootConfig.BootDevice.DiskAddress.AdapterType)
+			}
+			mac = utils.StringValue(resp.Status.Resources.BootConfig.BootDevice.MacAddress)
 		}
 		if resp.Status.Resources.BootConfig.BootDeviceOrderList != nil {
 			b = utils.StringValueSlice(resp.Status.Resources.BootConfig.BootDeviceOrderList)
 		}
-		mac = utils.StringValue(resp.Status.Resources.BootConfig.BootDevice.MacAddress)
 	}
 
 	d.Set("boot_device_order_list", b)


### PR DESCRIPTION
Fix: #168 

Unchecked nil assignment.
Caused when VM has following boot config:
```
"boot_config": {
    "boot_device_order_list": [
        "CDROM",
        "DISK",
        "NETWORK"
    ],
    "boot_type": "LEGACY"
},
```
instead of 
```
"boot_config": {
    "boot_device": {
        "disk_address": {
            "device_index": 0,
            "adapter_type": "SCSI"
        }
    },
    "boot_type": "LEGACY"
},
```