### PR TITLE
[Bug] Fix markdown syntax for some of the HCL examples

### DIFF
--- a/website/docs/d/access_control_policies.html.markdown
+++ b/website/docs/d/access_control_policies.html.markdown
@@ -12,7 +12,7 @@ Describes a list of access control policies.
 
 ## Example Usage
 
-``` hcl
+```hcl
 data "nutanix_access_control_policies" "test" {}
 ```
 

--- a/website/docs/d/access_control_policy.html.markdown
+++ b/website/docs/d/access_control_policy.html.markdown
@@ -12,7 +12,7 @@ Describes an Access Control Policy.
 
 ## Example Usage
 
-``` hcl
+```hcl
 resource "nutanix_access_control_policy" "test" {
 	name        = "NAME OF ACCESS CONTROL POLICY"
 	description = "DESCRIPTION OF THE ACCESS CONTROL POLICY"

--- a/website/docs/d/address_group.html.markdown
+++ b/website/docs/d/address_group.html.markdown
@@ -12,7 +12,7 @@ Provides a datasource to retrieve a address group.
 
 ## Example Usage
 
-``` hcl
+```hcl
 resource "nutanix_address_group" "test_address" {
   			name = "test"
   			description = "test address groups resource"

--- a/website/docs/d/address_groups.html.markdown
+++ b/website/docs/d/address_groups.html.markdown
@@ -12,7 +12,7 @@ Provides a datasource to retrieve list of address groups.
 
 ## Example Usage
 
-``` hcl
+```hcl
   data "nutanix_address_groups" "addr_groups" {}
 ```
 

--- a/website/docs/d/role.html.markdown
+++ b/website/docs/d/role.html.markdown
@@ -12,7 +12,7 @@ Describes a Role.
 
 ## Example Usage
 
