### PR TITLE
Fix SAML IDP test case and make sure users are delete in users acc test 

### DIFF
--- a/nutanix/services/iamv2/data_source_nutanix_saml_idp_v2_test.go
+++ b/nutanix/services/iamv2/data_source_nutanix_saml_idp_v2_test.go
@@ -14,12 +14,6 @@ func TestAccV2NutanixIdentityProvidersDatasource_GetSamlIdpById(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"http": {
-				VersionConstraint: "~> 2.0",
-				Source:            "hashicorp/http",
-			},
-		},
 		Steps: []resource.TestStep{
 			{
 				Config: testIdentityProviderDatasourceV2Config(filepath),

--- a/nutanix/services/iamv2/data_source_nutanix_saml_idp_v2_test.go
+++ b/nutanix/services/iamv2/data_source_nutanix_saml_idp_v2_test.go
@@ -14,6 +14,12 @@ func TestAccV2NutanixIdentityProvidersDatasource_GetSamlIdpById(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"http": {
+				VersionConstraint: "~> 2.0",
+				Source:            "hashicorp/http",
+			},
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: testIdentityProviderDatasourceV2Config(filepath),
@@ -39,21 +45,21 @@ func testIdentityProviderDatasourceV2Config(filepath string) string {
 			config = (jsondecode(file("%s")))
 			identity_providers = local.config.iam.identity_providers
 		}
-		
+
 		resource "nutanix_saml_identity_providers_v2" "test" {
 			name = local.identity_providers.name
 			username_attribute = local.identity_providers.username_attr
 			email_attribute = local.identity_providers.email_attr
 			groups_attribute = local.identity_providers.groups_attr
 			groups_delim = local.identity_providers.groups_delim
-			idp_metadata_xml = local.identity_providers.idp_metadata_xml
+			idp_metadata_xml = file("%[2]s") # xml content
 			entity_issuer = local.identity_providers.entity_issuer
-			is_signed_authn_req_enabled = local.identity_providers.is_signed_authn_req_enabled	
+			is_signed_authn_req_enabled = local.identity_providers.is_signed_authn_req_enabled
 			custom_attributes = local.identity_providers.custom_attributes
 		}
 
 		data "nutanix_saml_identity_provider_v2" "test" {
 			ext_id = nutanix_saml_identity_providers_v2.test.id
-		}		
-`, filepath)
+		}
+`, filepath, xmlFilePath)
 }

--- a/nutanix/services/iamv2/data_source_nutanix_saml_idps_v2_test.go
+++ b/nutanix/services/iamv2/data_source_nutanix_saml_idps_v2_test.go
@@ -83,15 +83,15 @@ func testIdentityProvidersDatasourceConfig(filepath string) string {
 		email_attribute = local.identity_providers.email_attr
 		groups_attribute = local.identity_providers.groups_attr
 		groups_delim = local.identity_providers.groups_delim
-		idp_metadata_xml = local.identity_providers.idp_metadata_xml
+		idp_metadata_xml = file("%[2]s") # xml content
 		entity_issuer = local.identity_providers.entity_issuer
-		is_signed_authn_req_enabled = local.identity_providers.is_signed_authn_req_enabled	
+		is_signed_authn_req_enabled = local.identity_providers.is_signed_authn_req_enabled
 		custom_attributes = local.identity_providers.custom_attributes
 	}
 	data "nutanix_saml_identity_providers_v2" "test"{
 		depends_on = [ resource.nutanix_saml_identity_providers_v2.test ]
 	}
-	`, filepath)
+	`, filepath, xmlFilePath)
 }
 
 func testIdentityProvidersDatasourceWithFilterConfig(filepath string) string {
@@ -108,18 +108,18 @@ func testIdentityProvidersDatasourceWithFilterConfig(filepath string) string {
 		email_attribute = local.identity_providers.email_attr
 		groups_attribute = local.identity_providers.groups_attr
 		groups_delim = local.identity_providers.groups_delim
-		idp_metadata_xml = local.identity_providers.idp_metadata_xml
+		idp_metadata_xml = file("%[2]s") # xml content
 		entity_issuer = local.identity_providers.entity_issuer
-		is_signed_authn_req_enabled = local.identity_providers.is_signed_authn_req_enabled	
+		is_signed_authn_req_enabled = local.identity_providers.is_signed_authn_req_enabled
 		custom_attributes = local.identity_providers.custom_attributes
 	}
 
 	data "nutanix_saml_identity_providers_v2" "test" {
 		filter = "extId eq '${resource.nutanix_saml_identity_providers_v2.test.id}'"
-		depends_on = [ resource.nutanix_saml_identity_providers_v2.test ]	
+		depends_on = [ resource.nutanix_saml_identity_providers_v2.test ]
 	}
-	
-	`, filepath)
+
+	`, filepath, xmlFilePath)
 }
 
 func testIdentityProvidersDatasourceWithLimitConfig(filepath string) string {
@@ -128,22 +128,22 @@ func testIdentityProvidersDatasourceWithLimitConfig(filepath string) string {
 			config = (jsondecode(file("%s")))
 			identity_providers = local.config.iam.identity_providers
 		}
-		
+
 		resource "nutanix_saml_identity_providers_v2" "test" {
 			name = local.identity_providers.name
 			username_attribute = local.identity_providers.username_attr
 			email_attribute = local.identity_providers.email_attr
 			groups_attribute = local.identity_providers.groups_attr
 			groups_delim = local.identity_providers.groups_delim
-			idp_metadata_xml = local.identity_providers.idp_metadata_xml
+			idp_metadata_xml = file("%[2]s") # xml content
 			entity_issuer = local.identity_providers.entity_issuer
-			is_signed_authn_req_enabled = local.identity_providers.is_signed_authn_req_enabled	
+			is_signed_authn_req_enabled = local.identity_providers.is_signed_authn_req_enabled
 			custom_attributes = local.identity_providers.custom_attributes
 		}
 
 		data "nutanix_saml_identity_providers_v2" "test" {
 			limit      = 1
-			depends_on = [ resource.nutanix_saml_identity_providers_v2.test ]	
+			depends_on = [ resource.nutanix_saml_identity_providers_v2.test ]
 		}
-	`, filepath)
+	`, filepath, xmlFilePath)
 }

