### PR TITLE
Update Acceptance tests workflow to run specific provider tests

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -20,7 +20,40 @@ jobs:
         with:
           go-version: 1.17
       - name: Acceptance test cases
-        run: ${{ secrets.ACCEPTANCE_TEST_ARGS }} make testacc
+        run: |
+              args="${{ github.event.client_payload.slash_command.args }}"
+              providers=(${args})
+              index=0
+              n=${#providers[@]}
+              runFlag=""
+              for provider in $args
+              do 
+                  if [ "$provider" = "foundation" ]
+                      then 
+                          runFlag+="TestAccFoundation*"
+                  elif [ "$provider" = "foundation_central" ]
+                      then
+                          runFlag+="TestAccFC*"
+                  elif [ "$provider" = "karbon" ]
+                      then
+                          runFlag+="TestAccKarbon*"
+                  elif [ "$provider" = "pc" ]
+                      then
+                          runFlag+="TestAccNutanix*"
+                  else 
+                          echo "Invalid provider=$provider given in arguments."
+                          exit 1
+                  fi
+                  if [ $index -lt $((n-1)) ]
+                      then
+                          runFlag+="|"
+                  fi
+                  index=$((index+1))
+              done
+              export TESTARGS='-run="'$runFlag'"'
+              echo "TESTARGS = $TESTARGS"
+              echo '${{ secrets.FOUNDATION_CONFIG }}' > test_foundation_config.json
+              ${{ secrets.ACCEPTANCE_TEST_ARGS }} make testacc
       - name: Code Coverage Check
         run:  |
               echo "Code coverage: Checking if code coverage is above threshold..."

--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -55,6 +55,7 @@ jobs:
               echo '${{ secrets.FOUNDATION_CONFIG }}' > test_foundation_config.json
               ${{ secrets.ACCEPTANCE_TEST_ARGS }} make testacc
       - name: Code Coverage Check
+        if: ${{ always() }}
         run:  |
               echo "Code coverage: Checking if code coverage is above threshold..."
               export TESTCOV_THRESHOLD=50


### PR DESCRIPTION
Examples:

"/ok-to-test pc" -> TESTARGS will be -run="TestAccNutanix*"
"/ok-to-test foundation pc" -> TESTARGS will be -run="TestAccFoundation*|TestAccNutanix*"

provider tests keywords : pc, foundation, karbon & foundation_central

Updated : 
- Have added a small update which will run code coverage despite of test result. This will enable to get coverage incase test fails. 