### PR TITLE
Add a new stage unzip before terraform setup.

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -54,10 +54,13 @@ jobs:
           go mod tidy
           go mod vendor
 
+      - name: Install unzip
+        run: sudo apt-get update && sudo apt-get install -y unzip
+
       - name: Setup Terraform v1.10.5
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.10.5
+          terraform_version: '1.10.5'
 
       - name: Verify Terraform Installation
         run: |


### PR DESCRIPTION
Terraform distributions are packaged as .zip files. During the setup process in a GitHub Actions workflow, Terraform is downloaded as a compressed file and must be extracted before it can be executed. The GitHub Actions runner downloads the Terraform binary from HashiCorp’s official releases and is compressed in a .zip format. hashicorp/setup-terraform action requires unzip to extract the downloaded .zip file. So made this changes in such a way to install the package unzip.

Without this changes we might endup in seeing this error
`##[group***Run hashicorp/setup-terraform@v3
with:
  terraform_version: 1.1***.5
  cli_config_credentials_hostname: app.terraform.io
  terraform_wrapper: ***
env:
  GOPATH: /home/ubuntu/go
  PATH: /home/ubuntu/go/bin:/home/ubuntu/go/bin:/home/ubuntu/actions-runner/_work/_tool/go/1.[2](https://github.com/nutanix/terraform-provider-nutanix/actions/runs/13921687687/job/38956245652#step:12:2)***.14/x64/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
##[endgroup***
##[error***Error: Unable to locate executable file: unzip. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
##[error***Unable to locate executable file: unzip. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`


