### PR TITLE
making changes to run the v4 pipeline

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -37,9 +37,12 @@ jobs:
                   elif [ "$provider" = "karbon" ]
                       then
                           runFlag+="TestAccKarbon*"
-                  elif [ "$provider" = "pc" ]
+                  elif [ "$provider" = "v3" ]
                       then
                           runFlag+="TestAccNutanix*"
+                  elif [ "$provider" = "v4" ]
+                      then
+                          runFlag+="TestAccV2Nutanix*"
                   elif [ "$provider" = "era" ]
                       then
                           runFlag+="TestAccEra*"
@@ -57,6 +60,7 @@ jobs:
               echo "TESTARGS = $TESTARGS"
               echo '${{ secrets.FOUNDATION_CONFIG }}' > test_foundation_config.json
               echo '${{ secrets.PC_CONFIG }}' > test_config.json
+              echo '${{ secrets.V4_CONFIG }}' > test_config_v2.json
               ${{ secrets.ACCEPTANCE_TEST_ARGS }} make testacc
       - name: Code Coverage Check
         if: ${{ always() }}


### PR DESCRIPTION
we are making this change because we need to run V4 testcases in pipeline. 
Now, we have two arguments to run v3 and v4 testcases separately . 

1. /ok-to-test v3 -> this will trigger all v3 testcases
2. /ok-to-test v4 -> this will trigger all v4 testcases

Also, we have added a separate test_config_v2.json for the variables.