### PR TITLE
Fix Virtual Machine v2 and Virtual Machines v2 Data Sources: Correct memorySizeBytes Attribute

### DIFF
--- a/nutanix/services/vmmv2/data_source_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/data_source_nutanix_virtual_machine_v2.go
@@ -70,7 +70,7 @@ func DatasourceNutanixVirtualMachineV4() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"memory_size_bytes": {
+			"memorysizebytes": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
@@ -1288,7 +1288,7 @@ func DatasourceNutanixVirtualMachineV4Read(ctx context.Context, d *schema.Resour
 	if err := d.Set("num_numa_nodes", getResp.NumNumaNodes); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("memory_size_bytes", getResp.MemorySizeBytes); err != nil {
+	if err := d.Set("memorysizebytes", getResp.MemorySizeBytes); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("is_vcpu_hard_pinning_enabled", getResp.IsVcpuHardPinningEnabled); err != nil {

--- a/nutanix/services/vmmv2/data_source_nutanix_virtual_machines_v2.go
+++ b/nutanix/services/vmmv2/data_source_nutanix_virtual_machines_v2.go
@@ -93,7 +93,7 @@ func DatasourceNutanixVirtualMachinesV4() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
-						"memory_size_bytes": {
+						"memorysizebytes": {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
@@ -1356,7 +1356,7 @@ func flattenVMEntities(vms []config.Vm) []interface{} {
 				vm["num_numa_nodes"] = v.NumNumaNodes
 			}
 			if v.MemorySizeBytes != nil {
-				vm["memory_size_bytes"] = v.MemorySizeBytes
+				vm["memorysizebytes"] = v.MemorySizeBytes
 			}
 			if v.IsVcpuHardPinningEnabled != nil {
 				vm["is_vcpu_hard_pinning_enabled"] = v.IsVcpuHardPinningEnabled

--- a/website/docs/d/virtual_machine_v2.html.markdown
+++ b/website/docs/d/virtual_machine_v2.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
 * `num_cores_per_socket`: Number of cores per socket.
 * `num_threads_per_core`: Number of threads per core
 * `num_numa_nodes`: Number of NUMA nodes. 0 means NUMA is disabled.
-* `memory_size_bytes`: Memory size in bytes.
+* `memorysizebytes`: Memory size in bytes.
 * `is_vcpu_hard_pinning_enabled`: Indicates whether the vCPUs should be hard pinned to specific pCPUs or not.
 * `is_cpu_passthrough_enabled`: Indicates whether to passthrough the host CPU features to the guest or not. Enabling this will make VM incapable of live migration.
 * `enabled_cpu_features`: The list of additional CPU features to be enabled. HardwareVirtualization: Indicates whether hardware assisted virtualization should be enabled for the Guest OS or not. Once enabled, the Guest OS can deploy a nested hypervisor

--- a/website/docs/d/virtual_machines_v2.html.markdown
+++ b/website/docs/d/virtual_machines_v2.html.markdown
@@ -48,7 +48,7 @@ The following attributes are exported:
 - `num_cores_per_socket`: Number of cores per socket.
 - `num_threads_per_core`: Number of threads per core
 - `num_numa_nodes`: Number of NUMA nodes. 0 means NUMA is disabled.
-- `memory_size_bytes`: Memory size in bytes.
+- `memorysizebytes`: Memory size in bytes.
 - `is_vcpu_hard_pinning_enabled`: Indicates whether the vCPUs should be hard pinned to specific pCPUs or not.
 - `is_cpu_passthrough_enabled`: Indicates whether to passthrough the host CPU features to the guest or not. Enabling this will make VM incapable of live migration.
 - `enabled_cpu_features`: The list of additional CPU features to be enabled. HardwareVirtualization: Indicates whether hardware assisted virtualization should be enabled for the Guest OS or not. Once enabled, the Guest OS can deploy a nested hypervisor


### PR DESCRIPTION
This PR addresses an issue with the memorySizeBytes attribute in both the Virtual Machine v2 and Virtual Machines v2 data sources. The attribute was previously incorrectly  fetched. This fix ensures the memorySizeBytes is properly retrieved and correctly handled.