### PR TITLE
#250 Set VM timeouts to highest previous values

### DIFF
--- a/nutanix/resource_nutanix_virtual_machine.go
+++ b/nutanix/resource_nutanix_virtual_machine.go
@@ -19,8 +19,8 @@ import (
 )
 
 var (
-	vmTimeout    = 1 * time.Minute
-	vmDelay      = 3 * time.Second
+	vmTimeout    = 10 * time.Minute
+	vmDelay      = 10 * time.Second
 	vmMinTimeout = 3 * time.Second
 	IDE          = "IDE"
 	useHotAdd    = true


### PR DESCRIPTION
Fixes #250 

This fixes the changes made here https://github.com/nutanix/terraform-provider-nutanix/pull/101/files#diff-442dc1a751160770b485d4d51e3cb4a68444104cf8f736b01adc3c0f01f55029. Uses the highest timeout values from that.