### PR TITLE
Add support for CPU passthrough

### DIFF
--- a/client/v3/v3_structs.go
+++ b/client/v3/v3_structs.go
@@ -283,6 +283,9 @@ type VMResources struct {
 	// Indicates whether VGA console should be enabled or not.
 	VgaConsoleEnabled *bool `json:"vga_console_enabled,omitempty" mapstructure:"vga_console_enabled,omitempty"`
 
+	// Indicates whether to passthrough the host’s CPU features to the guest. Enabling this will disable live migration of the VM.
+	EnableCPUPassthrough *bool `json:"enable_cpu_passthrough,omitempty" mapstructure:"enable_cpu_passthrough,omitempty"`
+
 	// Information regarding vNUMA configuration.
 	VMVnumaConfig *VMVnumaConfig `json:"vnuma_config,omitempty" mapstructure:"vnuma_config,omitempty"`
 
@@ -509,6 +512,9 @@ type VMResourcesDefStatus struct {
 
 	// Indicates whether VGA console has been enabled or not.
 	VgaConsoleEnabled *bool `json:"vga_console_enabled,omitempty" mapstructure:"vga_console_enabled,omitempty"`
+
+	// Indicates whether to passthrough the host’s CPU features to the guest. Enabling this will disable live migration of the VM.
+	EnableCPUPassthrough *bool `json:"enable_cpu_passthrough,omitempty" mapstructure:"enable_cpu_passthrough,omitempty"`
 
 	// Information regarding vNUMA configuration.
 	VnumaConfig *VMVnumaConfig `json:"vnuma_config,omitempty" mapstructure:"vnuma_config,omitempty"`

--- a/nutanix/data_source_nutanix_virtual_machine.go
+++ b/nutanix/data_source_nutanix_virtual_machine.go
@@ -194,7 +194,10 @@ func dataSourceNutanixVirtualMachine() *schema.Resource {
 			},
 
 			// RESOURCES ARGUMENTS
-
+			"enable_cpu_passthrough": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"num_vnuma_nodes": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -798,6 +801,7 @@ func dataSourceNutanixVirtualMachineRead(d *schema.ResourceData, meta interface{
 	d.Set("name", utils.StringValue(resp.Status.Name))
 	d.Set("description", utils.StringValue(resp.Status.Description))
 	d.Set("state", utils.StringValue(resp.Status.State))
+	d.Set("enable_cpu_passthrough", utils.BoolValue(resp.Status.Resources.EnableCPUPassthrough))
 	d.Set("num_vnuma_nodes", utils.Int64Value(resp.Status.Resources.VnumaConfig.NumVnumaNodes))
 	d.Set("guest_os_id", utils.StringValue(resp.Status.Resources.GuestOsID))
 	d.Set("power_state", utils.StringValue(resp.Status.Resources.PowerState))
@@ -999,7 +1003,10 @@ func resourceNutanixDatasourceVirtualMachineInstanceResourceV0() *schema.Resourc
 			},
 
 			// RESOURCES ARGUMENTS
-
+			"enable_cpu_passthrough": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"num_vnuma_nodes": {
 				Type:     schema.TypeInt,
 				Computed: true,


### PR DESCRIPTION
Adds support to enable nested VMs using the `enable_cpu_passthrough` attribute.