### PR TITLE
Optimize Image upload to avoid buffering. Add cluster related fields in image upload resource & data source for PC

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -309,6 +309,10 @@ func (c *Client) NewUploadRequest(ctx context.Context, method, urlStr string, fi
 		return nil, err
 	}
 	req.ContentLength = fileInfo.Size()
+	req.GetBody = func() (io.ReadCloser, error) {
+		r := *fileReader
+		return io.NopCloser(&r), nil
+	}
 
 	req.Header.Add("Content-Type", octetStreamType)
 	req.Header.Add("Accept", mediaType)
@@ -346,6 +350,10 @@ func (c *Client) NewUnAuthUploadRequest(ctx context.Context, method, urlStr stri
 		return nil, err
 	}
 	req.ContentLength = fileInfo.Size()
+	req.GetBody = func() (io.ReadCloser, error) {
+		r := *fileReader
+		return io.NopCloser(&r), nil
+	}
 
 	req.Header.Add("Content-Type", octetStreamType)
 	req.Header.Add("Accept", mediaType)

--- a/client/client.go
+++ b/client/client.go
@@ -310,7 +310,7 @@ func (c *Client) NewUploadRequest(ctx context.Context, method, urlStr string, fi
 }
 
 // NewUploadRequest handles image uploads for image service
