### PR TITLE
Foundation Acceptance tests and minor fixes

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -20,42 +20,7 @@ jobs:
         with:
           go-version: 1.17
       - name: Acceptance test cases
-        run: |
-              args=${{ github.event.client_payload.slash_command.args.unnamed.all }}
-              providers=(${args})
-              index=0
-              n=${#providers[@]}
-              runFlag=""
-              for provider in $args
-              do 
-                  if [ "$provider" = "foundation" ]
-                      then 
-                          runFlag+="TestAccFoundation*"
-                  elif [ "$provider" = "foundation_central" ]
-                      then
-                          runFlag+="TestAccFC*"
-                  elif [ "$provider" = "karbon" ]
-                      then
-                          runFlag+="TestAccKarbon*"
-                  elif [ "$provider" = "pc" ]
-                      then
-                          runFlag+="TestAccNutanix*"
-                  else 
-                          echo "Invalid provider=$provider given in arguments."
-                          exit 1
-                  fi
-                  if [ $index -lt $((n-1)) ]
-                      then
-                          runFlag+="|"
-                  fi
-                  index=$((index+1))
-              done
-              export TESTARGS='-run="'$runFlag'"'
-              echo ${{ github.event.client_payload.slash_command.args.unnamed.all }}
-              echo "Running make testacc with test arguments as $TESTARGS"
-              echo "Foundation config is ${{ secrets.FOUNDATION_CONFIG }}"
-              echo $TESTARGS
-              echo pwd
+        run: ${{ secrets.ACCEPTANCE_TEST_ARGS }} make testacc
       - name: Code Coverage Check
         run:  |
               echo "Code coverage: Checking if code coverage is above threshold..."

--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -20,7 +20,40 @@ jobs:
         with:
           go-version: 1.17
       - name: Acceptance test cases
-        run: ${{ secrets.ACCEPTANCE_TEST_ARGS }} make testacc
+        run: |
+              args=${{ github.event.client_payload.slash_command.args.unnamed.all }}
+              providers=(${args})
+              index=0
+              n=${#providers[@]}
+              runFlag=""
+              for provider in $args
+              do 
+                  if [ "$provider" = "foundation" ]
+                      then 
+                          runFlag+="TestAccFoundation*"
+                  elif [ "$provider" = "foundation_central" ]
+                      then
+                          runFlag+="TestAccFC*"
+                  elif [ "$provider" = "karbon" ]
+                      then
+                          runFlag+="TestAccKarbon*"
+                  elif [ "$provider" = "pc" ]
+                      then
+                          runFlag+="TestAccNutanix*"
+                  else 
+                          echo "Invalid provider=$provider given in arguments."
+                          exit 1
+                  fi
+                  if [ $index -lt $((n-1)) ]
+                      then
+                          runFlag+="|"
+                  fi
+                  index=$((index+1))
+              done
+              export TESTARGS='-run="'$runFlag'"'
+              echo "Running make testacc with test arguments as $TESTARGS"
+              ${{ secrets.CONFIG }} echo $config > test_foundation_config.json
+              ${{ secrets.ACCEPTANCE_TEST_ARGS }} make testacc
       - name: Code Coverage Check
         run:  |
               echo "Code coverage: Checking if code coverage is above threshold..."

--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -55,6 +55,7 @@ jobs:
               echo "Running make testacc with test arguments as $TESTARGS"
               echo "Foundation config is ${{ secrets.FOUNDATION_CONFIG }}"
               echo $TESTARGS
+              echo pwd
       - name: Code Coverage Check
         run:  |
               echo "Code coverage: Checking if code coverage is above threshold..."

--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -51,9 +51,10 @@ jobs:
                   index=$((index+1))
               done
               export TESTARGS='-run="'$runFlag'"'
+              echo ${{ github.event.client_payload.slash_command.args.unnamed.all }}
               echo "Running make testacc with test arguments as $TESTARGS"
-              echo ${{ secrets.FOUNDATION_CONFIG }} > test_foundation_config.json
-              ${{ secrets.ACCEPTANCE_TEST_ARGS }} make testacc
+              echo "Foundation config is ${{ secrets.FOUNDATION_CONFIG }}"
+              echo $TESTARGS
       - name: Code Coverage Check
         run:  |
               echo "Code coverage: Checking if code coverage is above threshold..."

--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -52,7 +52,7 @@ jobs:
               done
               export TESTARGS='-run="'$runFlag'"'
               echo "Running make testacc with test arguments as $TESTARGS"
-              ${{ secrets.CONFIG }} echo $config > test_foundation_config.json
+              echo ${{ secrets.FOUNDATION_CONFIG }} > test_foundation_config.json
               ${{ secrets.ACCEPTANCE_TEST_ARGS }} make testacc
       - name: Code Coverage Check
         run:  |

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,7 +9,7 @@ build: fmtcheck
 	go install
 
 test: fmtcheck
-	go test $(TEST) -timeout=30s -parallel=4
+	go test --tags=unit $(TEST) -timeout=30s -parallel=4
 
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 200m -coverprofile c.out -covermode=count

--- a/nutanix/config_test.go
+++ b/nutanix/config_test.go
@@ -7,18 +7,22 @@ import (
 
 func TestConfig_Client(t *testing.T) {
 	type fields struct {
-		Endpoint string
-		Username string
-		Password string
-		Port     string
-		Insecure bool
+		Endpoint           string
+		Username           string
+		Password           string
+		Port               string
+		Insecure           bool
+		FoundationPort     string
+		FoundationEndpoint string
 	}
 	config := &Config{
-		Endpoint: "http://localhost",
-		Username: "test",
-		Password: "test",
-		Port:     "8080",
-		Insecure: true,
+		Endpoint:           "http://localhost",
+		Username:           "test",
+		Password:           "test",
+		Port:               "8080",
+		Insecure:           true,
+		FoundationPort:     "8000",
+		FoundationEndpoint: "0.0.0.0",
 	}
 
 	client, err := config.Client()
@@ -35,11 +39,13 @@ func TestConfig_Client(t *testing.T) {
 		{
 			name: "new client",
 			fields: fields{
-				Endpoint: "http://localhost",
-				Username: "test",
-				Password: "test",
-				Port:     "8080",
-				Insecure: true,
+				Endpoint:           "http://localhost",
+				Username:           "test",
+				Password:           "test",
+				Port:               "8080",
+				Insecure:           true,
+				FoundationPort:     "8000",
+				FoundationEndpoint: "0.0.0.0",
 			},
 			want:    client,
 			wantErr: false,
@@ -50,11 +56,13 @@ func TestConfig_Client(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Config{
-				Endpoint: tt.fields.Endpoint,
-				Username: tt.fields.Username,
-				Password: tt.fields.Password,
-				Port:     tt.fields.Port,
-				Insecure: tt.fields.Insecure,
+				Endpoint:           tt.fields.Endpoint,
+				Username:           tt.fields.Username,
+				Password:           tt.fields.Password,
+				Port:               tt.fields.Port,
+				Insecure:           tt.fields.Insecure,
+				FoundationEndpoint: tt.fields.FoundationEndpoint,
+				FoundationPort:     tt.fields.FoundationPort,
 			}
 			got, err := c.Client()
 			if (err != nil) != tt.wantErr {

--- a/nutanix/data_source_nutanix_assert_helper_test.go
+++ b/nutanix/data_source_nutanix_assert_helper_test.go
@@ -1,0 +1,38 @@
+package nutanix
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccNutanixAssertHelperDS(t *testing.T) {
+	name := "checks"
+	errorMsg := "Error message for nutanix assert helper"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccFoundationPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNutanixAssertHelperDS(name, "false", errorMsg),
+				ExpectError: regexp.MustCompile(errorMsg),
+			},
+			{
+				Config: testAccNutanixAssertHelperDS(name, "true", errorMsg),
+			},
+		},
+	})
+}
+
+func testAccNutanixAssertHelperDS(name, condition, errMsg string) string {
+	return fmt.Sprintf(`
+	data "nutanix_assert_helper" "%s" {
+		checks {
+			condition = %s
+			error_message = "%s"
+		}
+	}
+	`, name, condition, errMsg)
+}

--- a/nutanix/data_source_nutanix_foundation_discover_nodes_test.go
+++ b/nutanix/data_source_nutanix_foundation_discover_nodes_test.go
@@ -1,0 +1,31 @@
+package nutanix
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccFoundationDiscoverNodesDataSource(t *testing.T) {
+	name := "nodes"
+	resourcePath := "data.nutanix_foundation_discover_nodes." + name
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccFoundationPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDiscoverNodesConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourcePath, "entities.0.nodes.0.ipv6_address"),
+					resource.TestCheckResourceAttrSet(resourcePath, "entities.0.nodes.0.hypervisor"),
+					resource.TestCheckResourceAttrSet(resourcePath, "entities.0.block_id"),
+				),
+			},
+		},
+	})
+}
+
+func testDiscoverNodesConfig(name string) string {
+	return fmt.Sprintf(`data "nutanix_foundation_discover_nodes" "%s" {}`, name)
+}

