### PR TITLE
Fix syntax error for bash, remove the space around operator in acceptance file

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -39,7 +39,7 @@ jobs:
             export NDB_ENDPOINT=${{ secrets.NDB_ENDPOINT }}
             export NDB_PASSWORD=${{ secrets.NDB_PASSWORD }}
             export NDB_USERNAME=${{ secrets.NDB_USERNAME }}
-            export PROTECTION_RULES_TEST_FLAG = ${{ secrets.PROTECTION_RULES_TEST_FLAG }}
+            export PROTECTION_RULES_TEST_FLAG=${{ secrets.PROTECTION_RULES_TEST_FLAG }}
             export CGO_ENABLED=${{ secrets.CGO_ENABLED }}
       - name: Acceptance test cases
         run: |


### PR DESCRIPTION
In bash, adding spaces around a equal operator leads to error export: `=': not a valid identifier. This needs to be fixed. Removed the spaces around a operator