### PR TITLE
fix: power_state_mechanism hot plug

### DIFF
--- a/nutanix/resource_nutanix_virtual_machine.go
+++ b/nutanix/resource_nutanix_virtual_machine.go
@@ -1230,7 +1230,6 @@ func resourceNutanixVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 	if d.HasChange("power_state_mechanism") {
 		_, n := d.GetChange("power_state_mechanism")
 		pw.Mechanism = utils.StringPtr(n.(string))
-		hotPlugChange = false
 	}
 	if d.HasChange("power_state_guest_transition_config") {
 		_, n := d.GetChange("power_state_guest_transition_config")


### PR DESCRIPTION
Is there a reason why a machine needs to reboot when the `power_state_mechanism` changes?

This change disables the reboot on update.