--- a/nutanix/data_source_nutanix_foundation_hypervisor_isos_test.go
+++ b/nutanix/data_source_nutanix_foundation_hypervisor_isos_test.go
@@ -1,0 +1,30 @@
+package nutanix
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccFoundationHypervisorISOSDataSource(t *testing.T) {
+	name := "hypervisor_isos"
+	resourcePath := "data.nutanix_foundation_hypervisor_isos." + name
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccFoundationPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testHypervisorISOSDSConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourcePath, "kvm.0.filename"),
+					resource.TestCheckResourceAttrSet(resourcePath, "esx.0.filename"),
+				),
+			},
+		},
+	})
+}
+
+func testHypervisorISOSDSConfig(name string) string {
+	return fmt.Sprintf(`data "nutanix_foundation_hypervisor_isos" "%s" {}`, name)
+}

--- a/nutanix/data_source_nutanix_foundation_node_network_details_test.go
+++ b/nutanix/data_source_nutanix_foundation_node_network_details_test.go
@@ -1,0 +1,34 @@
+package nutanix
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccFoundationNodeNetworkDetailsDataSource(t *testing.T) {
+	name := "nodes"
+	resourcePath := "data.nutanix_foundation_node_network_details." + name
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccFoundationPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNodeNetworkDetailsConfig(name, foundationVars.IPv6Addresses),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourcePath, "nodes.#", "2"),
+					resource.TestCheckResourceAttrSet(resourcePath, "nodes.0.ipmi_ip"),
+					resource.TestCheckResourceAttrSet(resourcePath, "nodes.1.ipmi_ip"),
+				),
+			},
+		},
+	})
+}
+
+func testNodeNetworkDetailsConfig(name string, ipv6Addr []string) string {
+	return fmt.Sprintf(`
+	data "nutanix_foundation_node_network_details" "%s" {
+		ipv6_addresses = ["%s", "%s"]
+	}`, name, ipv6Addr[0], ipv6Addr[1])
+}

--- a/nutanix/data_source_nutanix_foundation_nos_packages_test.go
+++ b/nutanix/data_source_nutanix_foundation_nos_packages_test.go
@@ -1,0 +1,29 @@
+package nutanix
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccFoundationNosPackagesDataSource(t *testing.T) {
+	name := "nos_packages"
+	resourcePath := "data.nutanix_foundation_nos_packages." + name
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccFoundationPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNosPackagesDSConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourcePath, "entities.0"),
+				),
+			},
+		},
+	})
+}
+
+func testNosPackagesDSConfig(name string) string {
+	return fmt.Sprintf(`data "nutanix_foundation_nos_packages" "%s" {}`, name)
+}

