### PR TITLE
Enable tests for protection rules based datasources and resources

### DIFF
--- a/nutanix/data_source_protection_rule.go
+++ b/nutanix/data_source_protection_rule.go
@@ -273,6 +273,9 @@ func dataSourceNutanixProtectionRuleRead(ctx context.Context, d *schema.Resource
 	if err := d.Set("name", resp.Spec.Name); err != nil {
 		return diag.FromErr(err)
 	}
+	if err := d.Set("description", resp.Spec.Description); err != nil {
+		return diag.FromErr(err)
+	}
 	if err := d.Set("start_time", resp.Spec.Resources.StartTime); err != nil {
 		return diag.FromErr(err)
 	}

--- a/nutanix/data_source_protection_rules_test.go
+++ b/nutanix/data_source_protection_rules_test.go
@@ -1,25 +1,87 @@
 package nutanix
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccNutanixProtectionRulesDataSource_basic(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
+	if os.Getenv("PROTECTION_RULES_TEST_FLAG") != "true" {
+		t.Skip()
+	}
+	dataSourceName := "data.nutanix_protection_rules.test"
+	aZUUIDSource := testVars.ProtectionPolicy.LocalAz.UUID
+	clusterUUIDSource := testVars.ProtectionPolicy.LocalAz.ClusterUUID
+	aZUUIDTarget := testVars.ProtectionPolicy.DestinationAz.UUID
+	clusterUUIDTarget := testVars.ProtectionPolicy.DestinationAz.UUID
+
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProtectionRulesDataSourceConfig(),
+				Config: testAccProtectionRulesDataSourceConfig(aZUUIDSource, clusterUUIDSource, aZUUIDTarget, clusterUUIDTarget, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "entities.1.metadata.uuid"),
+				),
 			},
 		},
 	})
 }
 
