### PR TITLE
Use correct API endpoint for category queries

### DIFF
--- a/client/v3/v3_service.go
+++ b/client/v3/v3_service.go
@@ -689,7 +689,7 @@ func (op Operations) DeleteCategoryValue(name string, value string) error {
 func (op Operations) GetCategoryQuery(query *CategoryQueryInput) (*CategoryQueryResponse, error) {
 	ctx := context.TODO()
 
-	path := "/categories/query"
+	path := "/category/query"
 
 	req, err := op.client.NewRequest(ctx, http.MethodPost, path, query)
 	categoryQueryResponse := new(CategoryQueryResponse)

--- a/client/v3/v3_service_test.go
+++ b/client/v3/v3_service_test.go
@@ -1980,7 +1980,7 @@ func TestOperations_GetCategoryQuery(t *testing.T) {
 
 	defer server.Close()
 
-	mux.HandleFunc("/api/nutanix/v3/categories/query", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/nutanix/v3/category/query", func(w http.ResponseWriter, r *http.Request) {
 		testHTTPMethod(t, r, http.MethodPost)
 		fmt.Fprint(w, `{"results":[{ "kind": "category_result" }]}`)
 	})


### PR DESCRIPTION
Hey folks, I found this bug while working with the client library downstream. The correct API endpoint `/category/query` is [documented here](https://www.nutanix.dev/api_references/prism-central-v3/#/b3A6MjU1ODczNjA-get-category-usage-details). The current implementation fails with a "method not allowed" error because it's essentially using the ["Get a category key" endpoint](https://www.nutanix.dev/api_references/prism-central-v3/#/b3A6MjU1ODczNTI-get-a-category-key) against a category called "query" (but the endpoint doesn't support `POST`).

`GetCategoryQuery()` does not seem to be used anywhere in the provider, so I'm not sure how interested you are in this fix, but I wanted to send this upstream as it might come in handy in the future. Feel free to close if not relevant.