### PR TITLE
Add new lines to ensure no old Go versions remain in the runner and add go version in quotes to avoid misinterpretation.

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -15,13 +15,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
-      - name: Remove Old Go Versions
+      - name: Remove Cached Go Versions
         run: |
-          rm -rf /home/ubuntu/actions-runner/_work/_tool/go
+          sudo rm -rf /home/ubuntu/actions-runner/_work/_tool/go
+          sudo rm -rf /usr/local/go
+          sudo apt remove --purge golang -y
+          hash -r  # Clear shell path cache
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.20
+          go-version: '1.20'
           check-latest: true  # Ensures the latest patch of Go 1.20 is installed
           cache: true  # Enables module caching
       - name: Verify Go Installation


### PR DESCRIPTION
Added new lines at stage remove old go versions and added go version in quotes so that 1.20 can't be interpreted as 1.2.