--- a/nutanix/data_source_nutanix_karbon_cluster_kubeconfig_test.go
+++ b/nutanix/data_source_nutanix_karbon_cluster_kubeconfig_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccNutanixKarbonClusterKubeConfigDataSource_basic(t *testing.T) {
+func TestAccKarbonClusterKubeConfigDataSource_basic(t *testing.T) {
 	t.Skip()
 	r := acctest.RandInt()
 	subnetName := testVars.SubnetName
@@ -30,7 +30,7 @@ func TestAccNutanixKarbonClusterKubeConfigDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccNutanixKarbonClusterKubeConfigDataSource_basicByName(t *testing.T) {
+func TestAccKarbonClusterKubeConfigDataSource_basicByName(t *testing.T) {
 	r := acctest.RandInt()
 	subnetName := testVars.SubnetName
 	defaultContainter := testVars.DefaultContainerName

--- a/nutanix/data_source_nutanix_karbon_cluster_ssh_test.go
+++ b/nutanix/data_source_nutanix_karbon_cluster_ssh_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccNutanixKarbonClusterSSHDataSource_basicx(t *testing.T) {
+func TestAccKarbonClusterSSHDataSource_basicx(t *testing.T) {
 	t.Skip()
 	r := acctest.RandInt()
 	//resourceName := "nutanix_karbon_cluster.cluster"
@@ -30,7 +30,7 @@ func TestAccNutanixKarbonClusterSSHDataSource_basicx(t *testing.T) {
 	})
 }
 
-func TestAccNutanixKarbonClusterSSHDataSource_basicByName(t *testing.T) {
+func TestAccKarbonClusterSSHDataSource_basicByName(t *testing.T) {
 	r := acctest.RandInt()
 	//resourceName := "nutanix_karbon_cluster.cluster"
 	subnetName := testVars.SubnetName

--- a/nutanix/data_source_nutanix_karbon_cluster_test.go
+++ b/nutanix/data_source_nutanix_karbon_cluster_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccNutanixKarbonClusterDataSource_basic(t *testing.T) {
+func TestAccKarbonClusterDataSource_basic(t *testing.T) {
 	t.Skip()
 	r := acctest.RandInt()
 	dataSourceName := "data.nutanix_karbon_cluster.kcluster"
@@ -29,7 +29,7 @@ func TestAccNutanixKarbonClusterDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccNutanixKarbonClusterDataSource_basicByName(t *testing.T) {
+func TestAccKarbonClusterDataSource_basicByName(t *testing.T) {
 	r := acctest.RandInt()
 	//resourceName := "nutanix_karbon_cluster.cluster"
 	subnetName := testVars.SubnetName

--- a/nutanix/data_source_nutanix_karbon_clusters_test.go
+++ b/nutanix/data_source_nutanix_karbon_clusters_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccNutanixKarbonClustersDataSource_basic(t *testing.T) {
+func TestAccKarbonClustersDataSource_basic(t *testing.T) {
 	r := acctest.RandInt()
 	//resourceName := "nutanix_karbon_cluster.cluster"
 	subnetName := testVars.SubnetName

--- a/nutanix/internal/data_source_assert_helper.go
+++ b/nutanix/internal/data_source_assert_helper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -51,5 +52,6 @@ func dataSourceAssertLogic(ctx context.Context, d *schema.ResourceData, meta int
 	if len(diags) > 0 {
 		return diags
 	}
+	d.SetId(resource.UniqueId())
 	return nil
 }

--- a/nutanix/main_test.go
+++ b/nutanix/main_test.go
@@ -52,12 +52,12 @@ type FoundationVars struct {
 			CvmIP                   string `json:"cvm_ip"`
 			HypervisorIP            string `json:"hypervisor_ip"`
 			Hypervisor              string `json:"hypervisor"`
-			HypervisorHostname      string `json:"hypervisor_hostname`
+			HypervisorHostname      string `json:"hypervisor_hostname"`
 			NodePosition            string `json:"node_position"`
 			IPv6Address             string `json:"ipv6_address"`
 			CurrentNetworkInterface string `json:"current_network_interface"`
 		} `json:"nodes"`
-		BlockId           string `json:"block_id"`
+		BlockID           string `json:"block_id"`
 		CvmGateway        string `json:"cvm_gateway"`
 		HypervisorGateway string `json:"hypervisor_gateway"`
 		CvmNetmask        string `json:"cvm_netmask"`

--- a/nutanix/main_test.go
+++ b/nutanix/main_test.go
@@ -31,25 +31,62 @@ type TestConfig struct {
 	} `json:"ad_rule_target"`
 }
 
+type IPMIConfig struct {
+	IpmiGateway  string `json:"ipmi_gateway"`
+	IpmiNetmask  string `json:"ipmi_netmask"`
+	IpmiUser     string `json:"ipmi_user"`
+	IpmiPassword string `json:"ipmi_password"`
+	IpmiIP       string `json:"ipmi_ip"`
+	IpmiMac      string `json:"ipmi_mac"`
+}
+type FoundationVars struct {
+	IPv6Addresses []string   `json:"ipv6_addresses"`
+	IpmiConfig    IPMIConfig `json:"ipmi_config"`
+	Blocks        []struct {
+		Nodes []struct {
+			IpmiIP                  string `json:"ipmi_ip"`
+			IpmiPassword            string `json:"ipmi_password"`
+			IpmiUser                string `json:"ipmi_user"`
+			IpmiNetmask             string `json:"ipmi_netmask"`
+			IpmiGateway             string `json:"ipmi_gateway"`
+			CvmIP                   string `json:"cvm_ip"`
+			HypervisorIP            string `json:"hypervisor_ip"`
+			Hypervisor              string `json:"hypervisor"`
+			HypervisorHostname      string `json:"hypervisor_hostname`
+			NodePosition            string `json:"node_position"`
+			IPv6Address             string `json:"ipv6_address"`
+			CurrentNetworkInterface string `json:"current_network_interface"`
+		} `json:"nodes"`
+		BlockId           string `json:"block_id"`
+		CvmGateway        string `json:"cvm_gateway"`
+		HypervisorGateway string `json:"hypervisor_gateway"`
+		CvmNetmask        string `json:"cvm_netmask"`
+		HypervisorNetmask string `json:"hypervisor_netmask"`
+		IpmiUser          string `json:"ipmi_user"`
+	} `json:"blocks"`
+}
+
 var testVars TestConfig
+var foundationVars FoundationVars
 
-func TestMain(m *testing.M) {
-	log.Println("Do some crazy stuff before tests!")
-
+func loadVars(filepath string, varStuct interface{}) {
 	// Read config.json from home current path
-	configData, err := os.ReadFile("../test_config.json")
+	configData, err := os.ReadFile(filepath)
 	if err != nil {
 		log.Printf("Got this error while reading config.json: %s", err.Error())
 		os.Exit(1)
 	}
 
-	err = json.Unmarshal(configData, &testVars)
+	err = json.Unmarshal(configData, varStuct)
 	if err != nil {
 		log.Printf("Got this error while unmarshalling config.json: %s", err.Error())
 		os.Exit(1)
 	}
-
-	log.Println(testVars)
+}
+func TestMain(m *testing.M) {
+	log.Println("Do some crazy stuff before tests!")
+	loadVars("../test_config.json", &testVars)
+	loadVars("../test_foundation_config.json", &foundationVars)
 
 	os.Exit(m.Run())
 }

--- a/nutanix/provider_test.go
+++ b/nutanix/provider_test.go
@@ -42,6 +42,13 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
+func testAccFoundationPreCheck(t *testing.T) {
+	if os.Getenv("FOUNDATION_ENDPOINT") == "" ||
+		os.Getenv("FOUNDATION_PORT") == "" {
+		t.Fatal("`FOUNDATION_ENDPOINT` and `FOUNDATION_PORT` must be set for foundation acceptance testing")
+	}
+}
+
 func randIntBetween(min, max int) int {
 	rand.Seed(time.Now().UnixNano())
 	return rand.Intn(max-min) + min

--- a/nutanix/resource_nutanix_foundation_image_nodes.go
+++ b/nutanix/resource_nutanix_foundation_image_nodes.go
@@ -937,15 +937,15 @@ func resourceFoundationImageNodesCreate(ctx context.Context, d *schema.ResourceD
 	d.Set("session_id", resp.SessionID)
 
 	// set cluster urls in state file
-	cluster_urls := make([]map[string]interface{}, len(request.Clusters))
+	clusterURLs := make([]map[string]interface{}, len(request.Clusters))
 	for k, v := range request.Clusters {
 		c := map[string]interface{}{
 			"cluster_url":  fmt.Sprintf(ClusterURL, v.ClusterMembers[0]),
 			"cluster_name": v.ClusterName,
 		}
-		cluster_urls[k] = c
+		clusterURLs[k] = c
 	}
-	d.Set("cluster_urls", cluster_urls)
+	d.Set("cluster_urls", clusterURLs)
 	return nil
 }
 

--- a/nutanix/resource_nutanix_foundation_image_nodes_test.go
+++ b/nutanix/resource_nutanix_foundation_image_nodes_test.go
@@ -1,0 +1,197 @@
+package nutanix
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccFoundationImageNodesResource(t *testing.T) {
+	name := "batch1"
+	resourcePath := "nutanix_foundation_image_nodes." + name
+
+	// get file file path to config having nodes info
+	path, _ := os.Getwd()
+	filepath := path + "/../test_foundation_config.json"
+
+	// using block 0 in the test_foundation_config.json for this testcase
+	blockNum := 0
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccFoundationPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testImageNodesResource(filepath, blockNum, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourcePath, "session_id"),
+					resource.TestCheckResourceAttr(resourcePath, "cluster_urls.0.cluster_name", foundationVars.Blocks[0].Nodes[0].HypervisorHostname),
+				),
+			},
+		},
+	})
+}
+
+// Checks negative scenario for a given invalid nos file name
+func TestAccFoundationImageNodesResource_InvalidNosError(t *testing.T) {
+	name := "batch1"
+
+	// get file file path to config having nodes info
+	path, _ := os.Getwd()
+	filepath := path + "/../test_foundation_config.json"
+
+	// using block 0 in the test_foundation_config.json for this testcase
+	blockNum := 0
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccFoundationPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testImageNodesResource_InvalidNosError(filepath, blockNum, name),
+				ExpectError: regexp.MustCompile("Node imaging process failed due to error: Couldn't find nos_package at"),
+			},
+		},
+	})
+}
+
+func testImageNodesResource(filepath string, blockNum int, name string) string {
+	return fmt.Sprintf(`
+	data "nutanix_foundation_nos_packages" "nos"{}
+
+	locals{
+		config = (jsondecode(file("%s"))).blocks[%v]
+	}
+	
+	resource "nutanix_foundation_image_nodes" "%s" {
+	  timeouts {
+		create = "80m"
+	  }
+	  cvm_gateway = local.config.cvm_gateway
+	  hypervisor_gateway = local.config.hypervisor_gateway
+	  cvm_netmask = local.config.cvm_netmask
+	  hypervisor_netmask = local.config.cvm_netmask
+	  ipmi_user = local.config.ipmi_user
+	  nos_package = data.nutanix_foundation_nos_packages.nos.entities[0]
+	  blocks {
+		// manual mode using ipmi (Bare Metal, AOS or DOS nodes)
+		nodes{
+			cvm_ip = local.config.nodes[0].cvm_ip
+			hypervisor_ip = local.config.nodes[0].hypervisor_ip
+			hypervisor = local.config.nodes[0].hypervisor
+			hypervisor_hostname = local.config.nodes[0].hypervisor_hostname
+			ipmi_ip = local.config.nodes[0].ipmi_ip
+			ipmi_netmask = local.config.nodes[0].ipmi_netmask
+			ipmi_gateway = local.config.nodes[0].ipmi_gateway
+			ipmi_user = local.config.nodes[0].ipmi_user
+			ipmi_password = local.config.nodes[0].ipmi_password
+			node_position = local.config.nodes[0].node_position
+		}
+		// using cvm (AOS or DOS nodes)
+		nodes{
+			cvm_ip = local.config.nodes[1].cvm_ip
+			hypervisor_ip = local.config.nodes[1].hypervisor_ip
+			hypervisor = local.config.nodes[1].hypervisor
+			hypervisor_hostname = local.config.nodes[1].hypervisor_hostname
+			ipmi_ip = local.config.nodes[1].ipmi_ip
+			ipv6_address = local.config.nodes[1].ipv6_address
+			current_network_interface = local.config.nodes[1].current_network_interface
+			node_position = local.config.nodes[1].node_position
+			device_hint = "vm_installer"
+		}
+		// using cvm (AOS or DOS nodes)
+		nodes{
+			cvm_ip = local.config.nodes[2].cvm_ip
+			hypervisor_ip = local.config.nodes[2].hypervisor_ip
+			hypervisor = local.config.nodes[2].hypervisor
+			hypervisor_hostname = local.config.nodes[2].hypervisor_hostname
+			ipmi_ip = local.config.nodes[2].ipmi_ip
+			ipv6_address = local.config.nodes[2].ipv6_address
+			current_network_interface = local.config.nodes[2].current_network_interface
+			node_position = local.config.nodes[2].node_position
+			device_hint = "vm_installer"
+		}
+		block_id = local.config.block_id
+	  }
+	  clusters {
+		cluster_members = [
+			local.config.nodes[0].cvm_ip,
+			local.config.nodes[1].cvm_ip,
+			local.config.nodes[2].cvm_ip
+		]
+		redundancy_factor = 2
+		cluster_name =  local.config.nodes[0].hypervisor_hostname
+	  }
+	}`, filepath, blockNum, name)
+}
+
+func testImageNodesResource_InvalidNosError(filepath string, blockNum int, name string) string {
+	return fmt.Sprintf(`
+	locals{
+		config = (jsondecode(file("%s"))).blocks[%v]
+	}
+	
+	resource "nutanix_foundation_image_nodes" "%s" {
+	  timeouts {
+		create = "80m"
+	  }
+	  cvm_gateway = local.config.cvm_gateway
+	  hypervisor_gateway = local.config.hypervisor_gateway
+	  cvm_netmask = local.config.cvm_netmask
+	  hypervisor_netmask = local.config.cvm_netmask
+	  ipmi_user = local.config.ipmi_user
+	  nos_package = "ironman"
+	  blocks {
+		// manual mode using ipmi (Bare Metal, AOS or DOS nodes)
+		nodes{
+			cvm_ip = local.config.nodes[0].cvm_ip
+			hypervisor_ip = local.config.nodes[0].hypervisor_ip
+			hypervisor = local.config.nodes[0].hypervisor
+			hypervisor_hostname = local.config.nodes[0].hypervisor_hostname
+			ipmi_ip = local.config.nodes[0].ipmi_ip
+			ipmi_netmask = local.config.nodes[0].ipmi_netmask
+			ipmi_gateway = local.config.nodes[0].ipmi_gateway
+			ipmi_user = local.config.nodes[0].ipmi_user
+			ipmi_password = local.config.nodes[0].ipmi_password
+			node_position = local.config.nodes[0].node_position
+		}
+		// using cvm (AOS or DOS nodes)
+		nodes{
+			cvm_ip = local.config.nodes[1].cvm_ip
+			hypervisor_ip = local.config.nodes[1].hypervisor_ip
+			hypervisor = local.config.nodes[1].hypervisor
+			hypervisor_hostname = local.config.nodes[1].hypervisor_hostname
+			ipmi_ip = local.config.nodes[1].ipmi_ip
+			ipv6_address = local.config.nodes[1].ipv6_address
+			current_network_interface = local.config.nodes[1].current_network_interface
+			node_position = local.config.nodes[1].node_position
+			device_hint = "vm_installer"
+		}
+		// using cvm (AOS or DOS nodes)
+		nodes{
+			cvm_ip = local.config.nodes[2].cvm_ip
+			hypervisor_ip = local.config.nodes[2].hypervisor_ip
+			hypervisor = local.config.nodes[2].hypervisor
+			hypervisor_hostname = local.config.nodes[2].hypervisor_hostname
+			ipmi_ip = local.config.nodes[2].ipmi_ip
+			ipv6_address = local.config.nodes[2].ipv6_address
+			current_network_interface = local.config.nodes[2].current_network_interface
+			node_position = local.config.nodes[2].node_position
+			device_hint = "vm_installer"
+		}
+		block_id = local.config.block_id
+	  }
+	  clusters {
+		cluster_members = [
+			local.config.nodes[0].cvm_ip,
+			local.config.nodes[1].cvm_ip,
+			local.config.nodes[2].cvm_ip
+		]
+		redundancy_factor = 2
+		cluster_name =  local.config.nodes[0].hypervisor_hostname
+	  }
+	}`, filepath, blockNum, name)
+}

--- a/nutanix/resource_nutanix_foundation_image_nodes_test.go
+++ b/nutanix/resource_nutanix_foundation_image_nodes_test.go
@@ -51,7 +51,7 @@ func TestAccFoundationImageNodesResource_InvalidNosError(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testImageNodesResource_InvalidNosError(filepath, blockNum, name),
+				Config:      testImageNodesResourceInvalidNosError(filepath, blockNum, name),
 				ExpectError: regexp.MustCompile("Node imaging process failed due to error: Couldn't find nos_package at"),
 			},
 		},
@@ -128,7 +128,7 @@ func testImageNodesResource(filepath string, blockNum int, name string) string {
 	}`, filepath, blockNum, name)
 }
 
-func testImageNodesResource_InvalidNosError(filepath string, blockNum int, name string) string {
+func testImageNodesResourceInvalidNosError(filepath string, blockNum int, name string) string {
 	return fmt.Sprintf(`
 	locals{
 		config = (jsondecode(file("%s"))).blocks[%v]

--- a/nutanix/resource_nutanix_foundation_image_test.go
+++ b/nutanix/resource_nutanix_foundation_image_test.go
@@ -1,3 +1,6 @@
+//go:build !unit
+// +build !unit
+
 package nutanix
 
 import (

--- a/nutanix/resource_nutanix_foundation_image_test.go
+++ b/nutanix/resource_nutanix_foundation_image_test.go
@@ -73,7 +73,6 @@ func TestAccFoundationImageResource_NOSUpload(t *testing.T) {
 				Config: testImageResourceUpload(nameForUpload, filename, "nos", filepath),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNosImageExists(filename),
-					resource.TestCheckResourceAttrSet(resourcePathForUpload, "md5sum"),
 					resource.TestCheckResourceAttrSet(resourcePathForUpload, "in_whitelist"),
 					resource.TestCheckResourceAttrSet(resourcePathForUpload, "name"),
 				),

--- a/nutanix/resource_nutanix_foundation_image_test.go
+++ b/nutanix/resource_nutanix_foundation_image_test.go
@@ -1,0 +1,116 @@
+package nutanix
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func GetResourceState(s *terraform.State, key string) map[string]string {
+	moduleState := s.RootModule()
+	return moduleState.Resources[key].Primary.Attributes
+}
+
+func testAccCheckNosImageExists(filename string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*Client).FoundationClientAPI
+		ctx := context.TODO()
+		resp, err := conn.FileManagement.ListNOSPackages(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed to fetch nos packages from FVM")
+		}
+
+		for _, v := range *resp {
+			if v == filename {
+				return nil
+			}
+		}
+		return fmt.Errorf("Upload for nos package %s failed. Image not found in FVM", filename)
+	}
+}
+
+func testAccCheckNosImageDestroy(filename string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*Client).FoundationClientAPI
+		ctx := context.TODO()
+		resp, err := conn.FileManagement.ListNOSPackages(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed to fetch nos packages from FVM")
+		}
+
+		for _, v := range *resp {
+			if v == filename {
+				fmt.Errorf("teraform destroy for nos package %s failed. It still exists in FVM", filename)
+			}
+		}
+		return nil
+	}
+}
+
+func TestAccFoundationImageResource_NOSUpload(t *testing.T) {
+	nameForUpload := "nos_upload"
+	resourcePathForUpload := "nutanix_foundation_image." + nameForUpload
+	r := acctest.RandIntRange(0, 500)
+	filename := fmt.Sprintf("test_nos_image-%d.tar.gz", r)
+	nosFile := "test_nos_image.tar.gz"
+
+	// get file file path to config having nodes info
+	path, _ := os.Getwd()
+	filepath := path + "/../test_files/" + nosFile
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccFoundationPreCheck(t) },
+		CheckDestroy: testAccCheckNosImageDestroy(filename),
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testImageResourceUpload(nameForUpload, filename, "nos", filepath),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNosImageExists(filename),
+					resource.TestCheckResourceAttrSet(resourcePathForUpload, "md5sum"),
+					resource.TestCheckResourceAttrSet(resourcePathForUpload, "in_whitelist"),
+					resource.TestCheckResourceAttrSet(resourcePathForUpload, "name"),
+				),
+			},
+		},
+	})
+}
+
+// Check negative scenario incase the resource errors out for incorrect installer type
+func TestAccFoundationImageResource_Error(t *testing.T) {
+	nameForUpload := "iso_upload"
+	r := acctest.RandIntRange(0, 500)
+	filename := fmt.Sprintf("test_alpine-%d.iso", r)
+	file := "alpine.iso"
+
+	// get file file path to config having nodes info
+	path, _ := os.Getwd()
+	filepath := path + "/../test_files/" + file
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccFoundationPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testImageResourceUpload(nameForUpload, filename, "check", filepath),
+				ExpectError: regexp.MustCompile("installer_type check should be one of "),
+			},
+		},
+	})
+}
+
+func testImageResourceUpload(name, filename, installer_type, filepath string) string {
+	return fmt.Sprintf(`
+	resource "nutanix_foundation_image" "%s"{
+		filename = "%s"
+		installer_type = "%s"
+		source = "%s"
+	}
+	`, name, filename, installer_type, filepath)
+}

