### PR TITLE
Install nodejs before terraform setup

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -54,10 +54,13 @@ jobs:
           go mod tidy
           go mod vendor
 
+      - name: Install unzip
+        run: sudo apt-get update && sudo apt-get install -y unzip
+
       - name: Setup Terraform v1.10.5
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.10.5
+          terraform_version: '1.10.5'
 
       - name: Verify Terraform Installation
         run: |

--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -54,8 +54,8 @@ jobs:
           go mod tidy
           go mod vendor
 
-      - name: Install unzip
-        run: sudo apt-get update && sudo apt-get install -y unzip
+      - name: Install unzip and Node.js
+        run: sudo apt-get update && sudo apt-get install -y unzip nodejs npm
 
       - name: Setup Terraform v1.10.5
         uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
The hashicorp/setup-terraform action is built using JavaScript (Node.js). When GitHub Actions runs this step, it expects node to be installed to execute the Terraform setup script. If node is missing, the action cannot execute, causing the below error.
/usr/bin/env: ‘node’: No such file or directory
##[error***Process completed with exit code 127.

To solve the above error made changes to install nodejs as well before terraform setup