-func testAccProtectionRulesDataSourceConfig() string {
-	return `
-		data "nutanix_protection_rules" "test" {}
-	`
+func testAccProtectionRulesDataSourceConfig(aZUUIDSource, clusterUUIDSource, aZUUIDTarget, clusterUUIDTarget string, snapshots int64) string {
+	return fmt.Sprintf(`
+		locals{
+			category = "AnalyticsExclusions"
+			keys = ["EfficiencyMeasurement", "AnomalyDetection"]
+		}
+		resource "nutanix_protection_rule" "test" {
+			count = 2
+			name = "test-rule-${count.index}"
+			description = "test-rule-desc-${count.index}"
+			ordered_availability_zone_list{
+				availability_zone_url = "%s"
+				cluster_uuid = "%s"
+			}
+			ordered_availability_zone_list{
+				availability_zone_url = "%s"
+				cluster_uuid = "%s"
+			}
+
+			availability_zone_connectivity_list{
+				source_availability_zone_index = 0
+				destination_availability_zone_index = 1
+				snapshot_schedule_list{
+					recovery_point_objective_secs = 3600
+					snapshot_type= "CRASH_CONSISTENT"
+					local_snapshot_retention_policy {
+						num_snapshots = %[5]d
+					}
+				}
+			}
+			availability_zone_connectivity_list{
+				source_availability_zone_index = 1
+				destination_availability_zone_index = 0
+				snapshot_schedule_list{
+					recovery_point_objective_secs = 3600
+					snapshot_type= "CRASH_CONSISTENT"
+					local_snapshot_retention_policy {
+						num_snapshots = %[5]d
+					}
+				}
+			}
+			category_filter {
+				params {
+					name = local.category
+					values = [local.keys[(count.index)]]
+				}
+			}
+		}
+		data "nutanix_protection_rules" "test" {
+			depends_on = [nutanix_protection_rule.test]
+		}
+	`, aZUUIDSource, clusterUUIDSource, aZUUIDTarget, clusterUUIDTarget, snapshots)
 }

--- a/nutanix/main_test.go
+++ b/nutanix/main_test.go
@@ -29,6 +29,17 @@ type TestConfig struct {
 		Name   string `json:"name"`
 		Values string `json:"values"`
 	} `json:"ad_rule_target"`
+	// here UUID = availability_zone_url
+	ProtectionPolicy struct {
+		LocalAz struct {
+			UUID        string `json:"uuid"`
+			ClusterUUID string `json:"cluster_uuid"`
+		} `json:"local_az"`
+		DestinationAz struct {
+			UUID        string `json:"uuid"`
+			ClusterUUID string `json:"cluster_uuid"`
+		} `json:"destination_az"`
+	} `json:"protection_policy"`
 }
 
 type IPMIConfig struct {

--- a/nutanix/resource_nutanix_protection_rule_test.go
+++ b/nutanix/resource_nutanix_protection_rule_test.go
@@ -2,6 +2,7 @@ package nutanix
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -13,15 +14,17 @@ import (
 )
 
 func TestAccNutanixProtectionRule_basic(t *testing.T) {
-	t.Skip()
+	if os.Getenv("PROTECTION_RULES_TEST_FLAG") != "true" {
+		t.Skip()
+	}
 	resourceName := "nutanix_protection_rule.test"
 
 	name := acctest.RandomWithPrefix("test-protection-name-dou")
 	description := acctest.RandomWithPrefix("test-protection-desc-dou")
-	aZUrlSource := "c99ab7cd-9191-4fcb-8fc0-232eff76e595"
-	uuidSource := "4db9adc1-8d13-4585-a901-a3ce1276ecb0"
-	aZUrlTarget := "45a97947-4b09-4179-8e9b-0c2859020539"
-	uuidTarget := "40cc9ba1-4c3c-4deb-a04e-a5e33c09d767"
+	aZUUIDSource := testVars.ProtectionPolicy.LocalAz.UUID
+	clusterUUIDSource := testVars.ProtectionPolicy.LocalAz.ClusterUUID
+	aZUUIDTarget := testVars.ProtectionPolicy.DestinationAz.UUID
+	clusterUUIDTarget := testVars.ProtectionPolicy.DestinationAz.UUID
 
 	nameUpdated := acctest.RandomWithPrefix("test-protection-name-dou")
 	descriptionUpdated := acctest.RandomWithPrefix("test-protection-desc-dou")
@@ -29,10 +32,10 @@ func TestAccNutanixProtectionRule_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNutanixProtectionRUleDestroy,
+		CheckDestroy: testAccCheckNutanixProtectionRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNutanixProtectionRuleConfig(name, description, aZUrlSource, uuidSource, aZUrlTarget, uuidTarget, 1),
+				Config: testAccNutanixProtectionRuleConfig(name, description, aZUUIDSource, clusterUUIDSource, aZUUIDTarget, clusterUUIDTarget, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNutanixProtectionRuleExists(&resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -40,7 +43,7 @@ func TestAccNutanixProtectionRule_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccNutanixProtectionRuleConfig(nameUpdated, descriptionUpdated, aZUrlSource, uuidSource, aZUrlTarget, uuidTarget, 2),
+				Config: testAccNutanixProtectionRuleConfig(nameUpdated, descriptionUpdated, aZUUIDSource, clusterUUIDSource, aZUUIDTarget, clusterUUIDTarget, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNutanixProtectionRuleExists(&resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", nameUpdated),
@@ -51,24 +54,26 @@ func TestAccNutanixProtectionRule_basic(t *testing.T) {
 	})
 }
 
-func TestAccNutanixProtectionRule_importBasic(t *testing.T) {
-	t.Skip()
+func TestAccResourceNutanixProtectionRule_importBasic(t *testing.T) {
+	if os.Getenv("PROTECTION_RULES_TEST_FLAG") != "true" {
+		t.Skip()
+	}
 	resourceName := "nutanix_protection_rule.test"
 
 	name := acctest.RandomWithPrefix("test-protection-name-dou")
 	description := acctest.RandomWithPrefix("test-protection-desc-dou")
-	aZUrlSource := "c99ab7cd-9191-4fcb-8fc0-232eff76e595"
-	uuidSource := "4db9adc1-8d13-4585-a901-a3ce1276ecb0"
-	aZUrlTarget := "45a97947-4b09-4179-8e9b-0c2859020539"
-	uuidTarget := "40cc9ba1-4c3c-4deb-a04e-a5e33c09d767"
+	aZUUIDSource := testVars.ProtectionPolicy.LocalAz.UUID
+	clusterUUIDSource := testVars.ProtectionPolicy.LocalAz.ClusterUUID
+	aZUUIDTarget := testVars.ProtectionPolicy.DestinationAz.UUID
+	clusterUUIDTarget := testVars.ProtectionPolicy.DestinationAz.UUID
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckNutanixProtectionRUleDestroy,
+		CheckDestroy: testAccCheckNutanixProtectionRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNutanixProtectionRuleConfig(name, description, aZUrlSource, uuidSource, aZUrlTarget, uuidTarget, 1),
+				Config: testAccNutanixProtectionRuleConfig(name, description, aZUUIDSource, clusterUUIDSource, aZUUIDTarget, clusterUUIDTarget, 1),
 			},
 			{
 				ResourceName:      resourceName,
@@ -104,7 +109,7 @@ func testAccCheckNutanixProtectionRuleExists(resourceName *string) resource.Test
 	}
 }
 
-func testAccCheckNutanixProtectionRUleDestroy(s *terraform.State) error {
+func testAccCheckNutanixProtectionRuleDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*Client)
 
 	for _, rs := range s.RootModule().Resources {
@@ -125,7 +130,7 @@ func testAccCheckNutanixProtectionRUleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccNutanixProtectionRuleConfig(name, description, aZUrlSource, clusterUUIDSource, aZUrlTarget, clusterUUIDTarget string, snapshots int64) string {
+func testAccNutanixProtectionRuleConfig(name, description, aZUUIDSource, clusterUUIDSource, aZUUIDTarget, clusterUUIDTarget string, snapshots int64) string {
 	return fmt.Sprintf(`
 		resource "nutanix_protection_rule" "test" {
 			name        = "%s"
@@ -168,5 +173,5 @@ func testAccNutanixProtectionRuleConfig(name, description, aZUrlSource, clusterU
 				}
 			}
 		}
-	`, name, description, aZUrlSource, clusterUUIDSource, aZUrlTarget, clusterUUIDTarget, snapshots)
+	`, name, description, aZUUIDSource, clusterUUIDSource, aZUUIDTarget, clusterUUIDTarget, snapshots)
 }

--- a/test_config.json
+++ b/test_config.json
@@ -37,6 +37,16 @@
     "ad_rule_target": {
         "name": "ADGroup",
         "values": "sspadmins"
+    },
+    "protection_policy":{
+        "local_az":{
+            "uuid":"a973cd7b-7696-4ca5-b959-04b5bcb9e683",
+            "cluster_uuid":"0005ded3-2367-7205-3507-ac1f6b60292f"
+        },
+        "destination_az":{
+            "uuid":"97b0cc07-d838-4925-acd7-540c11bd653d",
+            "cluster_uuid":"0005dc0f-13a7-62e0-185b-ac1f6b6f97e2"
+        }
     }
 }
 


### PR DESCRIPTION
Updates:
- Set **description** from api response in data_source_protection_rule
- Update test_config.json and main_test.go to have fields for local_az and destination_az (availibility zones) based required uuids which will be used in tests related to protection rules.
- Skip protection rules based data source and resource tests as per the env variable : **PROTECTION_RULES_TEST_FLAG**
- Create two protection rules before using nutanix_protection_rules data source in tests.