--- a/nutanix/resource_nutanix_foundation_image_test.go
+++ b/nutanix/resource_nutanix_foundation_image_test.go
@@ -60,12 +60,29 @@ func TestAccFoundationImageResource_NOSUpload(t *testing.T) {
 	filename := fmt.Sprintf("test_nos_image-%d.tar.gz", r)
 	nosFile := "test_nos_image.tar.gz"
 
-	// get file file path to config having nodes info
-	path, _ := os.Getwd()
-	filepath := path + "/../test_files/" + nosFile
+	// Get the Working directory
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("TestAccFoundationImageResource_NOSUpload failed to get working directory %s", err)
+	}
+
+	filepath := fmt.Sprintf("%s/%s", dir, nosFile)
+
+	defer os.Remove(filepath)
+
+	// get image url from env variables
+	image := os.Getenv("NOS_IMAGE_TEST_URL")
+	if image == "" {
+		t.Fatal("NOS_IMAGE_TEST_URL is empty. Please set env variable NOS_IMAGE_TEST_URL")
+	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccFoundationPreCheck(t) },
+		PreCheck: func() {
+			if err := downloadFile(filepath, image); err != nil {
+				t.Errorf("TestAccFoundationImageResource_NOSUpload failed to download image %s", err)
+			}
+			testAccFoundationPreCheck(t)
+		},
 		CheckDestroy: testAccCheckNosImageDestroy(filename),
 		Providers:    testAccProviders,
 		Steps: []resource.TestStep{
@@ -88,12 +105,25 @@ func TestAccFoundationImageResource_Error(t *testing.T) {
 	filename := fmt.Sprintf("test_alpine-%d.iso", r)
 	file := "alpine.iso"
 
-	// get file file path to config having nodes info
-	path, _ := os.Getwd()
-	filepath := path + "/../test_files/" + file
+	// Get the Working directory
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Errorf("TestAccFoundationImageResource_NOSUpload failed to get working directory %s", err)
+	}
 
+	filepath := fmt.Sprintf("%s/%s", dir, file)
+
+	defer os.Remove(filepath)
+
+	// get image url from env variables
+	image := "http://dl-cdn.alpinelinux.org/alpine/v3.8/releases/x86_64/alpine-virt-3.8.1-x86_64.iso"
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccFoundationPreCheck(t) },
+		PreCheck: func() {
+			if err := downloadFile(filepath, image); err != nil {
+				t.Errorf("TestAccFoundationImageResource_Error failed to download image %s", err)
+			}
+			testAccFoundationPreCheck(t)
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/nutanix/resource_nutanix_foundation_image_test.go
+++ b/nutanix/resource_nutanix_foundation_image_test.go
@@ -23,7 +23,7 @@ func testAccCheckNosImageExists(filename string) resource.TestCheckFunc {
 		ctx := context.TODO()
 		resp, err := conn.FileManagement.ListNOSPackages(ctx)
 		if err != nil {
-			return fmt.Errorf("Failed to fetch nos packages from FVM")
+			return fmt.Errorf("failed to fetch nos packages from FVM")
 		}
 
 		for _, v := range *resp {
@@ -31,7 +31,7 @@ func testAccCheckNosImageExists(filename string) resource.TestCheckFunc {
 				return nil
 			}
 		}
-		return fmt.Errorf("Upload for nos package %s failed. Image not found in FVM", filename)
+		return fmt.Errorf("upload for nos package %s failed. Image not found in FVM", filename)
 	}
 }
 
