### PR TITLE
Add check for cluster_reference before set to avoid it in case of overlay subnets in datasource nutanix_subnet

### DIFF
--- a/nutanix/data_source_nutanix_subnet.go
+++ b/nutanix/data_source_nutanix_subnet.go
@@ -415,7 +415,11 @@ func dataSourceNutanixSubnetRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	d.Set("cluster_reference_name", utils.StringValue(resp.Status.ClusterReference.Name))
+	//cluster reference is not there for overlay subnet
+	if resp.Status.ClusterReference != nil {
+		d.Set("cluster_reference_name", utils.StringValue(resp.Status.ClusterReference.Name))
+	}
+
 	d.Set("api_version", utils.StringValue(resp.APIVersion))
 	d.Set("name", utils.StringValue(resp.Status.Name))
 	d.Set("description", utils.StringValue(resp.Status.Description))


### PR DESCRIPTION
For overlay subnets, there is no cluster_reference field in response. So added a check before setting "cluster_reference_name"