### PR TITLE
Install latest version of Go language instead of using 1.2.2

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -15,10 +15,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
+      - name: Remove Old Go Versions
+        run: |
+          rm -rf /home/ubuntu/actions-runner/_work/_tool/go
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.20
+          check-latest: true  # Ensures the latest patch of Go 1.20 is installed
+          cache: true  # Enables module caching
       - name: Verify Go Installation
         run: |
           go version


### PR DESCRIPTION
Event though we have a code to install the go version of 1.20, it's always installing 1.2.2 which is very old version of Go. To install the latest of version made this changes.