@@ -41,12 +41,12 @@ func testAccCheckNosImageDestroy(filename string) resource.TestCheckFunc {
 		ctx := context.TODO()
 		resp, err := conn.FileManagement.ListNOSPackages(ctx)
 		if err != nil {
-			return fmt.Errorf("Failed to fetch nos packages from FVM")
+			return fmt.Errorf("failed to fetch nos packages from FVM")
 		}
 
 		for _, v := range *resp {
 			if v == filename {
-				fmt.Errorf("teraform destroy for nos package %s failed. It still exists in FVM", filename)
+				return fmt.Errorf("teraform destroy for nos package %s failed. It still exists in FVM", filename)
 			}
 		}
 		return nil
@@ -105,12 +105,12 @@ func TestAccFoundationImageResource_Error(t *testing.T) {
 	})
 }
 
-func testImageResourceUpload(name, filename, installer_type, filepath string) string {
+func testImageResourceUpload(name, filename, instType, filepath string) string {
 	return fmt.Sprintf(`
 	resource "nutanix_foundation_image" "%s"{
 		filename = "%s"
 		installer_type = "%s"
 		source = "%s"
 	}
-	`, name, filename, installer_type, filepath)
+	`, name, filename, instType, filepath)
 }

--- a/nutanix/resource_nutanix_foundation_ipmi_config_test.go
+++ b/nutanix/resource_nutanix_foundation_ipmi_config_test.go
@@ -1,0 +1,79 @@
+package nutanix
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccFoundationIPMIConfigResource(t *testing.T) {
+	name := "ipmi_configure"
+	resourcePath := "nutanix_foundation_ipmi_config." + name
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccFoundationPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testIPMIConfigResource(name, foundationVars.IpmiConfig),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourcePath, "blocks.0.nodes.0.ipmi_configure_successful", "true"),
+					// verify that again apply would again do create due to "ipmi_configure_now" = true
+					resource.TestCheckResourceAttr(resourcePath, "blocks.0.nodes.0.ipmi_configure_now", "true"),
+					resource.TestCheckResourceAttr(resourcePath, "blocks.0.nodes.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFoundationIPMIConfigResource_Error(t *testing.T) {
+	name := "ipmi_configure"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccFoundationPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testIPMIConfigResourceWithWrongPassword(name, foundationVars.IpmiConfig),
+				ExpectError: regexp.MustCompile("IPMI config failed for IPMI IP"),
+			},
+		},
+	})
+}
+
+func testIPMIConfigResource(name string, i IPMIConfig) string {
+	return fmt.Sprintf(`
+	resource "nutanix_foundation_ipmi_config" "%[1]s" {
+		ipmi_gateway = "%[2]s"
+		ipmi_netmask = "%[3]s"
+		ipmi_user = "%[4]s"
+		ipmi_password = "%[5]s"
+		blocks{
+			nodes {
+				ipmi_mac = "%[6]s"
+				ipmi_configure_now = true
+				ipmi_ip = "%[7]s"
+			}
+		}
+
+	}`, name, i.IpmiGateway, i.IpmiNetmask, i.IpmiUser, i.IpmiPassword, i.IpmiMac, i.IpmiIP)
+}
+
+func testIPMIConfigResourceWithWrongPassword(name string, i IPMIConfig) string {
+	return fmt.Sprintf(`
+	resource "nutanix_foundation_ipmi_config" "%[1]s" {
+		ipmi_gateway = "%[2]s"
+		ipmi_netmask = "%[3]s"
+		ipmi_user = "%[4]s"
+		ipmi_password = "%[5]s"
+		blocks{
+			nodes {
+				ipmi_mac = "%[6]s"
+				ipmi_configure_now = true
+				ipmi_ip = "%[7]s"
+			}
+		}
+
+	}`, name, i.IpmiGateway, i.IpmiNetmask, i.IpmiUser, "ironman", i.IpmiMac, i.IpmiIP)
+}

--- a/nutanix/resource_nutanix_karbon_cluster_test.go
+++ b/nutanix/resource_nutanix_karbon_cluster_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccNutanixKarbonCluster_basic(t *testing.T) {
+func TestAccKarbonCluster_basic(t *testing.T) {
 	t.Skip()
 	r := acctest.RandInt()
 	resourceName := "nutanix_karbon_cluster.cluster"
@@ -56,7 +56,7 @@ func TestAccNutanixKarbonCluster_basic(t *testing.T) {
 	})
 }
 
-func TestAccNutanixKarbonCluster_scaleDown(t *testing.T) {
+func TestAccKarbonCluster_scaleDown(t *testing.T) {
 	r := acctest.RandInt()
 	t.Skip()
 	resourceName := "nutanix_karbon_cluster.cluster"
@@ -101,7 +101,7 @@ func TestAccNutanixKarbonCluster_scaleDown(t *testing.T) {
 	})
 }
 
-func TestAccNutanixKarbonCluster_updateCNI(t *testing.T) {
+func TestAccKarbonCluster_updateCNI(t *testing.T) {
 	r := acctest.RandInt()
 	t.Skip()
 	resourceName := "nutanix_karbon_cluster.cluster"

--- a/test_files/README.md
+++ b/test_files/README.md
@@ -1,0 +1,1 @@
+This folder should contain files used in tests. For example, .iso or .tar files for testing image upload usecases for foundation and prism central resources.

--- a/test_files/README.md
+++ b/test_files/README.md
@@ -1,1 +1,0 @@
-This folder should contain files used in tests. For example, .iso or .tar files for testing image upload usecases for foundation and prism central resources.

--- a/test_foundation_config.json
+++ b/test_foundation_config.json
@@ -1,0 +1,79 @@
+{
+	"ipv6_addresses" : ["",""],
+	"ipmi_config": {
+		"ipmi_netmask":"",
+		"ipmi_gateway":"",
+		"ipmi_user":"",
+		"ipmi_password":"",
+		"ipmi_mac":"",
+		"ipmi_ip":""
+	},
+	"blocks":[
+		{
+			"cvm_gateway": "",
+			"hypervisor_gateway":"",
+			"cvm_netmask":"",
+			"hypervisor_netmask":"",
+			"ipmi_user": "",
+			"nodes": [
+				{
+					"ipmi_ip":"",
+					"ipmi_user":"",
+					"ipmi_password":"",
+					"ipmi_netmask":"",
+					"ipmi_gateway":"",
+					"cvm_ip":"",
+					"hypervisor":"",
+					"hypervisor_hostname":"",
+					"hypervisor_ip":"",
+					"node_position":"",
+					"ipv6_address":"",
+					"current_network_interface":""
+				},
+				{
+					"ipmi_ip":"",
+					"ipmi_user":"",
+					"ipmi_password":"",
+					"ipmi_netmask":"",
+					"ipmi_gateway":"",
+					"cvm_ip":"",
+					"hypervisor":"",
+					"hypervisor_hostname":"",
+					"hypervisor_ip":"",
+					"node_position":"",
+					"ipv6_address":"",
+					"current_network_interface":""
+				},
+				{
+					"ipmi_ip":"",
+					"ipmi_user":"",
+					"ipmi_password":"",
+					"ipmi_netmask":"",
+					"ipmi_gateway":"",
+					"cvm_ip":"",
+					"hypervisor":"",
+					"hypervisor_hostname":"",
+					"hypervisor_ip":"",
+					"node_position":"",
+					"ipv6_address":"",
+					"current_network_interface":""
+				},
+				{
+					"ipmi_ip":"",
+					"ipmi_user":"",
+					"ipmi_password":"",
+					"ipmi_netmask":"",
+					"ipmi_gateway":"",
+					"cvm_ip":"",
+					"hypervisor":"",
+					"hypervisor_hostname":"",
+					"hypervisor_ip":"",
+					"node_position":"",
+					"ipv6_address":"",
+					"current_network_interface":""
+				}
+			],
+			"block_id": ""
+		}
+	]
+}

--- a/website/docs/r/foundation_image_nodes.html.markdown
+++ b/website/docs/r/foundation_image_nodes.html.markdown
@@ -174,7 +174,7 @@ The following arguments are supported for each node:
 * `hypervisor_hostname` :- (Required) Hypervisor Hostname.
 * `hypervisor_ip` :- (Required) Hypervisor IP address.
 * `node_position` :- (Required) Position of the node in the block.
-* `image_now` :- (Required) If the node should be imaged now.
+* `image_now` :- (Optional, Default = true) If the node should be imaged now.
 * `bond_mode` :- (Required if node is capable) dynamic if using LACP, static for LAG
 * `rdma_passthrough` :- (Required if node is capable) passthru RDMA nic to CVM if possible, default to false
 * `bond_lacp_rate` :- (Required if node is lacp configured) slow or fast if lacp if being used at the switch
@@ -228,7 +228,7 @@ The following arguments are supported for each cluster:
 * `single_node_cluster` : - If it is a single node cluster.
 * `cluster_members` : - (Required) Members in the cluster.
 * `cvm_dns_servers` : - DNS servers of CVM.
-* `cluster_init_now` : - (Required) If cluster should be created.
+* `cluster_init_now` : - (Optional, Default = true) If cluster should be created.
 * `hypervisor_ntp_servers` : - NTP servers of hypervisor.
 
 ### hypervisor_iso
@@ -278,6 +278,10 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` : - unique id of terraform resouce is set to session_id of the imaging session
+* `session_id` : - session_id of the imaging session
+* `cluster_urls` :- list containing cluster name and cluster urls for created clusters in current session
+* `cluster_urls.#.cluster_name` :- cluster_name 
+* `cluster_urls.#.cluster_url` :- url to access the cluster login
 
 ## Defaults 
 


### PR DESCRIPTION
Overview : 
1. Add acceptance tests for Foundation resource and datasources.
2. Added "test_foundation_config.json" for constants required for foundation and foundation central acceptance tests.
3. Update existing acceptance tests for foundation releated changes
4. Add acceptance test for nutanix_assert_helper and minor fixes in same.
5. Made image_now & cluster_init_now as default to true for image_nodes resource. Updated doc for same.
6. Added field "cluster_urls" to output cluster_url for clusters created in session. For #426 
7. Update github workflows to become capable of running karbon, pc, foundation, foundation_central tests independently.
8. Change naming of karbon tests from TestAccNutanixKarbon to TestAccKarbon for seperate tests running.