--- a/nutanix/services/iamv2/datasource_nutanix_user_v2_test.go
+++ b/nutanix/services/iamv2/datasource_nutanix_user_v2_test.go
@@ -18,6 +18,8 @@ func TestAccV2NutanixUserDatasource_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
+		// using V3 API to delete user
+		CheckDestroy: testAccCheckNutanixUserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testUserDatasourceV4Config(filepath, name),
@@ -45,7 +47,7 @@ func testUserDatasourceV4Config(filepath, name string) string {
 			config = (jsondecode(file("%[1]s")))
 			users = local.config.iam.users
 		}
-		
+
 		resource "nutanix_users_v2" "test" {
 			username = "%[2]s"
 			first_name = "first-name-%[2]s"
@@ -57,15 +59,15 @@ func testUserDatasourceV4Config(filepath, name string) string {
 			display_name = "display-name-%[2]s"
 			password = local.users.password
 			user_type = "LOCAL"
-			status = "ACTIVE"  
-			force_reset_password = local.users.force_reset_password   
+			status = "ACTIVE"
+			force_reset_password = local.users.force_reset_password
 		}
-		
+
 		data "nutanix_user_v2" "test" {
 			ext_id = nutanix_users_v2.test.id
 			depends_on = [nutanix_users_v2.test]
-		}			
+		}
 
-		
+
 	`, filepath, name)
 }

--- a/nutanix/services/iamv2/datasource_nutanix_users_v2_test.go
+++ b/nutanix/services/iamv2/datasource_nutanix_users_v2_test.go
@@ -18,6 +18,7 @@ func TestAccV2NutanixUsersDatasource_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
+		CheckDestroy: testAccCheckNutanixUserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testUsersDatasourceV4Config(filepath, name),
@@ -39,6 +40,7 @@ func TestAccV2NutanixUsersDatasource_WithFilter(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
+		CheckDestroy: testAccCheckNutanixUserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testUsersDatasourceV4WithFilterConfig(filepath, name, "userType eq Schema.Enums.UserType'LOCAL'"),
@@ -65,6 +67,7 @@ func TestAccV2NutanixUsersDatasource_WithLimit(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
+		CheckDestroy: testAccCheckNutanixUserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testUsersDatasourceV4WithLimitConfig(filepath, name),
@@ -82,7 +85,7 @@ func testUsersDatasourceV4Config(filepath, name string) string {
 			config = (jsondecode(file("%[1]s")))
 			users = local.config.iam.users
 		}
-		
+
 		resource "nutanix_users_v2" "test" {
 			username = "%[2]s"
 			first_name = "first-name-%[2]s"
@@ -94,8 +97,8 @@ func testUsersDatasourceV4Config(filepath, name string) string {
 			display_name = "display-name-%[2]s"
 			password = local.users.password
 			user_type = "LOCAL"
-			status = "ACTIVE"  
-			force_reset_password = local.users.force_reset_password   
+			status = "ACTIVE"
+			force_reset_password = local.users.force_reset_password
 		}
 
 		data "nutanix_users_v2" "test"{
@@ -123,16 +126,16 @@ func testUsersDatasourceV4WithFilterConfig(filepath, name, userQuery string) str
 		display_name = "display-name-%[2]s"
 		password = local.users.password
 		user_type = "LOCAL"
-		status = "ACTIVE"  
-		force_reset_password = local.users.force_reset_password   
+		status = "ACTIVE"
+		force_reset_password = local.users.force_reset_password
 	}
-	
+
 	data "nutanix_users_v2" "test" {
 		filter = "%[3]s"
 		depends_on = [nutanix_users_v2.test]
 	}
 
-	
+
 	`, filepath, name, userQuery)
 }
 
