### PR TITLE
Update path to github.com/nutanix/terraform-provider-nutanix

### DIFF
--- a/client/karbon/karbon_api.go
+++ b/client/karbon/karbon_api.go
@@ -1,7 +1,7 @@
 package karbon
 
 import (
-	"github.com/terraform-providers/terraform-provider-nutanix/client"
+	"github.com/nutanix/terraform-provider-nutanix/client"
 )
 
 const (

--- a/client/karbon/karbon_cluster_service.go
+++ b/client/karbon/karbon_cluster_service.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/terraform-providers/terraform-provider-nutanix/client"
+	"github.com/nutanix/terraform-provider-nutanix/client"
 )
 
 // ClusterOperations ...

--- a/client/karbon/karbon_meta_service.go
+++ b/client/karbon/karbon_meta_service.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/terraform-providers/terraform-provider-nutanix/client"
+	"github.com/nutanix/terraform-provider-nutanix/client"
 )
 
 // MetaOperations ...

--- a/client/karbon/karbon_private_registry_service.go
+++ b/client/karbon/karbon_private_registry_service.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/terraform-providers/terraform-provider-nutanix/client"
+	"github.com/nutanix/terraform-provider-nutanix/client"
 )
 
 // PrivateRegistryOperations ...

--- a/client/v3/v3.go
+++ b/client/v3/v3.go
@@ -1,7 +1,7 @@
 package v3
 
 import (
-	"github.com/terraform-providers/terraform-provider-nutanix/client"
+	"github.com/nutanix/terraform-provider-nutanix/client"
 )
 
 const (

--- a/client/v3/v3_service.go
+++ b/client/v3/v3_service.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/terraform-providers/terraform-provider-nutanix/client"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	"github.com/nutanix/terraform-provider-nutanix/client"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 // Operations ...

--- a/client/v3/v3_service_test.go
+++ b/client/v3/v3_service_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/terraform-providers/terraform-provider-nutanix/client"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	"github.com/nutanix/terraform-provider-nutanix/client"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func setup() (*http.ServeMux, *client.Client, *httptest.Server) {

--- a/client/v3/v3_test.go
+++ b/client/v3/v3_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-nutanix/client"
+	"github.com/nutanix/terraform-provider-nutanix/client"
 )
 
 func TestNewV3Client(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-nutanix
+module github.com/nutanix/terraform-provider-nutanix
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/nutanix/terraform-provider-nutanix/nutanix"
 )
 
 func main() {

--- a/nutanix/config.go
+++ b/nutanix/config.go
@@ -3,9 +3,9 @@ package nutanix
 import (
 	"fmt"
 
-	"github.com/terraform-providers/terraform-provider-nutanix/client"
-	"github.com/terraform-providers/terraform-provider-nutanix/client/karbon"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/client"
+	"github.com/nutanix/terraform-provider-nutanix/client/karbon"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
 )
 
 // Version represents api version

--- a/nutanix/data_source_nutanix_access_control_policies.go
+++ b/nutanix/data_source_nutanix_access_control_policies.go
@@ -3,8 +3,8 @@ package nutanix
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixAccessControlPolicies() *schema.Resource {

--- a/nutanix/data_source_nutanix_access_control_policy.go
+++ b/nutanix/data_source_nutanix_access_control_policy.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixAccessControlPolicy() *schema.Resource {

--- a/nutanix/data_source_nutanix_category_key.go
+++ b/nutanix/data_source_nutanix_category_key.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixCategoryKey() *schema.Resource {

--- a/nutanix/data_source_nutanix_cluster.go
+++ b/nutanix/data_source_nutanix_cluster.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixCluster() *schema.Resource {

--- a/nutanix/data_source_nutanix_clusters.go
+++ b/nutanix/data_source_nutanix_clusters.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixClusters() *schema.Resource {

--- a/nutanix/data_source_nutanix_host.go
+++ b/nutanix/data_source_nutanix_host.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cast"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
 )
 
 func dataSourceNutanixHost() *schema.Resource {

--- a/nutanix/data_source_nutanix_hosts.go
+++ b/nutanix/data_source_nutanix_hosts.go
@@ -3,7 +3,7 @@ package nutanix
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
 )
 
 func dataSourceNutanixHosts() *schema.Resource {

--- a/nutanix/data_source_nutanix_image.go
+++ b/nutanix/data_source_nutanix_image.go
@@ -5,8 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixImage() *schema.Resource {

--- a/nutanix/data_source_nutanix_karbon_cluster.go
+++ b/nutanix/data_source_nutanix_karbon_cluster.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-nutanix/client/karbon"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	"github.com/nutanix/terraform-provider-nutanix/client/karbon"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixKarbonCluster() *schema.Resource {

--- a/nutanix/data_source_nutanix_karbon_cluster_kubeconfig.go
+++ b/nutanix/data_source_nutanix_karbon_cluster_kubeconfig.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-nutanix/client/karbon"
+	"github.com/nutanix/terraform-provider-nutanix/client/karbon"
 	"gopkg.in/yaml.v2"
 )
 

--- a/nutanix/data_source_nutanix_karbon_cluster_ssh.go
+++ b/nutanix/data_source_nutanix_karbon_cluster_ssh.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-nutanix/client/karbon"
+	"github.com/nutanix/terraform-provider-nutanix/client/karbon"
 )
 
 func dataSourceNutanixKarbonClusterSSH() *schema.Resource {

--- a/nutanix/data_source_nutanix_karbon_clusters.go
+++ b/nutanix/data_source_nutanix_karbon_clusters.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixKarbonClusters() *schema.Resource {

--- a/nutanix/data_source_nutanix_karbon_private_registries.go
+++ b/nutanix/data_source_nutanix_karbon_private_registries.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixKarbonPrivateRegistries() *schema.Resource {

--- a/nutanix/data_source_nutanix_karbon_private_registry.go
+++ b/nutanix/data_source_nutanix_karbon_private_registry.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-nutanix/client/karbon"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	"github.com/nutanix/terraform-provider-nutanix/client/karbon"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixKarbonPrivateRegistry() *schema.Resource {

--- a/nutanix/data_source_nutanix_network_security_rule.go
+++ b/nutanix/data_source_nutanix_network_security_rule.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/nutanix/data_source_nutanix_permission.go
+++ b/nutanix/data_source_nutanix_permission.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixPermission() *schema.Resource {

--- a/nutanix/data_source_nutanix_permissions.go
+++ b/nutanix/data_source_nutanix_permissions.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixPermissions() *schema.Resource {

--- a/nutanix/data_source_nutanix_project.go
+++ b/nutanix/data_source_nutanix_project.go
@@ -3,8 +3,8 @@ package nutanix
 import (
 	"fmt"
 
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/nutanix/data_source_nutanix_projects.go
+++ b/nutanix/data_source_nutanix_projects.go
@@ -3,8 +3,8 @@ package nutanix
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixProjects() *schema.Resource {

--- a/nutanix/data_source_nutanix_role.go
+++ b/nutanix/data_source_nutanix_role.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixRole() *schema.Resource {

--- a/nutanix/data_source_nutanix_roles.go
+++ b/nutanix/data_source_nutanix_roles.go
@@ -3,8 +3,8 @@ package nutanix
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixRoles() *schema.Resource {

--- a/nutanix/data_source_nutanix_subnet.go
+++ b/nutanix/data_source_nutanix_subnet.go
@@ -5,8 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixSubnet() *schema.Resource {

--- a/nutanix/data_source_nutanix_subnets.go
+++ b/nutanix/data_source_nutanix_subnets.go
@@ -3,8 +3,8 @@ package nutanix
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixSubnets() *schema.Resource {

--- a/nutanix/data_source_nutanix_user.go
+++ b/nutanix/data_source_nutanix_user.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixUser() *schema.Resource {

--- a/nutanix/data_source_nutanix_user_group.go
+++ b/nutanix/data_source_nutanix_user_group.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixUserGroup() *schema.Resource {

--- a/nutanix/data_source_nutanix_user_groups.go
+++ b/nutanix/data_source_nutanix_user_groups.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixUserGroups() *schema.Resource {

--- a/nutanix/data_source_nutanix_users.go
+++ b/nutanix/data_source_nutanix_users.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixUsers() *schema.Resource {

--- a/nutanix/data_source_nutanix_virtual_machine.go
+++ b/nutanix/data_source_nutanix_virtual_machine.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/nutanix/data_source_protection_rule.go
+++ b/nutanix/data_source_protection_rule.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/nutanix/data_source_protection_rules.go
+++ b/nutanix/data_source_protection_rules.go
@@ -3,8 +3,8 @@ package nutanix
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixProtectionRules() *schema.Resource {

--- a/nutanix/data_source_recovery_plan.go
+++ b/nutanix/data_source_recovery_plan.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/nutanix/data_source_recovery_plans.go
+++ b/nutanix/data_source_recovery_plans.go
@@ -3,8 +3,8 @@ package nutanix
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func dataSourceNutanixRecoveryPlans() *schema.Resource {

--- a/nutanix/helpers.go
+++ b/nutanix/helpers.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func getMetadataAttributes(d *schema.ResourceData, metadata *v3.Metadata, kind string) error {

--- a/nutanix/resource_nutanix_access_control_policy.go
+++ b/nutanix/resource_nutanix_access_control_policy.go
@@ -7,9 +7,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 	"github.com/spf13/cast"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
 )
 
 func resourceNutanixAccessControlPolicy() *schema.Resource {

--- a/nutanix/resource_nutanix_category_key.go
+++ b/nutanix/resource_nutanix_category_key.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func resourceNutanixCategoryKey() *schema.Resource {

--- a/nutanix/resource_nutanix_category_value.go
+++ b/nutanix/resource_nutanix_category_value.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 func resourceNutanixCategoryValue() *schema.Resource {

--- a/nutanix/resource_nutanix_image.go
+++ b/nutanix/resource_nutanix_image.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/nutanix/resource_nutanix_karbon_cluster.go
+++ b/nutanix/resource_nutanix_karbon_cluster.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	karbon "github.com/terraform-providers/terraform-provider-nutanix/client/karbon"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	karbon "github.com/nutanix/terraform-provider-nutanix/client/karbon"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/nutanix/resource_nutanix_karbon_private_registry.go
+++ b/nutanix/resource_nutanix_karbon_private_registry.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	karbon "github.com/terraform-providers/terraform-provider-nutanix/client/karbon"
+	karbon "github.com/nutanix/terraform-provider-nutanix/client/karbon"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/nutanix/resource_nutanix_network_security_rule.go
+++ b/nutanix/resource_nutanix_network_security_rule.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
 )
 
 var (

--- a/nutanix/resource_nutanix_project.go
+++ b/nutanix/resource_nutanix_project.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 	"github.com/spf13/cast"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
 )
 
 func resourceNutanixProject() *schema.Resource {

--- a/nutanix/resource_nutanix_protection_rule.go
+++ b/nutanix/resource_nutanix_protection_rule.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 	"github.com/spf13/cast"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
 )
 
 func resourceNutanixProtectionRule() *schema.Resource {

--- a/nutanix/resource_nutanix_recovery_plan.go
+++ b/nutanix/resource_nutanix_recovery_plan.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 	"github.com/spf13/cast"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
 )
 
 func resourceNutanixRecoveryPlan() *schema.Resource {

--- a/nutanix/resource_nutanix_role.go
+++ b/nutanix/resource_nutanix_role.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 	"github.com/spf13/cast"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
 )
 
 func resourceNutanixRole() *schema.Resource {

--- a/nutanix/resource_nutanix_subnet.go
+++ b/nutanix/resource_nutanix_subnet.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 var (

--- a/nutanix/resource_nutanix_user.go
+++ b/nutanix/resource_nutanix_user.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/nutanix/resource_nutanix_virtual_machine.go
+++ b/nutanix/resource_nutanix_virtual_machine.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 	"github.com/spf13/cast"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/nutanix/structure.go
+++ b/nutanix/structure.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	v3 "github.com/nutanix/terraform-provider-nutanix/client/v3"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 	"github.com/spf13/cast"
-	v3 "github.com/terraform-providers/terraform-provider-nutanix/client/v3"
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
 )
 
 const (

--- a/nutanix/structure_test.go
+++ b/nutanix/structure_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+	"github.com/nutanix/terraform-provider-nutanix/utils"
 )
 
 // based on AWS Provider we should change for us

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package main


### PR DESCRIPTION
This PR updates the current `github.com/terraform-providers/terraform-provider-nutanix` path in `go.mod` and include directives to `github.com/nutanix/terraform-provider-nutanix`, which is the new repository location. It seems that in the migration from `github.com/terraform-providers` (although the old path now redirects to `github.com/hashicorp/terraform-provider-nutanix`), this wasn't updated.