### PR TITLE
update go release to 1.17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
Update Golang version used by Go release to 1.17 mainly to unblock darwin/arm64 binary (fix #302) build and to get recent optimization