@@ -142,7 +145,7 @@ func testUsersDatasourceV4WithLimitConfig(filepath, name string) string {
 			config = (jsondecode(file("%[1]s")))
 			users = local.config.iam.users
 		}
-		
+
 		resource "nutanix_users_v2" "test" {
 			username = "%[2]s"
 			first_name = "first-name-%[2]s"
@@ -154,10 +157,10 @@ func testUsersDatasourceV4WithLimitConfig(filepath, name string) string {
 			display_name = "display-name-%[2]s"
 			password = local.users.password
 			user_type = "LOCAL"
-			status = "ACTIVE"  
-			force_reset_password = local.users.force_reset_password   
+			status = "ACTIVE"
+			force_reset_password = local.users.force_reset_password
 		}
-		
+
 		data "nutanix_users_v2" "test" {
 			limit     = 1
 			depends_on = [nutanix_users_v2.test]

--- a/nutanix/services/iamv2/datasource_nutanix_users_v2_test.go
+++ b/nutanix/services/iamv2/datasource_nutanix_users_v2_test.go
@@ -16,8 +16,8 @@ func TestAccV2NutanixUsersDatasource_Basic(t *testing.T) {
 	name := fmt.Sprintf("test-user-%d", r)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
-		Providers: acc.TestAccProviders,
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckNutanixUserDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -38,8 +38,8 @@ func TestAccV2NutanixUsersDatasource_WithFilter(t *testing.T) {
 	name := fmt.Sprintf("test-user-%d", r)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
-		Providers: acc.TestAccProviders,
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckNutanixUserDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -65,8 +65,8 @@ func TestAccV2NutanixUsersDatasource_WithLimit(t *testing.T) {
 	name := fmt.Sprintf("test-user-%d", r)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
-		Providers: acc.TestAccProviders,
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
 		CheckDestroy: testAccCheckNutanixUserDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/nutanix/services/iamv2/helper_test.go
+++ b/nutanix/services/iamv2/helper_test.go
@@ -2,6 +2,7 @@ package iamv2_test
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
@@ -40,24 +41,25 @@ func checkAttributeLength(resourceName, attribute string, minLength int) resourc
 }
 
 func testAccCheckNutanixUserDestroy(s *terraform.State) error {
-	fmt.Println("Checking user destroy")
+	log.Println("Checking user destroy")
 	conn := acc.TestAccProvider.Meta().(*conns.Client)
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "nutanix_users_v2" {
+		if rs.Type != "nutanix_users_v2" || rs.Primary.Attributes["users.#"] != "" {
 			continue
 		}
+
 		if _, err := conn.API.V3.GetUser(rs.Primary.ID); err != nil {
 			if strings.Contains(fmt.Sprint(err), "ENTITY_NOT_FOUND") {
 				return nil
 			}
 			return err
 		}
-		_, err := conn.API.V3.DeleteUser("4f1d9cf6-83dc-5fe2-8dd1-a84e062aaeee")
+		_, err := conn.API.V3.DeleteUser(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-		fmt.Println("Deleted user")
+		log.Println("User Deleted")
 	}
 	return nil
 }

--- a/nutanix/services/iamv2/main_test.go
+++ b/nutanix/services/iamv2/main_test.go
@@ -91,8 +91,8 @@ type TestConfig struct {
 var testVars TestConfig
 
 var (
-	path, _  = os.Getwd()
-	filepath = path + "/../../../test_config_v2.json"
+	path, _     = os.Getwd()
+	filepath    = path + "/../../../test_config_v2.json"
 	xmlFilePath = path + "/../../../test_idp_metadata.xml"
 )
 

--- a/nutanix/services/iamv2/main_test.go
+++ b/nutanix/services/iamv2/main_test.go
@@ -93,6 +93,7 @@ var testVars TestConfig
 var (
 	path, _  = os.Getwd()
 	filepath = path + "/../../../test_config_v2.json"
+	xmlFilePath = path + "/../../../test_idp_metadata.xml"
 )
 
 func loadVars(filepath string, varStuct interface{}) {

--- a/nutanix/services/iamv2/resource_nutanix_saml_idp_v2_test.go
+++ b/nutanix/services/iamv2/resource_nutanix_saml_idp_v2_test.go
@@ -74,11 +74,11 @@ func testIdentityProvidersResourceConfig(filepath string) string {
 		email_attribute = local.identity_providers.email_attr
 		groups_attribute = local.identity_providers.groups_attr
 		groups_delim = local.identity_providers.groups_delim
-		idp_metadata_xml = local.identity_providers.idp_metadata_xml
+		idp_metadata_xml = file("%[2]s") # xml content
 		entity_issuer = local.identity_providers.entity_issuer
-		is_signed_authn_req_enabled = local.identity_providers.is_signed_authn_req_enabled	
+		is_signed_authn_req_enabled = local.identity_providers.is_signed_authn_req_enabled
 		custom_attributes = local.identity_providers.custom_attributes
-	}`, filepath)
+	}`, filepath, xmlFilePath)
 }
 
 func testIdentityProvidersResourceWithoutName(filepath string) string {
@@ -95,12 +95,12 @@ func testIdentityProvidersResourceWithoutName(filepath string) string {
 				login_url = local.identity_providers.idp_metadata.login_url
 				logout_url = local.identity_providers.idp_metadata.logout_url
 				certificate = local.identity_providers.idp_metadata.certificate
-				name_id_policy_format = local.identity_providers.idp_metadata.name_id_policy_format  
+				name_id_policy_format = local.identity_providers.idp_metadata.name_id_policy_format
 			}
 			username_attribute = local.identity_providers.username_attr
 			email_attribute = local.identity_providers.email_attr
 			entity_issuer = local.identity_providers.entity_issuer
-			is_signed_authn_req_enabled = local.identity_providers.is_signed_authn_req_enabled	
+			is_signed_authn_req_enabled = local.identity_providers.is_signed_authn_req_enabled
 		}`, filepath)
 }
 
@@ -117,12 +117,12 @@ func testIdentityProvidersResourceWithoutEntityID(filepath string) string {
 			login_url = local.identity_providers.idp_metadata.login_url
 			logout_url = local.identity_providers.idp_metadata.logout_url
 			certificate = local.identity_providers.idp_metadata.certificate
-			name_id_policy_format = local.identity_providers.idp_metadata.name_id_policy_format  
+			name_id_policy_format = local.identity_providers.idp_metadata.name_id_policy_format
 		}
 		name = local.identity_providers.name
 		username_attribute = local.identity_providers.username_attr
 		email_attribute = local.identity_providers.email_attr
 		entity_issuer = local.identity_providers.entity_issuer
-		is_signed_authn_req_enabled = local.identity_providers.is_signed_authn_req_enabled	
+		is_signed_authn_req_enabled = local.identity_providers.is_signed_authn_req_enabled
 	}`, filepath)
 }

--- a/nutanix/services/iamv2/resource_nutanix_users_v2_test.go
+++ b/nutanix/services/iamv2/resource_nutanix_users_v2_test.go
@@ -20,6 +20,8 @@ func TestAccV2NutanixUsersResource_LocalActiveUser(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccFoundationPreCheck(t) },
 		Providers: acc.TestAccProviders,
+		// using V3 API to delete user
+		CheckDestroy: testAccCheckNutanixUserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testLocalActiveUserResourceConfig(filepath, name),
@@ -61,6 +63,8 @@ func TestAccV2NutanixUsersResource_AlreadyExistsUser(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccFoundationPreCheck(t) },
 		Providers: acc.TestAccProviders,
+		// using V3 API to delete user
+		CheckDestroy: testAccCheckNutanixUserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testLocalActiveUserResourceConfig(filepath, name),
@@ -89,6 +93,8 @@ func TestAccV2NutanixUsersResource_LocalInactiveUser(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccFoundationPreCheck(t) },
 		Providers: acc.TestAccProviders,
+		// using V3 API to delete user
+		CheckDestroy: testAccCheckNutanixUserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testLocalInactiveUserResourceConfig(filepath, name),
@@ -114,6 +120,8 @@ func TestAccV2NutanixUsersResource_SAMLUser(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccFoundationPreCheck(t) },
 		Providers: acc.TestAccProviders,
+		// using V3 API to delete user
+		CheckDestroy: testAccCheckNutanixUserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testSAMLUserResourceConfig(filepath, name),
@@ -158,6 +166,8 @@ func TestAccV2NutanixUsersResource_DeactivateLocalUser(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccFoundationPreCheck(t) },
 		Providers: acc.TestAccProviders,
+		// using V3 API to delete user
+		CheckDestroy: testAccCheckNutanixUserDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testLocalActiveUserResourceConfig(filepath, name),
@@ -238,8 +248,8 @@ func testLocalActiveUserResourceConfig(filepath, name string) string {
 		display_name = "display-name-%[2]s"
 		password = local.users.password
 		user_type = "LOCAL"
-		status = "ACTIVE"  
-		force_reset_password = local.users.force_reset_password  
+		status = "ACTIVE"
+		force_reset_password = local.users.force_reset_password
 	}`, filepath, name)
 }
 
@@ -262,9 +272,9 @@ func testLocalActiveUserResourceUpdateConfig(filepath, name string) string {
 		display_name = "display-name-%[2]s_updated"
 		password = "${local.users.password}_updated"
 		user_type = "LOCAL"
-		status = "ACTIVE"  
+		status = "ACTIVE"
 		force_reset_password = local.users.force_reset_password
-		
+
 	}`, filepath, name)
 }
 
@@ -283,10 +293,10 @@ func testLocalUserAlreadyExistsResourceConfig(filepath, name string) string {
 		display_name = "display-name-%[2]s"
 		password = local.users.password
 		user_type = "LOCAL"
-		status = "ACTIVE"  
+		status = "ACTIVE"
 		force_reset_password = local.users.force_reset_password
 	}
-		
+
 	`, filepath, name)
 }
 
@@ -309,7 +319,7 @@ func testLocalInactiveUserResourceConfig(filepath, name string) string {
 		display_name = "display-name-%[2]s"
 		password = local.users.password
 		user_type = "LOCAL"
-		status = "INACTIVE"  
+		status = "INACTIVE"
 		force_reset_password = local.users.force_reset_password
 
 	}`, filepath, name)