-func (c *Client) NewUnAuthUploadRequest(ctx context.Context, method, urlStr string, body []byte) (*http.Request, error) {
+func (c *Client) NewUnAuthUploadRequest(ctx context.Context, method, urlStr string, file *os.File) (*http.Request, error) {
 	// check if client exists or not
 	if c.client == nil {
 		return nil, fmt.Errorf(c.ErrorMsg)
@@ -322,9 +322,7 @@ func (c *Client) NewUnAuthUploadRequest(ctx context.Context, method, urlStr stri
 
 	u := c.BaseURL.ResolveReference(rel)
 
-	buf := bytes.NewBuffer(body)
-
-	req, err := http.NewRequest(method, u.String(), buf)
+	req, err := http.NewRequest(method, u.String(), file)
 
 	if err != nil {
 		return nil, err

--- a/client/client.go
+++ b/client/client.go
@@ -301,8 +301,8 @@ func (c *Client) NewUploadRequest(ctx context.Context, method, urlStr string, fi
 		return nil, err
 	}
 
-	// Set req.ContentLength by reading file size, as we send *os.File in http.NewRequest()
-	// http.NewRequest() only sets content length value for types - bytes.Buffer, bytes.Reader and strings.Reader
+	// Set req.ContentLength and req.GetBody as internally there is no implementation of such for os.File type reader
+	// http.NewRequest() only sets this values for types - bytes.Buffer, bytes.Reader and strings.Reader
 	// Refer https://github.com/golang/go/blob/a0f77e56b7a7ecb92dca3e2afdd56ee773c2cb07/src/net/http/request.go#L896
 	fileInfo, err := fileReader.Stat()
 	if err != nil {
@@ -310,8 +310,7 @@ func (c *Client) NewUploadRequest(ctx context.Context, method, urlStr string, fi
 	}
 	req.ContentLength = fileInfo.Size()
 	req.GetBody = func() (io.ReadCloser, error) {
-		r := *fileReader
-		return io.NopCloser(&r), nil
+		return io.NopCloser(fileReader), nil
 	}
 
 	req.Header.Add("Content-Type", octetStreamType)
@@ -342,8 +341,8 @@ func (c *Client) NewUnAuthUploadRequest(ctx context.Context, method, urlStr stri
 		return nil, err
 	}
 
-	// Set req.ContentLength by reading file size, as we send *os.File in http.NewRequest()
-	// http.NewRequest() only sets content length value for types - bytes.Buffer, bytes.Reader and strings.Reader
+	// Set req.ContentLength and req.GetBody as internally there is no implementation of such for os.File type reader
+	// http.NewRequest() only sets this values for types - bytes.Buffer, bytes.Reader and strings.Reader
 	// Refer https://github.com/golang/go/blob/a0f77e56b7a7ecb92dca3e2afdd56ee773c2cb07/src/net/http/request.go#L896
 	fileInfo, err := fileReader.Stat()
 	if err != nil {
@@ -351,8 +350,7 @@ func (c *Client) NewUnAuthUploadRequest(ctx context.Context, method, urlStr stri
 	}
 	req.ContentLength = fileInfo.Size()
 	req.GetBody = func() (io.ReadCloser, error) {
-		r := *fileReader
-		return io.NopCloser(&r), nil
+		return io.NopCloser(fileReader), nil
 	}
 
 	req.Header.Add("Content-Type", octetStreamType)

--- a/client/client.go
+++ b/client/client.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/PaesslerAG/jsonpath"
@@ -281,7 +282,7 @@ func (c *Client) NewUnAuthFormEncodedRequest(ctx context.Context, method, urlStr
 }
 
 // NewUploadRequest Handles image uploads for image service
-func (c *Client) NewUploadRequest(ctx context.Context, method, urlStr string, body []byte) (*http.Request, error) {
+func (c *Client) NewUploadRequest(ctx context.Context, method, urlStr string, fileReader *os.File) (*http.Request, error) {
 	// check if client exists or not
 	if c.client == nil {
 		return nil, fmt.Errorf(c.ErrorMsg)
@@ -293,9 +294,7 @@ func (c *Client) NewUploadRequest(ctx context.Context, method, urlStr string, bo
 
 	u := c.BaseURL.ResolveReference(rel)
 
-	buf := bytes.NewBuffer(body)
-
-	req, err := http.NewRequest(method, u.String(), buf)
+	req, err := http.NewRequest(method, u.String(), fileReader)
 
 	if err != nil {
 		return nil, err

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"reflect"
 	"regexp"
 	"strings"
@@ -362,7 +363,7 @@ func TestClient_NewUploadRequest(t *testing.T) {
 		ctx    context.Context
 		method string
 		urlStr string
-		body   []byte
+		file   *os.File
 	}
 
 	tests := []struct {
@@ -385,7 +386,7 @@ func TestClient_NewUploadRequest(t *testing.T) {
 				UserAgent:          tt.fields.UserAgent,
 				onRequestCompleted: tt.fields.onRequestCompleted,
 			}
-			got, err := c.NewUploadRequest(tt.args.ctx, tt.args.method, tt.args.urlStr, tt.args.body)
+			got, err := c.NewUploadRequest(tt.args.ctx, tt.args.method, tt.args.urlStr, tt.args.file)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Client.NewUploadRequest() error = %v, wantErr %v", err, tt.wantErr)
 

--- a/client/foundation/foundation_file_management_service.go
+++ b/client/foundation/foundation_file_management_service.go
@@ -3,7 +3,6 @@ package foundation
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -56,13 +55,7 @@ func (fmo FileManagementOperations) UploadImage(ctx context.Context, installerTy
 	}
 	defer file.Close()
 
-	// read file as slice of bytes
-	fileContents, err := ioutil.ReadAll(file)
-	if err != nil {
-		return nil, fmt.Errorf("error while reading file: %s", err)
-	}
-
-	req, err := fmo.client.NewUnAuthUploadRequest(ctx, http.MethodPost, path, fileContents)
+	req, err := fmo.client.NewUnAuthUploadRequest(ctx, http.MethodPost, path, file)
 	if err != nil {
 		return nil, err
 	}

--- a/client/v3/v3_service.go
+++ b/client/v3/v3_service.go
@@ -3,7 +3,6 @@ package v3
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -367,12 +366,7 @@ func (op Operations) UploadImage(uuid, filepath string) error {
 	}
 	defer file.Close()
 
-	fileContents, err := ioutil.ReadAll(file)
-	if err != nil {
-		return fmt.Errorf("error: Cannot read file %s", err)
-	}
-
-	req, err := op.client.NewUploadRequest(ctx, http.MethodPut, path, fileContents)
+	req, err := op.client.NewUploadRequest(ctx, http.MethodPut, path, file)
 
 	if err != nil {
 		return fmt.Errorf("error: Creating request %s", err)

--- a/client/v3/v3_structs.go
+++ b/client/v3/v3_structs.go
@@ -996,6 +996,9 @@ type ImageResourcesDefStatus struct {
 	// Cluster reference lists
 	InitialPlacementRefList []*ReferenceValues `json:"initial_placement_ref_list,omitempty" mapstructure:"initial_placement_ref_list, omitempty"`
 
+	// cluster reference list when request was made without refs
+	CurrentClusterReferenceList []*ReferenceValues `json:"current_cluster_reference_list,omitempty" mapstructure:"current_cluster_reference_list, omitempty"`
+
 	// The image version
 	Version *ImageVersionStatus `json:"version,omitempty" mapstructure:"version,omitempty"`
 }

--- a/client/v3/v3_structs.go
+++ b/client/v3/v3_structs.go
@@ -885,6 +885,9 @@ type ImageResources struct {
 	// The image version
 	Version *ImageVersionResources `json:"version,omitempty" mapstructure:"version,omitempty"`
 
+	// Cluster reference lists
+	InitialPlacementRefList []*ReferenceValues `json:"initial_placement_ref_list,omitempty" mapstructure:"initial_placement_ref_list, omitempty"`
+
 	// Reference to the source image such as 'vm_disk
 	DataSourceReference *Reference `json:"data_source_reference,omitempty" mapstructure:"data_source_reference,omitempty"`
 }
@@ -989,6 +992,9 @@ type ImageResourcesDefStatus struct {
 
 	// The source URI points at the location of a the source image which is used to create/update image.
 	SourceURI *string `json:"source_uri,omitempty" mapstructure:"source_uri,omitempty"`
+
+	// Cluster reference lists
+	InitialPlacementRefList []*ReferenceValues `json:"initial_placement_ref_list,omitempty" mapstructure:"initial_placement_ref_list, omitempty"`
 
 	// The image version
 	Version *ImageVersionStatus `json:"version,omitempty" mapstructure:"version,omitempty"`

--- a/nutanix/data_source_nutanix_image.go
+++ b/nutanix/data_source_nutanix_image.go
@@ -91,6 +91,46 @@ func dataSourceNutanixImage() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"cluster_references": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"current_cluster_reference_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"image_type": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -165,6 +205,15 @@ func dataSourceNutanixImageRead(ctx context.Context, d *schema.ResourceData, met
 	if err := d.Set("availability_zone_reference", flattenReferenceValues(resp.Status.AvailabilityZoneReference)); err != nil {
 		return diag.FromErr(err)
 	}
+
+	if err := d.Set("cluster_references", flattenArrayOfReferenceValues(resp.Status.Resources.InitialPlacementRefList)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("current_cluster_reference_list", flattenArrayOfReferenceValues(resp.Status.Resources.CurrentClusterReferenceList)); err != nil {
+		return diag.FromErr(err)
+	}
+
 	if err := flattenClusterReference(resp.Status.ClusterReference, d); err != nil {
 		return diag.FromErr(err)
 	}
@@ -300,6 +349,46 @@ func resourceNutanixDatasourceImageInstanceResourceV0() *schema.Resource {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"cluster_references": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"current_cluster_reference_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"image_type": {
 				Type:     schema.TypeString,

--- a/nutanix/helpers.go
+++ b/nutanix/helpers.go
@@ -265,6 +265,31 @@ func validateArrayRef(references interface{}, kindValue *string) []*v3.Reference
 	return nil
 }
 
+func validateArrayRefValues(references interface{}, kindValue string) []*v3.ReferenceValues {
+	refs := make([]*v3.ReferenceValues, 0)
+
+	for _, s := range references.([]interface{}) {
+		ref := s.(map[string]interface{})
+		r := v3.ReferenceValues{}
+
+		if kindValue != "" {
+			r.Kind = kindValue
+		} else {
+			r.Kind = ref["kind"].(string)
+		}
+
+		r.UUID = ref["uuid"].(string)
+		r.Name = ref["name"].(string)
+
+		refs = append(refs, &r)
+	}
+	if len(refs) > 0 {
+		return refs
+	}
+
+	return nil
+}
+
 func flattenArrayReferenceValues(refs []*v3.Reference) []map[string]interface{} {
 	references := make([]map[string]interface{}, 0)
 	for _, r := range refs {
@@ -326,6 +351,23 @@ func flattenReferenceValuesList(r *v3.Reference) []interface{} {
 		}
 
 		references = append(references, reference)
+	}
+	return references
+}
+
+func flattenArrayOfReferenceValues(refs []*v3.ReferenceValues) []map[string]interface{} {
+	references := make([]map[string]interface{}, 0)
+	for _, r := range refs {
+		reference := make(map[string]interface{})
+		if r != nil {
+			reference["kind"] = r.Kind
+			reference["uuid"] = r.UUID
+
+			if r.Name != "" {
+				reference["name"] = r.Name
+			}
+			references = append(references, reference)
+		}
 	}
 	return references
 }

--- a/nutanix/resource_nutanix_image.go
+++ b/nutanix/resource_nutanix_image.go
@@ -120,8 +120,45 @@ func resourceNutanixImage() *schema.Resource {
 				Type:     schema.TypeList,
 				Computed: true,
 				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"current_cluster_reference_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"image_type": {
 				Type:     schema.TypeString,
@@ -346,13 +383,12 @@ func resourceNutanixImageRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("error setting retrieval_uri_list for image UUID(%s), %s", d.Id(), err)
 	}
 
-	clusterList := make([]string, 0, len(resp.Status.Resources.InitialPlacementRefList))
-	for _, ref := range resp.Status.Resources.InitialPlacementRefList {
-		clusterList = append(clusterList, ref.UUID)
+	if err := d.Set("cluster_references", flattenArrayOfReferenceValues(resp.Status.Resources.InitialPlacementRefList)); err != nil {
+		return diag.FromErr(err)
 	}
 
-	if err = d.Set("cluster_references", clusterList); err != nil {
-		return diag.Errorf("error setting cluster_references for image UUID(%s), %s", d.Id(), err)
+	if err := d.Set("current_cluster_reference_list", flattenArrayOfReferenceValues(resp.Status.Resources.CurrentClusterReferenceList)); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return nil
@@ -536,15 +572,9 @@ func getImageResource(d *schema.ResourceData, image *v3.ImageResources) error {
 		image.Checksum = checks
 	}
 
-	// set image placement policies for given clusters
+	// List of clusters where image is requested to be placed at time of creation
 	if refs, refsok := d.GetOk("cluster_references"); refsok && len(refs.([]interface{})) > 0 {
-		r := refs.([]interface{})
-		image.InitialPlacementRefList = make([]*v3.ReferenceValues, len(r))
-		for k, v := range r {
-			reference := &v3.ReferenceValues{}
-			reference.UUID = v.(string)
-			image.InitialPlacementRefList[k] = reference
-		}
+		image.InitialPlacementRefList = validateArrayRefValues(refs, "cluster")
 	}
 
 	return nil
@@ -627,8 +657,45 @@ func resourceNutanixImageInstanceResourceV0() *schema.Resource {
 				Type:     schema.TypeList,
 				Computed: true,
 				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"current_cluster_reference_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"image_type": {
 				Type:     schema.TypeString,

--- a/nutanix/resource_nutanix_image.go
+++ b/nutanix/resource_nutanix_image.go
@@ -134,7 +134,6 @@ func resourceNutanixImage() *schema.Resource {
 						},
 						"name": {
 							Type:     schema.TypeString,
-							Optional: true,
 							Computed: true,
 						},
 					},
@@ -671,7 +670,6 @@ func resourceNutanixImageInstanceResourceV0() *schema.Resource {
 						},
 						"name": {
 							Type:     schema.TypeString,
-							Optional: true,
 							Computed: true,
 						},
 					},

--- a/nutanix/resource_nutanix_image_test.go
+++ b/nutanix/resource_nutanix_image_test.go
@@ -70,7 +70,7 @@ func TestAccNutanixImage_Update(t *testing.T) {
 	})
 }
 
-func TestAccNutanixImage_WithCategories(t *testing.T) {
+func TestAccNutanixImage_WithCategoriesAndCluster(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "nutanix_image.acctest-test-categories"
 
@@ -298,6 +298,15 @@ resource "nutanix_category_value" "ubuntu"{
 	value = "ubuntu"
 }
 
+data "nutanix_clusters" "clusters"{}
+
+locals {
+	cluster1 = [
+	  for cluster in data.nutanix_clusters.clusters.entities :
+	  cluster.metadata.uuid if cluster.service_list[0] != "PRISM_CENTRAL"
+	][0]
+}
+
 resource "nutanix_image" "acctest-test-categories" {
   name        = "Ubuntu-%d"
   description = "Ubuntu"
@@ -310,6 +319,10 @@ resource "nutanix_image" "acctest-test-categories" {
  categories {
 	name  = nutanix_category_key.os_version.id
 	value =	nutanix_category_value.os_version_value.id
+ }
+
+ cluster_references{
+	 uuid = local.cluster1
  }
 
   source_uri  = "http://archive.ubuntu.com/ubuntu/dists/bionic/main/installer-amd64/current/images/netboot/mini.iso"
@@ -348,6 +361,14 @@ resource "nutanix_category_value" "ubuntu"{
 	value = "ubuntu"
 }
 
+data "nutanix_clusters" "clusters"{}
+
+locals {
+	cluster1 = [
+	  for cluster in data.nutanix_clusters.clusters.entities :
+	  cluster.metadata.uuid if cluster.service_list[0] != "PRISM_CENTRAL"
+	][0]
+}
 
 resource "nutanix_image" "acctest-test-categories" {
   	name        = "Ubuntu-%d"
@@ -361,6 +382,10 @@ resource "nutanix_image" "acctest-test-categories" {
 	categories {
 	   name  = nutanix_category_key.os_version.id
 	   value = nutanix_category_value.os_version_value_updated.id
+	}
+
+	cluster_references{
+		uuid = local.cluster1
 	}
 
   	source_uri  = "http://archive.ubuntu.com/ubuntu/dists/bionic/main/installer-amd64/current/images/netboot/mini.iso"


### PR DESCRIPTION
New additions: 
1. Directly used os.File as input to http.NewRequest() and added implementation for setting content length & GetBody values for req{} as there is no implementation in http.NewRequest() for os.File type .
2. Added cluster related fields in image upload resource and data source for PC to upload image to particular cluster in multicluster setup