### PR TITLE
Better error handling for foundation resources and data sources

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -545,11 +545,6 @@ func CheckResponse(r *http.Response) error {
 	}
 	log.Print("[DEBUG] first nil check")
 
-	// This check is used for some foundation api errors
-	if errStruct, ok := res["error"]; ok {
-		return fmt.Errorf("error: %s", errStruct)
-	}
-
 	// karbon error check
 	if messageInfo, ok := res["message_info"]; ok {
 		return fmt.Errorf("error: %s", messageInfo)

--- a/client/foundation/foundation_structs.go
+++ b/client/foundation/foundation_structs.go
@@ -320,6 +320,7 @@ type IPMIConfigAPIResponse struct {
 	Blocks       []IPMIConfigBlockResponse `json:"blocks"`
 	IpmiGateway  string                    `json:"ipmi_gateway"`
 	IpmiPassword string                    `json:"ipmi_password"`
+	Error        *Error                    `json:"error"`
 }
 
 // IPMI config info response for every node along with success flag

--- a/client/foundation/foundation_structs.go
+++ b/client/foundation/foundation_structs.go
@@ -163,14 +163,11 @@ type ImageNodesAPIResponse struct {
 	Error *Error `json:"error"`
 }
 
-type Details struct {
-}
-
 //Error details for image nodes errored response
 type Error struct {
-	Message   string  `json:"message"`
-	Details   Details `json:"details"`
-	SessionID string  `json:"session_id"`
+	Message   string            `json:"message"`
+	Details   map[string]string `json:"details"`
+	SessionID string            `json:"session_id"`
 }
 
 //Node Imaging progress response

--- a/nutanix/resource_nutanix_foundation_image_nodes.go
+++ b/nutanix/resource_nutanix_foundation_image_nodes.go
@@ -1190,7 +1190,6 @@ func collectIndividualErrorDiagnostics(progress *foundation.ImageNodesProgressRe
 				Detail:   message,
 			})
 		}
-
 	}
 
 	// append errors for failed cluster creation
@@ -1206,7 +1205,6 @@ func collectIndividualErrorDiagnostics(progress *foundation.ImageNodesProgressRe
 				Detail:   message,
 			})
 		}
-
 	}
 
 	return diags

--- a/nutanix/resource_nutanix_foundation_image_nodes.go
+++ b/nutanix/resource_nutanix_foundation_image_nodes.go
@@ -780,6 +780,11 @@ func resourceFoundationImageNodesCreate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
+	// if node images gets errors out initially itself
+	if resp.Error != nil {
+		return diag.Errorf("Node imaging process failed due to error: %s", resp.Error.Message)
+	}
+
 	//poll for progress
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},

--- a/nutanix/resource_nutanix_foundation_ipmi_config.go
+++ b/nutanix/resource_nutanix_foundation_ipmi_config.go
@@ -171,6 +171,21 @@ func resourceFoundationIPMIConfigCreate(ctx context.Context, d *schema.ResourceD
 
 	// incase of errored response
 	if resp.Error != nil {
+
+		// check if error details exists for every ipmi IP
+		var diags diag.Diagnostics
+		for k, v := range resp.Error.Details {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("IPMI config failed for IPMI IP: %s", k),
+				Detail:   v,
+			})
+		}
+		if len(diags) > 0 {
+			return diags
+		}
+
+		// incase there is no error details
 		return diag.Errorf(resp.Error.Message)
 	}
 
@@ -197,11 +212,9 @@ func resourceFoundationIPMIConfigCreate(ctx context.Context, d *schema.ResourceD
 		nodes := make([]map[string]interface{}, len(v.Nodes))
 		for k1, v1 := range v.Nodes {
 			node := make(map[string]interface{})
-			node["ipmi_configure_successful"] = v1.IpmiConfigureSuccessful
-			node["ipmi_configure_now"] = v1.IpmiConfigureNow
+			node["ipmi_configure_now"] = true
 			node["ipmi_ip"] = v1.IpmiIP
 			node["ipmi_mac"] = v1.IpmiMac
-			node["ipmi_message"] = v1.IpmiMessage
 			nodes[k1] = node
 		}
 		block["nodes"] = nodes

--- a/nutanix/resource_nutanix_foundation_ipmi_config.go
+++ b/nutanix/resource_nutanix_foundation_ipmi_config.go
@@ -210,9 +210,11 @@ func resourceFoundationIPMIConfigCreate(ctx context.Context, d *schema.ResourceD
 		nodes := make([]map[string]interface{}, len(v.Nodes))
 		for k1, v1 := range v.Nodes {
 			node := make(map[string]interface{})
+			node["ipmi_configure_successful"] = v1.IpmiConfigureSuccessful
 			node["ipmi_configure_now"] = true
 			node["ipmi_ip"] = v1.IpmiIP
 			node["ipmi_mac"] = v1.IpmiMac
+			node["ipmi_message"] = v1.IpmiMessage
 			nodes[k1] = node
 		}
 		block["nodes"] = nodes

--- a/nutanix/resource_nutanix_foundation_ipmi_config.go
+++ b/nutanix/resource_nutanix_foundation_ipmi_config.go
@@ -77,7 +77,6 @@ func resourceNutanixFoundationIPMIConfig() *schema.Resource {
 						"block_id": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 						},
 					},
 				},
@@ -168,6 +167,11 @@ func resourceFoundationIPMIConfigCreate(ctx context.Context, d *schema.ResourceD
 	resp, err := conn.Networking.ConfigureIPMI(ctx, inpSpec)
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	// incase of errored response
+	if resp.Error != nil {
+		return diag.Errorf(resp.Error.Message)
 	}
 
 	if setErr := d.Set("ipmi_user", resp.IpmiUser); setErr != nil {

--- a/nutanix/resource_nutanix_foundation_ipmi_config.go
+++ b/nutanix/resource_nutanix_foundation_ipmi_config.go
@@ -171,7 +171,6 @@ func resourceFoundationIPMIConfigCreate(ctx context.Context, d *schema.ResourceD
 
 	// incase of errored response
 	if resp.Error != nil {
-
 		// check if error details exists for every ipmi IP
 		var diags diag.Diagnostics
 		for k, v := range resp.Error.Details {
@@ -184,7 +183,6 @@ func resourceFoundationIPMIConfigCreate(ctx context.Context, d *schema.ResourceD
 		if len(diags) > 0 {
 			return diags
 		}
-
 		// incase there is no error details
 		return diag.Errorf(resp.Error.Message)
 	}


### PR DESCRIPTION
Remove error handling from client level for some foundation entities and handle it from respective provider code level. 
Entities effected : 
- ipmi_config resource
- image_nodes resource
- node_network_details data source