### PR TITLE
Fix Secure boot VMs when doing updates

### DIFF
--- a/nutanix/resource_nutanix_virtual_machine.go
+++ b/nutanix/resource_nutanix_virtual_machine.go
@@ -1337,6 +1337,12 @@ func changePowerState(ctx context.Context, conn *v3.Client, id string, powerStat
 	spec.AvailabilityZoneReference = response.Status.AvailabilityZoneReference
 	spec.ClusterReference = response.Status.ClusterReference
 
+	// check if SECURE_BOOT is set, we need to set MachineType to Q35 if that's the case.
+	if *res.BootConfig.BootType == "SECURE_BOOT" {
+		log.Printf("[DEBUG] Machine Boot is set to Secure Boot, set MachineType to Q35")
+		res.MachineType = response.Spec.Resources.MachineType
+	}
+
 	res.PowerStateMechanism = pw
 	spec.Resources = res
 	request.Metadata = metadata

--- a/nutanix/resource_nutanix_virtual_machine.go
+++ b/nutanix/resource_nutanix_virtual_machine.go
@@ -1203,6 +1203,12 @@ func resourceNutanixVirtualMachineUpdate(ctx context.Context, d *schema.Resource
 		metadata.SpecVersion = specVersion
 	}
 
+	// Check if we are dealing with SECURE_BOOT machine, MachineType is needed then set to Q35
+	if *res.BootConfig.BootType == "SECURE_BOOT" {
+		log.Printf("[DEBUG] UpdateVM: Machine Boot is set to Secure Boot, set MachineType to Q35")
+		res.MachineType = response.Spec.Resources.MachineType
+	}
+
 	spec.Resources = res
 	request.Metadata = metadata
 	request.Spec = spec


### PR DESCRIPTION
This is my simple fix for SECURE_BOOT VMs to handle terraform apply updates, when it's doing first power off VM and then powering it back on. 

I noticed that MachineType was not set to Q35 when powering off was done and second time MachineType is missing when actual update is done and VM is booted after that.

Issue #494 