### PR TITLE
adding a VM to a project does not require a reboot

### DIFF
--- a/nutanix/resource_nutanix_virtual_machine.go
+++ b/nutanix/resource_nutanix_virtual_machine.go
@@ -1141,7 +1141,6 @@ func resourceNutanixVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 	if d.HasChange("project_reference") {
 		_, n := d.GetChange("project_reference")
 		metadata.ProjectReference = validateRef(n.(map[string]interface{}))
-		hotPlugChange = false
 	}
 
 	spec.Name = response.Status.Name


### PR DESCRIPTION
closes #233
 
When a VM is added to a project, it does not require a reboot. Removed hotplugChange in update code.
