### PR TITLE
Setup terraform, beautify the code, fix export of variables

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -15,26 +15,31 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
+
       - name: Remove Cached Go Versions
         run: |
           sudo rm -rf /home/ubuntu/actions-runner/_work/_tool/go
           sudo rm -rf /usr/local/go
           sudo apt remove --purge golang -y
           hash -r  # Clear shell path cache
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.20'
           check-latest: true  # Ensures the latest patch of Go 1.20 is installed
           cache: true  # Enables module caching
+
       - name: Verify Go Installation
         run: |
           go version
           which go
+
       - name: Set Go Environment
         run: |
           echo "GOPATH=$HOME/go" >> $GITHUB_ENV
           echo "PATH=$HOME/go/bin:$PATH" >> $GITHUB_ENV
+
       - name: Cache Go Modules
         uses: actions/cache@v3
         with:
@@ -43,10 +48,21 @@ jobs:
           key: go-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             go-mod-${{ runner.os }}-
+
       - name: Install Dependencies
         run: |
           go mod tidy
           go mod vendor
+
+      - name: Setup Terraform v1.10.5
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.10.5
+
+      - name: Verify Terraform Installation
+        run: |
+          terraform version
+
       - name: Set environment variables
         run: |
             export NUTANIX_PE_PASSWORD=${{ secrets.NUTANIX_PE_PASSWORD}}
@@ -65,6 +81,7 @@ jobs:
             export NDB_USERNAME=${{ secrets.NDB_USERNAME }}
             export PROTECTION_RULES_TEST_FLAG=${{ secrets.PROTECTION_RULES_TEST_FLAG }}
             export CGO_ENABLED=${{ secrets.CGO_ENABLED }}
+
       - name: Check gofmt
         run: |
             echo "==> Checking that code complies with gofmt requirements..."
@@ -78,6 +95,7 @@ jobs:
                 echo "No gofmt issues found."
             fi
         continue-on-error: true
+
       - name: Acceptance test cases
         run: |
               args="${{ github.event.client_payload.slash_command.args }}"
@@ -129,6 +147,7 @@ jobs:
               echo "==> Running testcases..."
               TF_ACC=1 go test ./... -v ${TESTARGS} -timeout 500m -coverprofile c.out -covermode=count   
               echo "done"
+
       - name: Code Coverage Check
         if: ${{ always() }}
         run:  |

--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -65,22 +65,22 @@ jobs:
 
       - name: Set environment variables
         run: |
-            export NUTANIX_PE_PASSWORD=${{ secrets.NUTANIX_PE_PASSWORD}}
-            export NUTANIX_PE_USERNAME=${{ secrets.NUTANIX_PE_USERNAME}}
-            export NUTANIX_USERNAME=${{ secrets.NUTANIX_USERNAME}}
-            export NUTANIX_PASSWORD=${{ secrets.NUTANIX_PASSWORD }}
-            export NUTANIX_INSECURE=${{ secrets.NUTANIX_INSECURE }}
-            export NUTANIX_PORT=${{ secrets.NUTANIX_PORT }}
-            export NUTANIX_ENDPOINT=${{ secrets.NUTANIX_ENDPOINT }}
-            export NUTANIX_STORAGE_CONTAINER=${{ secrets.NUTANIX_STORAGE_CONTAINER}}
-            export FOUNDATION_ENDPOINT=${{ secrets.FOUNDATION_ENDPOINT }}
-            export FOUNDATION_PORT=${{ secrets.FOUNDATION_PORT }}
-            export NOS_IMAGE_TEST_URL=${{ secrets.NOS_IMAGE_TEST_URL }}
-            export NDB_ENDPOINT=${{ secrets.NDB_ENDPOINT }}
-            export NDB_PASSWORD=${{ secrets.NDB_PASSWORD }}
-            export NDB_USERNAME=${{ secrets.NDB_USERNAME }}
-            export PROTECTION_RULES_TEST_FLAG=${{ secrets.PROTECTION_RULES_TEST_FLAG }}
-            export CGO_ENABLED=${{ secrets.CGO_ENABLED }}
+            echo "NUTANIX_PE_PASSWORD=${{ secrets.NUTANIX_PE_PASSWORD }}" >> $GITHUB_ENV
+            echo "NUTANIX_PE_USERNAME=${{ secrets.NUTANIX_PE_USERNAME }}" >> $GITHUB_ENV
+            echo "NUTANIX_USERNAME=${{ secrets.NUTANIX_USERNAME }}" >> $GITHUB_ENV
+            echo "NUTANIX_PASSWORD=${{ secrets.NUTANIX_PASSWORD }}" >> $GITHUB_ENV
+            echo "NUTANIX_INSECURE=${{ secrets.NUTANIX_INSECURE }}" >> $GITHUB_ENV
+            echo "NUTANIX_PORT=${{ secrets.NUTANIX_PORT }}" >> $GITHUB_ENV
+            echo "NUTANIX_ENDPOINT=${{ secrets.NUTANIX_ENDPOINT }}" >> $GITHUB_ENV
+            echo "NUTANIX_STORAGE_CONTAINER=${{ secrets.NUTANIX_STORAGE_CONTAINER }}" >> $GITHUB_ENV
+            echo "FOUNDATION_ENDPOINT=${{ secrets.FOUNDATION_ENDPOINT }}" >> $GITHUB_ENV
+            echo "FOUNDATION_PORT=${{ secrets.FOUNDATION_PORT }}" >> $GITHUB_ENV
+            echo "NOS_IMAGE_TEST_URL=${{ secrets.NOS_IMAGE_TEST_URL }}" >> $GITHUB_ENV
+            echo "NDB_ENDPOINT=${{ secrets.NDB_ENDPOINT }}" >> $GITHUB_ENV
+            echo "NDB_PASSWORD=${{ secrets.NDB_PASSWORD }}" >> $GITHUB_ENV
+            echo "NDB_USERNAME=${{ secrets.NDB_USERNAME }}" >> $GITHUB_ENV
+            echo "PROTECTION_RULES_TEST_FLAG=${{ secrets.PROTECTION_RULES_TEST_FLAG }}" >> $GITHUB_ENV
+            echo "CGO_ENABLED=${{ secrets.CGO_ENABLED }}" >> $GITHUB_ENV
 
       - name: Check gofmt
         run: |


### PR DESCRIPTION
- Added a new stage to setup the terraform and print the terraform version:
        For running tests Terraform setup should be added. This helps in installing Terraform with version 1.10.5
- Code beautify:
        This improves the readability.
- Fix export of variables.
      the earlier approach does not persist the exported environment variables beyond the run block. so made the changes
      `export NUTANIX_PE_PASSWORD=${{ secrets.NUTANIX_PE_PASSWORD}}` to `echo "NUTANIX_PE_PASSWORD=${{ secrets.NUTANIX_PE_PASSWORD }}" >> $GITHUB_ENV`