@@ -326,7 +336,7 @@ func testSAMLUserResourceConfig(filepath, name string) string {
 	resource "nutanix_users_v2" "test" {
 		username = "%[2]s"
 		user_type = "SAML"
-		idp_id = local.users.idp_id		
+		idp_id = local.users.idp_id
 	}`, filepath, name)
 }
 
@@ -342,7 +352,7 @@ func testLDAPUserWithMinimalConfigResourceConfig(filepath string) string {
 		username = local.users.name
 		user_type = "LDAP"
 		idp_id = local.users.directory_service_id
-		
+
 	}`, filepath)
 }
 
@@ -363,7 +373,7 @@ func testDeactivateLocalUserResourceConfig(filepath, name string) string {
 		region = local.users.region
 		password = local.users.password
 		force_reset_password = local.users.force_reset_password
-		status = INACTIVE  
+		status = INACTIVE
 	}`, filepath, name)
 }
 
@@ -385,9 +395,9 @@ func testUsersResourceWithoutUserNameConfig(filepath string) string {
 		display_name = "display-name"
 		password = local.users.password
 		user_type = "LOCAL"
-		status = "ACTIVE"  
-		force_reset_password = local.users.force_reset_password  
-		
+		status = "ACTIVE"
+		force_reset_password = local.users.force_reset_password
+
 	}`, filepath)
 }
 
@@ -409,8 +419,8 @@ func testUsersResourceWithoutUserTypeConfig(filepath, name string) string {
 		region = local.users.region
 		display_name = "display-name-%[2]s"
 		password = local.users.password
-		status = "ACTIVE"  
-		force_reset_password = local.users.force_reset_password  
+		status = "ACTIVE"
+		force_reset_password = local.users.force_reset_password
 
 	}`, filepath, name)
 }


### PR DESCRIPTION
## Tests Changes : 
- fix SAML IDP test case to read idp metatdata xml content from file instead of storing it in `test_config_v2.json` file 
-  make sure users are delete in users acceptance test cases  