### PR TITLE
#688 : fix validation for access control policy

### DIFF
--- a/nutanix/resource_nutanix_access_control_policy.go
+++ b/nutanix/resource_nutanix_access_control_policy.go
@@ -160,7 +160,7 @@ func resourceNutanixAccessControlPolicy() *schema.Resource {
 									"left_hand_side": {
 										Type:         schema.TypeString,
 										Required:     true,
-										ValidateFunc: validation.StringInSlice([]string{"CATEGORY", "PROJECT"}, false),
+										ValidateFunc: validation.StringInSlice([]string{"CATEGORY", "PROJECT", "CLUSTER", "VPC", "CONNECTIVITY_TYPE"}, false),
 									},
 									"operator": {
 										Type:         schema.TypeString,


### PR DESCRIPTION
fix validation for access control policy, add ["CLUSTER", "VPC", "CONNECTIVITY_TYPE"]  as accepted values for context_filter_list.scope_filter_expression_list.left_hand_side attribute