### PR TITLE
Make PC connection details optional with foundation connection details

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -176,6 +176,11 @@ func NewBaseClient(credentials *Credentials, absolutePath string, isHTTP bool) (
 
 // NewRequest creates a request
 func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
+	// check if client exists or not
+	if c.client == nil {
+		return nil, fmt.Errorf("client for %s is missing", c.UserAgent)
+	}
+
 	rel, errp := url.Parse(c.AbsolutePath + urlStr)
 	if errp != nil {
 		return nil, errp
@@ -214,6 +219,11 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body int
 
 // NewRequest creates a request without authorisation headers
 func (c *Client) NewUnAuthRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
+	// check if client exists or not
+	if c.client == nil {
+		return nil, fmt.Errorf("client for %s is missing", c.UserAgent)
+	}
+
 	//create main api url
 	rel, err := url.Parse(c.AbsolutePath + urlStr)
 	if err != nil {
@@ -243,6 +253,10 @@ func (c *Client) NewUnAuthRequest(ctx context.Context, method, urlStr string, bo
 
 // NewUnAuthFormEncodedRequest returns content-type: application/x-www-form-urlencoded based unauth request
 func (c *Client) NewUnAuthFormEncodedRequest(ctx context.Context, method, urlStr string, body map[string]string) (*http.Request, error) {
+	// check if client exists or not
+	if c.client == nil {
+		return nil, fmt.Errorf("client for %s is missing", c.UserAgent)
+	}
 	//create main api url
 	rel, err := url.Parse(c.AbsolutePath + urlStr)
 	if err != nil {
@@ -272,6 +286,10 @@ func (c *Client) NewUnAuthFormEncodedRequest(ctx context.Context, method, urlStr
 
 // NewUploadRequest Handles image uploads for image service
 func (c *Client) NewUploadRequest(ctx context.Context, method, urlStr string, body []byte) (*http.Request, error) {
+	// check if client exists or not
+	if c.client == nil {
+		return nil, fmt.Errorf("client for %s is missing", c.UserAgent)
+	}
 	rel, errp := url.Parse(c.AbsolutePath + urlStr)
 	if errp != nil {
 		return nil, errp
@@ -298,6 +316,10 @@ func (c *Client) NewUploadRequest(ctx context.Context, method, urlStr string, bo
 
 // NewUploadRequest handles image uploads for image service
 func (c *Client) NewUnAuthUploadRequest(ctx context.Context, method, urlStr string, body []byte) (*http.Request, error) {
+	// check if client exists or not
+	if c.client == nil {
+		return nil, fmt.Errorf("client for %s is missing", c.UserAgent)
+	}
 	rel, errp := url.Parse(c.AbsolutePath + urlStr)
 	if errp != nil {
 		return nil, errp
@@ -326,6 +348,11 @@ func (c *Client) OnRequestCompleted(rc RequestCompletionCallback) {
 
 // Do performs request passed
 func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) error {
+	// check if client exists or not
+	if c.client == nil {
+		return fmt.Errorf("client for %s is missing", c.UserAgent)
+	}
+
 	req = req.WithContext(ctx)
 	resp, err := c.client.Do(req)
 
@@ -377,6 +404,10 @@ func searchSlice(slice []string, key string) bool {
 
 // DoWithFilters performs request passed and filters entities in json response
 func (c *Client) DoWithFilters(ctx context.Context, req *http.Request, v interface{}, filters []*AdditionalFilter, baseSearchPaths []string) error {
+	// check if client exists or not
+	if c.client == nil {
+		return fmt.Errorf("client for %s is missing", c.UserAgent)
+	}
 	req = req.WithContext(ctx)
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -51,7 +51,7 @@ type Client struct {
 	AbsolutePath string
 
 	// error message, incase client is in error state
-	Error string
+	ErrorMsg string
 }
 
 // RequestCompletionCallback defines the type of the request callback function
@@ -69,6 +69,7 @@ type Credentials struct {
 	ProxyURL           string
 	FoundationEndpoint string
 	FoundationPort     string
+	RequiredFields     map[string][]string
 }
 
 // AdditionalFilter specification for client side filters
@@ -181,7 +182,7 @@ func NewBaseClient(credentials *Credentials, absolutePath string, isHTTP bool) (
 func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
 	// check if client exists or not
 	if c.client == nil {
-		return nil, fmt.Errorf(c.Error)
+		return nil, fmt.Errorf(c.ErrorMsg)
 	}
 
 	rel, errp := url.Parse(c.AbsolutePath + urlStr)
@@ -224,7 +225,7 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body int
 func (c *Client) NewUnAuthRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
 	// check if client exists or not
 	if c.client == nil {
-		return nil, fmt.Errorf(c.Error)
+		return nil, fmt.Errorf(c.ErrorMsg)
 	}
 
 	//create main api url
@@ -258,7 +259,7 @@ func (c *Client) NewUnAuthRequest(ctx context.Context, method, urlStr string, bo
 func (c *Client) NewUnAuthFormEncodedRequest(ctx context.Context, method, urlStr string, body map[string]string) (*http.Request, error) {
 	// check if client exists or not
 	if c.client == nil {
-		return nil, fmt.Errorf(c.Error)
+		return nil, fmt.Errorf(c.ErrorMsg)
 	}
 	//create main api url
 	rel, err := url.Parse(c.AbsolutePath + urlStr)
@@ -291,7 +292,7 @@ func (c *Client) NewUnAuthFormEncodedRequest(ctx context.Context, method, urlStr
 func (c *Client) NewUploadRequest(ctx context.Context, method, urlStr string, body []byte) (*http.Request, error) {
 	// check if client exists or not
 	if c.client == nil {
-		return nil, fmt.Errorf(c.Error)
+		return nil, fmt.Errorf(c.ErrorMsg)
 	}
 	rel, errp := url.Parse(c.AbsolutePath + urlStr)
 	if errp != nil {
@@ -321,7 +322,7 @@ func (c *Client) NewUploadRequest(ctx context.Context, method, urlStr string, bo
 func (c *Client) NewUnAuthUploadRequest(ctx context.Context, method, urlStr string, body []byte) (*http.Request, error) {
 	// check if client exists or not
 	if c.client == nil {
-		return nil, fmt.Errorf(c.Error)
+		return nil, fmt.Errorf(c.ErrorMsg)
 	}
 	rel, errp := url.Parse(c.AbsolutePath + urlStr)
 	if errp != nil {
@@ -353,7 +354,7 @@ func (c *Client) OnRequestCompleted(rc RequestCompletionCallback) {
 func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) error {
 	// check if client exists or not
 	if c.client == nil {
-		return fmt.Errorf(c.Error)
+		return fmt.Errorf(c.ErrorMsg)
 	}
 
 	req = req.WithContext(ctx)
@@ -409,7 +410,7 @@ func searchSlice(slice []string, key string) bool {
 func (c *Client) DoWithFilters(ctx context.Context, req *http.Request, v interface{}, filters []*AdditionalFilter, baseSearchPaths []string) error {
 	// check if client exists or not
 	if c.client == nil {
-		return fmt.Errorf(c.Error)
+		return fmt.Errorf(c.ErrorMsg)
 	}
 	req = req.WithContext(ctx)
 	resp, err := c.client.Do(req)

--- a/client/client.go
+++ b/client/client.go
@@ -49,6 +49,9 @@ type Client struct {
 
 	// absolutePath: for example api/nutanix/v3
 	AbsolutePath string
+
+	// error message, incase client is in error state
+	Error string
 }
 
 // RequestCompletionCallback defines the type of the request callback function
@@ -113,7 +116,7 @@ func NewClient(credentials *Credentials, userAgent string, absolutePath string, 
 		return nil, err
 	}
 
-	c := &Client{credentials, httpClient, baseURL, userAgent, nil, nil, absolutePath}
+	c := &Client{credentials, httpClient, baseURL, userAgent, nil, nil, absolutePath, ""}
 
 	if credentials.SessionAuth {
 		log.Printf("[DEBUG] Using session_auth\n")
@@ -169,7 +172,7 @@ func NewBaseClient(credentials *Credentials, absolutePath string, isHTTP bool) (
 		return nil, err
 	}
 
-	c := &Client{credentials, httpClient, baseURL, "", nil, nil, absolutePath}
+	c := &Client{credentials, httpClient, baseURL, "", nil, nil, absolutePath, ""}
 
 	return c, nil
 }
@@ -178,7 +181,7 @@ func NewBaseClient(credentials *Credentials, absolutePath string, isHTTP bool) (
 func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
 	// check if client exists or not
 	if c.client == nil {
-		return nil, fmt.Errorf("client for %s is missing", c.UserAgent)
+		return nil, fmt.Errorf(c.Error)
 	}
 
 	rel, errp := url.Parse(c.AbsolutePath + urlStr)
@@ -221,7 +224,7 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body int
 func (c *Client) NewUnAuthRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
 	// check if client exists or not
 	if c.client == nil {
-		return nil, fmt.Errorf("client for %s is missing", c.UserAgent)
+		return nil, fmt.Errorf(c.Error)
 	}
 
 	//create main api url
@@ -255,7 +258,7 @@ func (c *Client) NewUnAuthRequest(ctx context.Context, method, urlStr string, bo
 func (c *Client) NewUnAuthFormEncodedRequest(ctx context.Context, method, urlStr string, body map[string]string) (*http.Request, error) {
 	// check if client exists or not
 	if c.client == nil {
-		return nil, fmt.Errorf("client for %s is missing", c.UserAgent)
+		return nil, fmt.Errorf(c.Error)
 	}
 	//create main api url
 	rel, err := url.Parse(c.AbsolutePath + urlStr)
@@ -288,7 +291,7 @@ func (c *Client) NewUnAuthFormEncodedRequest(ctx context.Context, method, urlStr
 func (c *Client) NewUploadRequest(ctx context.Context, method, urlStr string, body []byte) (*http.Request, error) {
 	// check if client exists or not
 	if c.client == nil {
-		return nil, fmt.Errorf("client for %s is missing", c.UserAgent)
+		return nil, fmt.Errorf(c.Error)
 	}
 	rel, errp := url.Parse(c.AbsolutePath + urlStr)
 	if errp != nil {
@@ -318,7 +321,7 @@ func (c *Client) NewUploadRequest(ctx context.Context, method, urlStr string, bo
 func (c *Client) NewUnAuthUploadRequest(ctx context.Context, method, urlStr string, body []byte) (*http.Request, error) {
 	// check if client exists or not
 	if c.client == nil {
-		return nil, fmt.Errorf("client for %s is missing", c.UserAgent)
+		return nil, fmt.Errorf(c.Error)
 	}
 	rel, errp := url.Parse(c.AbsolutePath + urlStr)
 	if errp != nil {
@@ -350,7 +353,7 @@ func (c *Client) OnRequestCompleted(rc RequestCompletionCallback) {
 func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) error {
 	// check if client exists or not
 	if c.client == nil {
-		return fmt.Errorf("client for %s is missing", c.UserAgent)
+		return fmt.Errorf(c.Error)
 	}
 
 	req = req.WithContext(ctx)
@@ -406,7 +409,7 @@ func searchSlice(slice []string, key string) bool {
 func (c *Client) DoWithFilters(ctx context.Context, req *http.Request, v interface{}, filters []*AdditionalFilter, baseSearchPaths []string) error {
 	// check if client exists or not
 	if c.client == nil {
-		return fmt.Errorf("client for %s is missing", c.UserAgent)
+		return fmt.Errorf(c.Error)
 	}
 	req = req.WithContext(ctx)
 	resp, err := c.client.Do(req)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -24,14 +24,14 @@ func setup() (*http.ServeMux, *Client, *httptest.Server) {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 
-	client, _ := NewClient(&Credentials{"", "username", "password", "", "", true, false, "", "", ""}, testUserAgent, testAbsolutePath, false)
+	client, _ := NewClient(&Credentials{"", "username", "password", "", "", true, false, "", "", "", nil}, testUserAgent, testAbsolutePath, false)
 	client.BaseURL, _ = url.Parse(server.URL)
 
 	return mux, client, server
 }
 
 func TestNewClient(t *testing.T) {
-	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", ""}, testUserAgent, testAbsolutePath, false)
+	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", "", nil}, testUserAgent, testAbsolutePath, false)
 
 	if err != nil {
 		t.Errorf("Unexpected Error: %v", err)
@@ -49,7 +49,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestNewRequest(t *testing.T) {
-	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", ""}, testUserAgent, testAbsolutePath, false)
+	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", "", nil}, testUserAgent, testAbsolutePath, false)
 
 	if err != nil {
 		t.Errorf("Unexpected Error: %v", err)

--- a/client/foundation/foundation_api.go
+++ b/client/foundation/foundation_api.go
@@ -2,6 +2,7 @@ package foundation
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-nutanix/client"
 )
@@ -9,6 +10,7 @@ import (
 const (
 	absolutePath = "foundation"
 	userAgent    = "foundation"
+	clientName   = "foundation"
 )
 
 //Foundation client with its services
@@ -39,9 +41,10 @@ func NewFoundationAPIClient(credentials client.Credentials) (*Client, error) {
 		}
 		baseClient = c
 	} else {
+		errorMsg := fmt.Sprintf("Foundation Client is missing. "+
+			"Please provide required detail - %s in provider configuration.", strings.Join(credentials.RequiredFields[clientName], ", "))
 		// create empty client if required fields are not provided
-		baseClient = &client.Client{Error: "Foundation Client is missing. " +
-			"Please provide required detail - foundation_endpoint in provider configuration."}
+		baseClient = &client.Client{ErrorMsg: errorMsg}
 	}
 
 	//Fill user agent details

--- a/client/foundation/foundation_api.go
+++ b/client/foundation/foundation_api.go
@@ -40,7 +40,8 @@ func NewFoundationAPIClient(credentials client.Credentials) (*Client, error) {
 		baseClient = c
 	} else {
 		// create empty client if required fields are not provided
-		baseClient = &client.Client{}
+		baseClient = &client.Client{Error: "Foundation Client is missing. " +
+			"Please provide required detail - foundation_endpoint in provider configuration."}
 	}
 
 	//Fill user agent details

--- a/client/foundation/foundation_api.go
+++ b/client/foundation/foundation_api.go
@@ -29,27 +29,34 @@ type Client struct {
 
 //This routine returns new Foundation API Client
 func NewFoundationAPIClient(credentials client.Credentials) (*Client, error) {
-	//for foundation client, url should be based on foundation's endpoint and port
-	credentials.URL = fmt.Sprintf("%s:%s", credentials.FoundationEndpoint, credentials.FoundationPort)
-	client, err := client.NewBaseClient(&credentials, absolutePath, true)
 
-	if err != nil {
-		return nil, err
+	var baseClient *client.Client
+	if credentials.FoundationEndpoint != "" {
+		// for foundation client, url should be based on foundation's endpoint and port
+		credentials.URL = fmt.Sprintf("%s:%s", credentials.FoundationEndpoint, credentials.FoundationPort)
+		c, err := client.NewBaseClient(&credentials, absolutePath, true)
+		if err != nil {
+			return nil, err
+		}
+		baseClient = c
+	} else {
+		// create empty client if required fields are not provided
+		baseClient = &client.Client{}
 	}
 
 	//Fill user agent details
-	client.UserAgent = userAgent
+	baseClient.UserAgent = userAgent
 
 	foundationClient := &Client{
-		client: client,
+		client: baseClient,
 		NodeImaging: NodeImagingOperations{
-			client: client,
+			client: baseClient,
 		},
 		FileManagement: FileManagementOperations{
-			client: client,
+			client: baseClient,
 		},
 		Networking: NetworkingOperations{
-			client: client,
+			client: baseClient,
 		},
 	}
 	return foundationClient, nil

--- a/client/foundation/foundation_api.go
+++ b/client/foundation/foundation_api.go
@@ -29,7 +29,6 @@ type Client struct {
 
 //This routine returns new Foundation API Client
 func NewFoundationAPIClient(credentials client.Credentials) (*Client, error) {
-
 	var baseClient *client.Client
 	if credentials.FoundationEndpoint != "" {
 		// for foundation client, url should be based on foundation's endpoint and port

--- a/client/karbon/karbon_api.go
+++ b/client/karbon/karbon_api.go
@@ -29,7 +29,9 @@ func NewKarbonAPIClient(credentials client.Credentials) (*Client, error) {
 		}
 		baseClient = c
 	} else {
-		baseClient = &client.Client{UserAgent: userAgent}
+		baseClient = &client.Client{UserAgent: userAgent, Error: "Karbon Client is missing. " +
+			"Please provide required details - username, password & endpoint" +
+			" in provider configuration."}
 	}
 
 	f := &Client{

--- a/client/karbon/karbon_api.go
+++ b/client/karbon/karbon_api.go
@@ -1,12 +1,16 @@
 package karbon
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/terraform-providers/terraform-provider-nutanix/client"
 )
 
 const (
 	absolutePath = "karbon"
 	userAgent    = "nutanix"
+	clientName   = "karbon"
 )
 
 // Client manages the V3 API
@@ -29,9 +33,9 @@ func NewKarbonAPIClient(credentials client.Credentials) (*Client, error) {
 		}
 		baseClient = c
 	} else {
-		baseClient = &client.Client{UserAgent: userAgent, Error: "Karbon Client is missing. " +
-			"Please provide required details - username, password & endpoint" +
-			" in provider configuration."}
+		errorMsg := fmt.Sprintf("karbon Client is missing. "+
+			"Please provide required detail - %s in provider configuration.", strings.Join(credentials.RequiredFields[clientName], ", "))
+		baseClient = &client.Client{UserAgent: userAgent, ErrorMsg: errorMsg}
 	}
 
 	f := &Client{

--- a/client/karbon/karbon_api.go
+++ b/client/karbon/karbon_api.go
@@ -19,22 +19,29 @@ type Client struct {
 
 // NewKarbonAPIClient return a client to operate Karbon resources
 func NewKarbonAPIClient(credentials client.Credentials) (*Client, error) {
-	c, err := client.NewClient(&credentials, userAgent, absolutePath, false)
+	var baseClient *client.Client
 
-	if err != nil {
-		return nil, err
+	// check if all required fields are present. Else create an empty client
+	if credentials.Username != "" && credentials.Password != "" && credentials.Endpoint != "" {
+		c, err := client.NewClient(&credentials, userAgent, absolutePath, false)
+		if err != nil {
+			return nil, err
+		}
+		baseClient = c
+	} else {
+		baseClient = &client.Client{UserAgent: userAgent}
 	}
 
 	f := &Client{
-		client: c,
+		client: baseClient,
 		Cluster: ClusterOperations{
-			client: c,
+			client: baseClient,
 		},
 		PrivateRegistry: PrivateRegistryOperations{
-			client: c,
+			client: baseClient,
 		},
 		Meta: MetaOperations{
-			client: c,
+			client: baseClient,
 		},
 	}
 

--- a/client/v3/v3.go
+++ b/client/v3/v3.go
@@ -28,7 +28,9 @@ func NewV3Client(credentials client.Credentials) (*Client, error) {
 		}
 		baseClient = c
 	} else {
-		baseClient = &client.Client{UserAgent: userAgent}
+		baseClient = &client.Client{UserAgent: userAgent, Error: "nutanix pc Client is missing. " +
+			"Please provide required details - username, password & endpoint" +
+			" in provider configuration."}
 	}
 
 	f := &Client{

--- a/client/v3/v3.go
+++ b/client/v3/v3.go
@@ -18,16 +18,23 @@ type Client struct {
 
 // NewV3Client return a client to operate V3 resources
 func NewV3Client(credentials client.Credentials) (*Client, error) {
-	c, err := client.NewClient(&credentials, userAgent, absolutePath, false)
+	var baseClient *client.Client
 
-	if err != nil {
-		return nil, err
+	// check if all required fields are present. Else create an empty client
+	if credentials.Username != "" && credentials.Password != "" && credentials.Endpoint != "" {
+		c, err := client.NewClient(&credentials, userAgent, absolutePath, false)
+		if err != nil {
+			return nil, err
+		}
+		baseClient = c
+	} else {
+		baseClient = &client.Client{UserAgent: userAgent}
 	}
 
 	f := &Client{
-		client: c,
+		client: baseClient,
 		V3: Operations{
-			client: c,
+			client: baseClient,
 		},
 	}
 

--- a/client/v3/v3.go
+++ b/client/v3/v3.go
@@ -1,6 +1,9 @@
 package v3
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/terraform-providers/terraform-provider-nutanix/client"
 )
 
@@ -8,6 +11,7 @@ const (
 	libraryVersion = "v3"
 	absolutePath   = "api/nutanix/" + libraryVersion
 	userAgent      = "nutanix/" + libraryVersion
+	clientName     = "prism central"
 )
 
 // Client manages the V3 API
@@ -28,9 +32,10 @@ func NewV3Client(credentials client.Credentials) (*Client, error) {
 		}
 		baseClient = c
 	} else {
-		baseClient = &client.Client{UserAgent: userAgent, Error: "nutanix pc Client is missing. " +
-			"Please provide required details - username, password & endpoint" +
-			" in provider configuration."}
+		errorMsg := fmt.Sprintf("Prism Central (PC) Client is missing. "+
+			"Please provide required detail - %s in provider configuration.", strings.Join(credentials.RequiredFields[clientName], ", "))
+
+		baseClient = &client.Client{UserAgent: userAgent, ErrorMsg: errorMsg}
 	}
 
 	f := &Client{

--- a/client/v3/v3_service_test.go
+++ b/client/v3/v3_service_test.go
@@ -24,7 +24,7 @@ func setup() (*http.ServeMux, *client.Client, *httptest.Server) {
 		Username: "username",
 		Password: "password",
 		Port:     "",
-		Endpoint: "",
+		Endpoint: "0.0.0.0",
 		Insecure: true},
 		userAgent,
 		absolutePath,

--- a/client/v3/v3_test.go
+++ b/client/v3/v3_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 func TestNewV3Client(t *testing.T) {
-	cred := client.Credentials{URL: "foo.com", Username: "username", Password: "password", Port: "", Endpoint: "", Insecure: true}
+	cred := client.Credentials{URL: "foo.com", Username: "username", Password: "password", Port: "", Endpoint: "0.0.0.0", Insecure: true}
 	c, _ := NewV3Client(cred)
 
-	cred2 := client.Credentials{URL: "^^^", Username: "username", Password: "password", Port: "", Endpoint: "", Insecure: true}
+	cred2 := client.Credentials{URL: "^^^", Username: "username", Password: "password", Port: "", Endpoint: "0.0.0.0", Insecure: true}
 	c2, _ := NewV3Client(cred2)
 
 	type args struct {

--- a/nutanix/config.go
+++ b/nutanix/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	ProxyURL           string
 	FoundationEndpoint string
 	FoundationPort     string
+	RequiredFields     map[string][]string
 }
 
 // Client ...
@@ -39,6 +40,7 @@ func (c *Config) Client() (*Client, error) {
 		ProxyURL:           c.ProxyURL,
 		FoundationEndpoint: c.FoundationEndpoint,
 		FoundationPort:     c.FoundationPort,
+		RequiredFields:     c.RequiredFields,
 	}
 
 	v3Client, err := v3.NewV3Client(configCreds)

--- a/nutanix/provider.go
+++ b/nutanix/provider.go
@@ -178,9 +178,9 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	// Return error if both foundation and pc connection related fields are empty
 	if (username == "" || password == "" || endpoint == "") && (foundationEndpoint == "") {
-		return nil, fmt.Errorf("please provide required provider configuration for atleast PC connection or foundation. " +
-			"The required fields of PC connection are username, password and endpoint. " +
-			"The required fields for foundation is foundation_endpoint.")
+		return nil, fmt.Errorf("please provide required provider configuration for atleast PC connection or foundation " +
+			"The required fields of PC connection are username, password and endpoint " +
+			"The required fields for foundation is foundation_endpoint")
 	}
 
 	config := Config{

--- a/nutanix/provider.go
+++ b/nutanix/provider.go
@@ -178,7 +178,9 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	// Return error if both foundation and pc connection related fields are empty
 	if (username == "" || password == "" || endpoint == "") && (foundationEndpoint == "") {
-		return nil, fmt.Errorf("please provide required provider configuration for atleast PC connection or foundation. The required fields of PC connection are username, password and endpoint. The required fields for foundation is foundation_endpoint")
+		return nil, fmt.Errorf("please provide required provider configuration for atleast PC connection or foundation. " +
+			"The required fields of PC connection are username, password and endpoint. " +
+			"The required fields for foundation is foundation_endpoint.")
 	}
 
 	config := Config{

--- a/nutanix/provider.go
+++ b/nutanix/provider.go
@@ -10,6 +10,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+var requiredProviderFields map[string][]string = map[string][]string{
+	"prism central": {"username", "password", "endpoint"},
+	"karbon":        {"username", "password", "endpoint"},
+	"foundation":    {"foundation_endpoint"},
+}
+
 // Provider function returns the object that implements the terraform.ResourceProvider interface, specifically a schema.Provider
 func Provider() *schema.Provider {
 	// defines descriptions for ResourceProvider schema definitions
@@ -174,11 +180,6 @@ func Provider() *schema.Provider {
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	log.Printf("[DEBUG] config wait_timeout %d", d.Get("wait_timeout").(int))
 
-	// required fields for individual provider service
-	requiredProviderFields := map[string][]string{
-		"Prism Central & Karbon": {"username", "password", "endpoint"},
-		"Foundation":             {"foundation_endpoint"},
-	}
 	disabledProviders := make([]string, 0)
 	// create warnings for disabled provider services
 	var diags diag.Diagnostics
@@ -216,6 +217,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		ProxyURL:           d.Get("proxy_url").(string),
 		FoundationEndpoint: d.Get("foundation_endpoint").(string),
 		FoundationPort:     d.Get("foundation_port").(string),
+		RequiredFields:     requiredProviderFields,
 	}
 	c, err := config.Client()
 	if err != nil {

--- a/nutanix/provider.go
+++ b/nutanix/provider.go
@@ -1,9 +1,12 @@
 package nutanix
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -162,39 +165,62 @@ func Provider() *schema.Provider {
 			"nutanix_foundation_ipmi_config":  resourceNutanixFoundationIPMIConfig(),
 			"nutanix_foundation_image":        resourceNutanixFoundationImage(),
 		},
-		ConfigureFunc: providerConfigure,
+		ConfigureContextFunc: providerConfigure,
 	}
 }
 
 // This function used to fetch the configuration params given to our provider which
 // we will use to initialize a dummy client that interacts with API.
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	log.Printf("[DEBUG] config wait_timeout %d", d.Get("wait_timeout").(int))
 
-	username := d.Get("username")
-	password := d.Get("password")
-	endpoint := d.Get("endpoint")
-	foundationEndpoint := d.Get("foundation_endpoint")
+	// required fields for individual provider service
+	requiredProviderFields := map[string][]string{
+		"Prism Central & Karbon": {"username", "password", "endpoint"},
+		"Foundation":             {"foundation_endpoint"},
+	}
+	disabledProviders := make([]string, 0)
+	// create warnings for disabled provider services
+	var diags diag.Diagnostics
+	for k, v := range requiredProviderFields {
+		// check if any field is not provided
+		for _, attr := range v {
+			// for string fields
+			if val, ok := d.Get(attr).(string); ok && val == "" {
+				disabledProviders = append(disabledProviders, k)
+				break
+			}
+			// for integer fields
+			if val, ok := d.Get(attr).(float64); ok && int64(val) == 0 {
+				disabledProviders = append(disabledProviders, k)
+				break
+			}
+		}
+	}
 
-	// Return error if both foundation and pc connection related fields are empty
-	if (username == "" || password == "" || endpoint == "") && (foundationEndpoint == "") {
-		return nil, fmt.Errorf("please provide required provider configuration for atleast PC connection or foundation " +
-			"The required fields of PC connection are username, password and endpoint " +
-			"The required fields for foundation is foundation_endpoint")
+	if len(disabledProviders) > 0 {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  fmt.Sprintf("Disabled Providers: %s. Please provide required fields in provider configuration to enable them. Refer docs.", strings.Join(disabledProviders, ", ")),
+		})
 	}
 
 	config := Config{
-		Endpoint:           endpoint.(string),
-		Username:           username.(string),
-		Password:           password.(string),
+		Endpoint:           d.Get("endpoint").(string),
+		Username:           d.Get("username").(string),
+		Password:           d.Get("password").(string),
 		Insecure:           d.Get("insecure").(bool),
 		SessionAuth:        d.Get("session_auth").(bool),
 		Port:               d.Get("port").(string),
 		WaitTimeout:        int64(d.Get("wait_timeout").(int)),
 		ProxyURL:           d.Get("proxy_url").(string),
-		FoundationEndpoint: foundationEndpoint.(string),
+		FoundationEndpoint: d.Get("foundation_endpoint").(string),
 		FoundationPort:     d.Get("foundation_port").(string),
 	}
+	c, err := config.Client()
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
 
-	return config.Client()
+	return c, diags
 }

--- a/nutanix/provider.go
+++ b/nutanix/provider.go
@@ -1,6 +1,7 @@
 package nutanix
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -39,13 +40,13 @@ func Provider() *schema.Provider {
 		Schema: map[string]*schema.Schema{
 			"username": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("NUTANIX_USERNAME", nil),
 				Description: descriptions["username"],
 			},
 			"password": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("NUTANIX_PASSWORD", nil),
 				Description: descriptions["password"],
 			},
@@ -70,7 +71,7 @@ func Provider() *schema.Provider {
 			},
 			"endpoint": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("NUTANIX_ENDPOINT", nil),
 				Description: descriptions["endpoint"],
 			},
@@ -95,6 +96,7 @@ func Provider() *schema.Provider {
 			"foundation_port": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Default:     "8000",
 				DefaultFunc: schema.EnvDefaultFunc("FOUNDATION_PORT", nil),
 				Description: descriptions["foundation_port"],
 			},
@@ -169,16 +171,26 @@ func Provider() *schema.Provider {
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	log.Printf("[DEBUG] config wait_timeout %d", d.Get("wait_timeout").(int))
 
+	username := d.Get("username")
+	password := d.Get("password")
+	endpoint := d.Get("endpoint")
+	foundationEndpoint := d.Get("foundation_endpoint")
+
+	// Return error if both foundation and pc connection related fields are empty
+	if (username == "" || password == "" || endpoint == "") && (foundationEndpoint == "") {
+		return nil, fmt.Errorf("please provide required provider configuration for atleast PC connection or foundation. The required fields of PC connection are username, password and endpoint. The required fields for foundation is foundation_endpoint")
+	}
+
 	config := Config{
-		Endpoint:           d.Get("endpoint").(string),
-		Username:           d.Get("username").(string),
-		Password:           d.Get("password").(string),
+		Endpoint:           endpoint.(string),
+		Username:           username.(string),
+		Password:           password.(string),
 		Insecure:           d.Get("insecure").(bool),
 		SessionAuth:        d.Get("session_auth").(bool),
 		Port:               d.Get("port").(string),
 		WaitTimeout:        int64(d.Get("wait_timeout").(int)),
 		ProxyURL:           d.Get("proxy_url").(string),
-		FoundationEndpoint: d.Get("foundation_endpoint").(string),
+		FoundationEndpoint: foundationEndpoint.(string),
 		FoundationPort:     d.Get("foundation_port").(string),
 	}
 


### PR DESCRIPTION
Changes :
- Make PC connection details and Foundation details optional in provider configuration.
- Update client creation code to return empty client in case required details are not present.
- Raise warnings about disabled provider services as per the provider configuration fields
- Raise errors if certain resource is used without giving proper provider configuration fields required.
- Fix existing v3 tests to have some dummy endpoint value rather then "" because now there will be a case of empty client affected due to it as well.