### PR TITLE
Skipping state refresh for ngt credentials while reading nutanix_vm.

### DIFF
--- a/nutanix/resource_nutanix_virtual_machine.go
+++ b/nutanix/resource_nutanix_virtual_machine.go
@@ -2603,7 +2603,6 @@ func resourceNutanixVirtualMachineInstanceResourceV0() *schema.Resource {
 			"ngt_credentials": {
 				Type:     schema.TypeMap,
 				Optional: true,
-				Computed: true,
 			},
 			"ngt_enabled_capability_list": {
 				Type:     schema.TypeList,

--- a/nutanix/structure.go
+++ b/nutanix/structure.go
@@ -295,12 +295,10 @@ func flattenGPUList(gpu []*v3.VMGpuOutputStatus) []map[string]interface{} {
 
 func flattenNutanixGuestTools(d *schema.ResourceData, guest *v3.GuestToolsStatus) error {
 	nutanixGuestTools := make(map[string]interface{})
-	ngtCredentials := make(map[string]string)
 	ngtEnabledCapabilityList := make([]string, 0)
 
 	if guest != nil && guest.NutanixGuestTools != nil {
 		tools := guest.NutanixGuestTools
-		ngtCredentials = tools.Credentials
 		ngtEnabledCapabilityList = utils.StringValueSlice(tools.EnabledCapabilityList)
 
 		nutanixGuestTools["available_version"] = utils.StringValue(tools.AvailableVersion)
@@ -315,10 +313,6 @@ func flattenNutanixGuestTools(d *schema.ResourceData, guest *v3.GuestToolsStatus
 	}
 
 	if err := d.Set("ngt_enabled_capability_list", ngtEnabledCapabilityList); err != nil {
-		return err
-	}
-
-	if err := d.Set("ngt_credentials", ngtCredentials); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Behaviour: NGT Credentials were listed in plan as additions even after the operation was performed.

Reason: vms/uuid and vms/ API doesn't return NGT credentials as a part of nutanix guest customization. Due to which we were populating empty credentials in the state which caused the diff.