-``` hcl
+```hcl
 resource "nutanix_role" "test" {
 	name        = "NAME"
 	description = "DESCRIPTION"

--- a/website/docs/d/roles.html.markdown
+++ b/website/docs/d/roles.html.markdown
@@ -12,7 +12,7 @@ Describes a list of roles.
 
 ## Example Usage
 
-``` hcl
+```hcl
 data "nutanix_roles" "test" {}
 ```
 

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -12,7 +12,7 @@ Provides a datasource to retrieve a user based on the input parameters.
 
 ## Example Usage
 
-``` hcl
+```hcl
 resource "nutanix_user" "user" {
 	directory_service_user {
 		user_principal_name = "test-user@ntnxlab.local"

--- a/website/docs/d/user_group.html.markdown
+++ b/website/docs/d/user_group.html.markdown
@@ -12,7 +12,7 @@ Provides a datasource to retrieve a user group based on the input parameters.
 
 ## Example Usage
 
-``` hcl
+```hcl
 
 //Retrieve by UUID
 data "nutanix_user_group" "usergroup" {

--- a/website/docs/d/user_groups.html.markdown
+++ b/website/docs/d/user_groups.html.markdown
@@ -12,7 +12,7 @@ Provides a datasource to retrieve all the user groups.
 
 ## Example Usage
 
-``` hcl
+```hcl
 data "nutanix_user_groups" "usergroups" {}
 ```
 

--- a/website/docs/d/users.html.markdown
+++ b/website/docs/d/users.html.markdown
@@ -12,7 +12,7 @@ Provides a datasource to retrieve all the users.
 
 ## Example Usage
 
-``` hcl
+```hcl
 resource "nutanix_user" "user" {
 	directory_service_user {
 		user_principal_name = "test-user@ntnxlab.local"

--- a/website/docs/r/access_control_policy.html.markdown
+++ b/website/docs/r/access_control_policy.html.markdown
@@ -12,7 +12,7 @@ Provides a resource to create an access control policy based on the input parame
 
 ## Example Usage
 
-``` hcl
+```hcl
 resource "nutanix_access_control_policy" "test" {
 	name        = "NAME OF ACCESS CONTROL POLICY"
 	description = "DESCRIPTION OF THE ACCESS CONTROL POLICY"

--- a/website/docs/r/address_group.html.markdown
+++ b/website/docs/r/address_group.html.markdown
@@ -12,7 +12,7 @@ Provides a resource to create a address group based on the input parameters.
 
 ## Example Usage
 
-``` hcl
+```hcl
 resource "nutanix_address_group" "test_address" {
 	name = "test"
 	description = "test address groups resource"

--- a/website/docs/r/foundation_central_api_key.html.markdown
+++ b/website/docs/r/foundation_central_api_key.html.markdown
@@ -12,7 +12,7 @@ Provides a resource to create a new API key for nodes registration with Foundati
 
 ## Example Usage
 
-``` hcl
+```hcl
 resource "nutanix_foundation_central_api_keys" "new_api_key" {
 	alias = "<NAME-FOR-API-KEY>"
 }

--- a/website/docs/r/foundation_central_image_cluster.html.markdown
+++ b/website/docs/r/foundation_central_image_cluster.html.markdown
@@ -12,7 +12,7 @@ Image Nodes and Create a cluster out of nodes registered with Foundation Central
 
 ## Example Usage
 
-``` hcl
+```hcl
 resource "nutanix_foundation_central_image_cluster" "img2"{
   cluster_name = "test-FC"
   cluster_external_ip = "<CLUSTER-IP>"

--- a/website/docs/r/ndb_database.html.markdown
+++ b/website/docs/r/ndb_database.html.markdown
@@ -15,7 +15,7 @@ Provides a resource to create database instance based on the input parameters. F
 
 ### NDB database resource with new database server VM
 
-``` hcl
+```hcl
 resource "nutanix_ndb_database" "dbp" {
 
     // name of database type
@@ -102,7 +102,7 @@ resource "nutanix_ndb_database" "dbp" {
 
 ### NDB database resource to provision HA instance with new database server VM
 
-``` hcl
+```hcl
 resource "nutanix_ndb_database" "dbp" {
     databasetype = "postgres_database"
     name = "test-pg-inst-HA-tf"

--- a/website/docs/r/role.html.markdown
+++ b/website/docs/r/role.html.markdown
@@ -12,7 +12,7 @@ Provides a resource to create a role based on the input parameters.
 
 ## Example Usage
 
-``` hcl
+```hcl
 resource "nutanix_role" "test" {
 	name        = "NAME"
 	description = "DESCRIPTION"

--- a/website/docs/r/service_group.html.markdown
+++ b/website/docs/r/service_group.html.markdown
@@ -12,7 +12,7 @@ Provides a resource to create a service group based on the input parameters.
 
 ## Example Usage
 
-``` hcl
+```hcl
 resource "nutanix_service_group" "test" {
 		name = "test_service_gp"
 		description = "this is service group"

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -12,7 +12,7 @@ Provides a resource to create a subnet based on the input parameters. A subnet i
 
 ## Example Usage
 
-``` hcl
+```hcl
 data "nutanix_clusters" "clusters" {
   metadata = {
     length = 2

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -12,7 +12,7 @@ Provides a resource to create a user based on the input parameters.
 
 ## Example Usage
 
-``` hcl
+```hcl
 resource "nutanix_user" "user" {
 	directory_service_user {
 		user_principal_name = "test-user@ntnxlab.local"
@@ -24,7 +24,7 @@ resource "nutanix_user" "user" {
 ```
 
 
-``` hcl
+```hcl
 resource "nutanix_user" "user" {
 	identity_provider_user {
 		username = "username"

--- a/website/docs/r/user_groups.html.markdown
+++ b/website/docs/r/user_groups.html.markdown
@@ -12,7 +12,7 @@ Provides a resource to add a User group to the system..
 
 ## Example Usage
 
-``` hcl
+```hcl
 resource "nutanix_user_groups" "user_grp" {
 	directory_service_user_group{
 		distinguished_name = "<distinguished name for the user group>"
@@ -21,7 +21,7 @@ resource "nutanix_user_groups" "user_grp" {
 ```
 
 
-``` hcl
+```hcl
 resource "nutanix_user_groups" "user_grp" {
 	saml_user_group{
     name = "<name of saml group>"


### PR DESCRIPTION
Currently they're set to have a space between the three backticks and the language name:

```

``` hcl

```

instead of 

```

```hcl

```

Fixes: #680 