### PR TITLE
Add information about how to import virtual machine to state

### DIFF
--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -249,3 +249,10 @@ The `project_reference`, `owner_reference`, `availability_zone_reference`, `netw
 * `uuid`: - the UUID(Required).
 
 See detailed information in [Nutanix Virtual Machine](http://developer.nutanix.com/reference/prism_central/v3/#vms).
+
+## Import
+Nutanix Virtual machines can be imported using the `UUID` eg,
+
+`
+terraform import nutanix_virtual_machine.vm01 0F75E6A7-55FB-44D9-A50D-14AD72E2CF7C
+`


### PR DESCRIPTION
This PRs adds information about how to import an existing VM in Nutanix to the terraform state. This is tested and works as expected.

Note that I'm sure that all other resources could be imported by using the same pattern though I haven't tested it yet.