### PR TITLE
Fix checksum issue in image resource

### DIFF
--- a/client/v3/v3_service.go
+++ b/client/v3/v3_service.go
@@ -33,7 +33,7 @@ type Service interface {
 	GetImage(uuid string) (*ImageIntentResponse, error)
 	ListImage(getEntitiesRequest *DSMetadata) (*ImageListIntentResponse, error)
 	UpdateImage(uuid string, body *ImageIntentInput) (*ImageIntentResponse, error)
-	UploadImage(uuid, filepath string) error
+	UploadImage(uuid string, filepath string, checksum *Checksum) error
 	CreateOrUpdateCategoryKey(body *CategoryKey) (*CategoryKeyStatus, error)
 	ListCategories(getEntitiesRequest *CategoryListMetadata) (*CategoryKeyListResponse, error)
 	DeleteCategoryKey(name string) error
@@ -375,7 +375,7 @@ func (op Operations) CreateImage(body *ImageIntentInput) (*ImageIntentResponse, 
  *
  * @param uuid @param filepath
  */
-func (op Operations) UploadImage(uuid, filepath string) error {
+func (op Operations) UploadImage(uuid, filepath string, checksum *Checksum) error {
 	ctx := context.Background()
 
 	path := fmt.Sprintf("/images/%s/file", uuid)
@@ -390,6 +390,11 @@ func (op Operations) UploadImage(uuid, filepath string) error {
 
 	if err != nil {
 		return fmt.Errorf("error: Creating request %s", err)
+	}
+
+	if checksum != nil && *checksum != (Checksum{}) {
+		req.Header.Add("X-Nutanix-Checksum-Type", *checksum.ChecksumAlgorithm)
+		req.Header.Add("X-Nutanix-Checksum-Bytes", *checksum.ChecksumValue)
 	}
 
 	err = op.client.Do(ctx, req, nil)

--- a/client/v3/v3_service_test.go
+++ b/client/v3/v3_service_test.go
@@ -987,7 +987,7 @@ func TestOperations_UploadImageError(t *testing.T) {
 			op := Operations{
 				client: tt.fields.client,
 			}
-			if err := op.UploadImage(tt.args.UUID, tt.args.filepath); (err != nil) != tt.wantErr {
+			if err := op.UploadImage(tt.args.UUID, tt.args.filepath, nil); (err != nil) != tt.wantErr {
 				t.Errorf("Operations.UploadImage() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -1037,7 +1037,7 @@ func TestOperations_UploadImage(t *testing.T) {
 			op := Operations{
 				client: tt.fields.client,
 			}
-			if err := op.UploadImage(tt.args.UUID, tt.args.filepath); err != nil {
+			if err := op.UploadImage(tt.args.UUID, tt.args.filepath, nil); err != nil {
 				t.Errorf("Operations.UploadImage() error = %v", err)
 			}
 		})

--- a/nutanix/data_source_nutanix_image.go
+++ b/nutanix/data_source_nutanix_image.go
@@ -234,6 +234,16 @@ func dataSourceNutanixImageRead(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
+	checksum := make(map[string]string)
+	if resp.Status.Resources.Checksum != nil {
+		checksum["checksum_algorithm"] = utils.StringValue(resp.Status.Resources.Checksum.ChecksumAlgorithm)
+		checksum["checksum_value"] = utils.StringValue(resp.Status.Resources.Checksum.ChecksumValue)
+	}
+
+	if err := d.Set("checksum", checksum); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(utils.StringValue(resp.Metadata.UUID))
 
 	return nil

--- a/nutanix/resource_nutanix_image.go
+++ b/nutanix/resource_nutanix_image.go
@@ -302,7 +302,6 @@ func resourceNutanixImageCreate(ctx context.Context, d *schema.ResourceData, met
 
 		// check if any recent tasks related to image upload failed or not
 		for _, tUUID := range resp.Status.ExecutionContext.TaskUUID.([]interface{}) {
-
 			u := tUUID.(string)
 			// get image upload task status
 			uploadTaskInfo, err := conn.V3.GetTask(u)
@@ -319,9 +318,7 @@ func resourceNutanixImageCreate(ctx context.Context, d *schema.ResourceData, met
 				return diag.Errorf("error_detail: %s, progress_message: %s", utils.StringValue(uploadTaskInfo.ErrorDetail), utils.StringValue(uploadTaskInfo.ProgressMessage))
 			}
 		}
-
 	}
-
 	return resourceNutanixImageRead(ctx, d, meta)
 }
 

--- a/nutanix/resource_nutanix_image.go
+++ b/nutanix/resource_nutanix_image.go
@@ -283,8 +283,9 @@ func resourceNutanixImageCreate(ctx context.Context, d *schema.ResourceData, met
 	if pok {
 		path := d.Get("source_path")
 
-		err = conn.V3.UploadImage(UUID, path.(string))
+		err = conn.V3.UploadImage(UUID, path.(string), spec.Resources.Checksum)
 		if err != nil {
+			// delete image if upload image from local fails in between of chunks upload
 			delErr := resourceNutanixImageDelete(ctx, d, meta)
 			if delErr != nil {
 				return delErr
@@ -292,6 +293,33 @@ func resourceNutanixImageCreate(ctx context.Context, d *schema.ResourceData, met
 
 			return diag.Errorf("failed uploading image: %s", err)
 		}
+
+		// read image info to get most recent task reference pointing to image upload task
+		resp, err := conn.V3.GetImage(UUID)
+		if err != nil {
+			return diag.Errorf("error reading image UUID (%s) with error %s", UUID, err)
+		}
+
+		// check if any recent tasks related to image upload failed or not
+		for _, tUUID := range resp.Status.ExecutionContext.TaskUUID.([]interface{}) {
+
+			u := tUUID.(string)
+			// get image upload task status
+			uploadTaskInfo, err := conn.V3.GetTask(u)
+			if err != nil {
+				diag.Errorf("failed getting task info: %s", err)
+			}
+
+			if *uploadTaskInfo.Status == "FAILED" {
+				// delete image if upload image task fails due to PC side checks
+				delErr := resourceNutanixImageDelete(ctx, d, meta)
+				if delErr != nil {
+					return delErr
+				}
+				return diag.Errorf("error_detail: %s, progress_message: %s", utils.StringValue(uploadTaskInfo.ErrorDetail), utils.StringValue(uploadTaskInfo.ProgressMessage))
+			}
+		}
+
 	}
 
 	return resourceNutanixImageRead(ctx, d, meta)
@@ -445,11 +473,12 @@ func resourceNutanixImageUpdate(ctx context.Context, d *schema.ResourceData, met
 		spec.Description = utils.StringPtr(d.Get("description").(string))
 	}
 
-	if d.HasChange("source_uri") || d.HasChange("checksum") || d.HasChange("source_path") {
-		if err := getImageResource(d, res); err != nil {
-			return diag.FromErr(err)
-		}
-		spec.Resources = res
+	if d.HasChange("image_type") {
+		spec.Resources.ImageType = utils.StringPtr(d.Get("image_type").(string))
+	}
+
+	if d.HasChange("checksum") {
+		return diag.Errorf("Checksum update is not allowed. Previous checksum algorithm is %s and value is %s", *res.Checksum.ChecksumAlgorithm, *res.Checksum.ChecksumValue)
 	}
 
 	request.Metadata = metadata


### PR DESCRIPTION
1. The resource nutanix_image was not considering checksum incase of local image upload. So have added logic to send checksum in headers while uploading image chunks. 
2. Have added logic in polling to check the image upload tasks (triggered by PC) status after upload from terraform finishes so that any failures in checks done by PC can be collected and displayed. 
3. Restrict user to update checksum, cluster references, source path and source uri as these are not allowed from api side
