### PR TITLE
Fix acceptance tests that was using V1 nutanix_clusters data source 

### DIFF
--- a/nutanix/services/clustersv2/resource_nutanix_cluster_entity_v2_test.go
+++ b/nutanix/services/clustersv2/resource_nutanix_cluster_entity_v2_test.go
@@ -127,7 +127,7 @@ func TestAccV2NutanixClusterResource_CreateClusterWithAllConfig(t *testing.T) {
 	})
 }
 
-var clusterConfig = fmt.Sprintf(` 
+var clusterConfig = fmt.Sprintf(`
 	data "nutanix_clusters_v2" "clusters" {}
 
 	locals {
@@ -143,8 +143,8 @@ func testAccClusterResourceMinimumConfig(name string) string {
 	return fmt.Sprintf(`
 		# cluster config
 		%[1]s
-		
-		# check if the nodes is un configured or not 
+
+		# check if the nodes is un configured or not
 		resource "nutanix_clusters_discover_unconfigured_nodes_v2" "test-discover-cluster-node" {
 		  ext_id       = local.cluster_ext_id
 		  address_type = "IPV4"
@@ -154,7 +154,7 @@ func testAccClusterResourceMinimumConfig(name string) string {
 			}
 		  }
 		  depends_on = [data.nutanix_clusters_v2.clusters]
-		
+
 		  ## check if the node is  un configured or not
 		  lifecycle {
 			postcondition {
@@ -163,7 +163,7 @@ func testAccClusterResourceMinimumConfig(name string) string {
 			}
 		  }
 		}
-		
+
 		# create a new cluster
 		resource "nutanix_cluster_v2" "test" {
 		  name   = "%[2]s"
@@ -182,22 +182,30 @@ func testAccClusterResourceMinimumConfig(name string) string {
 			cluster_arch     = local.clusters.config.cluster_arch
 			fault_tolerance_state {
 			  domain_awareness_level          = local.clusters.config.fault_tolerance_state.domain_awareness_level
-			}  
+			}
 		  }
-		
+
+		  network {
+			external_address {
+			  ipv4 {
+				value = local.clusters.network.virtual_ip
+			  }
+			}
+		  }
+
 		  provisioner "local-exec" {
-			command = "ssh-keygen -f "~/.ssh/known_hosts" -R "${local.clusters.nodes[0].cvm_ip}";  sshpass -p '${local.clusters.pe_password}' ssh -o StrictHostKeyChecking=no ${local.clusters.pe_username}@${local.clusters.nodes[0].cvm_ip} '/home/nutanix/prism/cli/ncli user reset-password user-name=${local.clusters.nodes[0].username} password=${local.clusters.nodes[0].password}' "
-		
+			command = "ssh-keygen -f '~/.ssh/known_hosts' -R '${local.clusters.nodes[0].cvm_ip}';  sshpass -p '${local.clusters.pe_password}' ssh -o StrictHostKeyChecking=no ${local.clusters.pe_username}@${local.clusters.nodes[0].cvm_ip} '/home/nutanix/prism/cli/ncli user reset-password user-name=${local.clusters.nodes[0].username} password=${local.clusters.nodes[0].password}' "
+
 			on_failure = continue
 		  }
-          # Set lifecycle to ignore changes 
+          # Set lifecycle to ignore changes
 		  lifecycle {
 			ignore_changes = [network.0.smtp_server.0.server.0.password,  links, categories, config.0.cluster_function]
 		  }
 		  depends_on = [nutanix_clusters_discover_unconfigured_nodes_v2.test-discover-cluster-node]
 		}
-		
-		
+
+
 		# register the cluster to pc
 		resource "nutanix_pc_registration_v2" "node-registration" {
 		  pc_ext_id = local.cluster_ext_id
@@ -228,7 +236,7 @@ func testAccClusterResourceAllConfig(name string) string {
 	return fmt.Sprintf(`
 		%[1]s
 
-		# check if the nodes is un configured or not 
+		# check if the nodes is un configured or not
 		resource "nutanix_clusters_discover_unconfigured_nodes_v2" "test-discover-cluster-node" {
 		  ext_id       = local.cluster_ext_id
 		  address_type = "IPV4"
@@ -238,7 +246,7 @@ func testAccClusterResourceAllConfig(name string) string {
 			}
 		  }
 		  depends_on = [data.nutanix_clusters_v2.clusters]
-		
+
 		  ## check if the node is  un configured or not
 		  lifecycle {
 			postcondition {
@@ -247,8 +255,8 @@ func testAccClusterResourceAllConfig(name string) string {
 			}
 		  }
 		}
-		
-		
+
+
 		resource "nutanix_cluster_v2" "test" {
 		  name   = "%[2]s"
 		  dryrun = false
@@ -293,21 +301,21 @@ func testAccClusterResourceAllConfig(name string) string {
 			  fqdn {
 				value = local.clusters.network.ntp_servers[3]
 			  }
-			}			
+			}
 		  }
-		  
+
 		  lifecycle {
 			ignore_changes = [network.0.smtp_server.0.server.0.password,  links, categories, config.0.cluster_function]
 		  }
-		
+
 		  provisioner "local-exec" {
-			command = "ssh-keygen -f "~/.ssh/known_hosts" -R "${local.clusters.nodes[0].cvm_ip}"; sshpass -p '${local.clusters.pe_password}' ssh -o StrictHostKeyChecking=no ${local.clusters.pe_username}@${local.clusters.nodes[0].cvm_ip} '/home/nutanix/prism/cli/ncli user reset-password user-name=${local.clusters.nodes[0].username} password=${local.clusters.nodes[0].password}' "
-		
+			command = "ssh-keygen -f '~/.ssh/known_hosts' -R '${local.clusters.nodes[0].cvm_ip}'; sshpass -p '${local.clusters.pe_password}' ssh -o StrictHostKeyChecking=no ${local.clusters.pe_username}@${local.clusters.nodes[0].cvm_ip} '/home/nutanix/prism/cli/ncli user reset-password user-name=${local.clusters.nodes[0].username} password=${local.clusters.nodes[0].password}' "
+
 			on_failure = continue
 		  }
 		  depends_on = [nutanix_clusters_discover_unconfigured_nodes_v2.test-discover-cluster-node]
 		}
-		
+
 		# register the cluster to pc
 		resource "nutanix_pc_registration_v2" "node-registration" {
 		  pc_ext_id = local.cluster_ext_id
@@ -337,8 +345,8 @@ func testAccClusterResourceUpdateConfig(updatedName string) string {
 	return fmt.Sprintf(`
 		# cluster config
 		%[1]s
-		
-		# check if the nodes is un configured or not 
+
+		# check if the nodes is un configured or not
 		resource "nutanix_clusters_discover_unconfigured_nodes_v2" "test-discover-cluster-node" {
 		  ext_id       = local.cluster_ext_id
 		  address_type = "IPV4"
@@ -348,7 +356,7 @@ func testAccClusterResourceUpdateConfig(updatedName string) string {
 			}
 		  }
 		  depends_on = [data.nutanix_clusters_v2.clusters]
-		
+
 		  ## check if the node is  un configured or not
 		  lifecycle {
 			postcondition {
@@ -357,8 +365,8 @@ func testAccClusterResourceUpdateConfig(updatedName string) string {
 			}
 		  }
 		}
-		
-		
+
+
 		resource "nutanix_cluster_v2" "test" {
 		  name   = "%[2]s"
 		  dryrun = false
@@ -425,20 +433,20 @@ func testAccClusterResourceUpdateConfig(updatedName string) string {
 			  type = local.clusters.network.smtp_server.type
 			}
 		  }
-		  
+
 		  lifecycle {
 			ignore_changes = [network.0.smtp_server.0.server.0.password,  links, categories, config.0.cluster_function]
 		  }
-		
+
 		  provisioner "local-exec" {
 
-			command = "ssh-keygen -f "~/.ssh/known_hosts" -R "${local.clusters.nodes[0].cvm_ip}"; ssh-keygen -f "/home/haroon/.ssh/known_hosts" -R "${local.clusters.nodes[0].cvm_ip}" ;  sshpass -p '${local.clusters.pe_password}' ssh -o StrictHostKeyChecking=no ${local.clusters.pe_username}@${local.clusters.nodes[0].cvm_ip} '/home/nutanix/prism/cli/ncli user reset-password user-name=${local.clusters.nodes[0].username} password=${local.clusters.nodes[0].password}' "
-		
+			command = "ssh-keygen -f '~/.ssh/known_hosts' -R '${local.clusters.nodes[0].cvm_ip}';  sshpass -p '${local.clusters.pe_password}' ssh -o StrictHostKeyChecking=no ${local.clusters.pe_username}@${local.clusters.nodes[0].cvm_ip} '/home/nutanix/prism/cli/ncli user reset-password user-name=${local.clusters.nodes[0].username} password=${local.clusters.nodes[0].password}' "
+
 			on_failure = continue
 		  }
 		  depends_on = [nutanix_clusters_discover_unconfigured_nodes_v2.test-discover-cluster-node]
 		}
-		
+
 		# register the cluster to pc
 		resource "nutanix_pc_registration_v2" "node-registration" {
 		  pc_ext_id = local.cluster_ext_id

--- a/nutanix/services/networkingv2/data_source_nutanix_floating_ip_v2_test.go
+++ b/nutanix/services/networkingv2/data_source_nutanix_floating_ip_v2_test.go
@@ -38,12 +38,15 @@ func testAccFipDataSourceConfig(name, desc string) string {
 	networkID := acctest.RandIntRange(0, 999)
 	return fmt.Sprintf(`
 
-		data "nutanix_clusters" "clusters" {}
+		data "nutanix_clusters_v2" "clusters" {}
 
 		locals {
-			cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+			cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 		}
-		
+
 		resource "nutanix_subnet_v2" "test" {
 			name = "terraform-test-subnet-floating-ip"
 			description = "test subnet description"

--- a/nutanix/services/networkingv2/data_source_nutanix_floating_ips_v2_test.go
+++ b/nutanix/services/networkingv2/data_source_nutanix_floating_ips_v2_test.go
@@ -58,12 +58,15 @@ func TestAccV2NutanixFloatingIPsDataSource_WithFilter(t *testing.T) {
 func testAccFipsDataSourceConfig(name, desc string) string {
 	return fmt.Sprintf(`
 
-		data "nutanix_clusters" "clusters" {}
+		data "nutanix_clusters_v2" "clusters" {}
 
 		locals {
-			cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+			cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 		}
-		
+
 		resource "nutanix_subnet_v2" "test" {
 			name = "terraform-test-subnet-floating-ip"
 			description = "test subnet description"
@@ -110,12 +113,15 @@ func testAccFipsDataSourceConfig(name, desc string) string {
 func testAccFipsDataSourceWithFilterConfig(name, desc string) string {
 	return fmt.Sprintf(`
 
-		data "nutanix_clusters" "clusters" {}
+		data "nutanix_clusters_v2" "clusters" {}
 
 		locals {
-		cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+		cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 		}
-		
+
 		resource "nutanix_subnet_v2" "test" {
 			name = "terraform-test-subnet-floating-ip"
 			description = "test subnet description"

--- a/nutanix/services/networkingv2/data_source_nutanix_pbr_v2_test.go
+++ b/nutanix/services/networkingv2/data_source_nutanix_pbr_v2_test.go
@@ -36,12 +36,15 @@ func TestAccV2NutanixPbrDataSource_Basic(t *testing.T) {
 
 func testAccPbrDataSourceConfig(name, desc string) string {
 	return fmt.Sprintf(`
-	data "nutanix_clusters" "clusters" {}
+	data "nutanix_clusters_v2" "clusters" {}
 
 	locals {
-		cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+		cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 	}
-	
+
 	resource "nutanix_subnet_v2" "test" {
 		name = "terraform-test-subnet-vpc_%[1]s"
 		description = "test subnet description"
@@ -70,7 +73,7 @@ func testAccPbrDataSourceConfig(name, desc string) string {
 				}
 			}
 		}
-		depends_on = [data.nutanix_clusters.clusters]
+		depends_on = [data.nutanix_clusters_v2.clusters]
 	}
 	resource "nutanix_vpc_v2" "test" {
 		name =  "pbr_vpc_%[1]s"

--- a/nutanix/services/networkingv2/data_source_nutanix_pbrs_v2_test.go
+++ b/nutanix/services/networkingv2/data_source_nutanix_pbrs_v2_test.go
@@ -56,13 +56,16 @@ func TestAccV2NutanixPbrsDataSource_WithFilter(t *testing.T) {
 
 func testAccPbrsDataSourceConfig(name, desc string) string {
 	return fmt.Sprintf(`
-	
-	data "nutanix_clusters" "clusters" {}
+
+	data "nutanix_clusters_v2" "clusters" {}
 
 	locals {
-		cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+		cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 	}
-	
+
 	resource "nutanix_subnet_v2" "test" {
 		name = "terraform-test-subnet-vpc_%[1]s"
 		description = "test subnet description"
@@ -91,7 +94,7 @@ func testAccPbrsDataSourceConfig(name, desc string) string {
 				}
 			}
 		}
-		depends_on = [data.nutanix_clusters.clusters]
+		depends_on = [data.nutanix_clusters_v2.clusters]
 	}
 	resource "nutanix_vpc_v2" "test" {
 		name =  "pbr_vpc_%[1]s"
@@ -133,13 +136,16 @@ func testAccPbrsDataSourceConfig(name, desc string) string {
 
 func testAccPbrsDataSourceWithFilterConfig(name, desc string) string {
 	return fmt.Sprintf(`
-	
-	data "nutanix_clusters" "clusters" {}
+
+	data "nutanix_clusters_v2" "clusters" {}
 
 	locals {
-		cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+		cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 	}
-	
+
 	resource "nutanix_subnet_v2" "test" {
 		name = "terraform-test-subnet-vpc_%[1]s"
 		description = "test subnet description"
@@ -168,7 +174,7 @@ func testAccPbrsDataSourceWithFilterConfig(name, desc string) string {
 				}
 			}
 		}
-		depends_on = [data.nutanix_clusters.clusters]
+		depends_on = [data.nutanix_clusters_v2.clusters]
 	}
 	resource "nutanix_vpc_v2" "test" {
 		name =  "pbr_vpc_%[1]s"

--- a/nutanix/services/networkingv2/data_source_nutanix_vpcs_v2_test.go
+++ b/nutanix/services/networkingv2/data_source_nutanix_vpcs_v2_test.go
@@ -76,12 +76,15 @@ func TestAccV2NutanixVpcsDataSource_WithFilter(t *testing.T) {
 func testAccVpcsDataSourceConfig(name, desc string) string {
 	return fmt.Sprintf(`
 
-		data "nutanix_clusters" "clusters" {}
+		data "nutanix_clusters_v2" "clusters" {}
 
 		locals {
-			cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+			cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 		}
-		
+
 		resource "nutanix_subnet_v2" "test" {
 			name = "terraform-test-subnet-vpc"
 			description = "test subnet description"
@@ -110,7 +113,7 @@ func testAccVpcsDataSourceConfig(name, desc string) string {
 					}
 				}
 			}
-			depends_on = [data.nutanix_clusters.clusters]
+			depends_on = [data.nutanix_clusters_v2.clusters]
 		}
 		resource "nutanix_vpc_v2" "rtest" {
 			name =  "%[1]s"

--- a/nutanix/services/networkingv2/resource_nutanix_floating_ip_v2_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_floating_ip_v2_test.go
@@ -93,12 +93,15 @@ func TestAccV2NutanixFloatingIPResource_WithPrivateIpAssociation(t *testing.T) {
 
 func testFloatingIPv2Config(name, desc string) string {
 	return fmt.Sprintf(`
-		data "nutanix_clusters" "clusters" {}
+		data "nutanix_clusters_v2" "clusters" {}
 
 		locals {
-		cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+		cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 		}
-		
+
 		resource "nutanix_subnet_v2" "test" {
 			name = "terraform-test-subnet-floating-ip"
 			description = "test subnet description"
@@ -172,12 +175,15 @@ func testFloatingIPv2ConfigWithVMNic(name, desc string) string {
 
 func testFloatingIPv2ConfigWithPrivateIP(name, desc string) string {
 	return fmt.Sprintf(`
-		data "nutanix_clusters" "clusters" {}
+		data "nutanix_clusters_v2" "clusters" {}
 
 		locals {
-			cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+			cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 		}
-		
+
 		resource "nutanix_subnet_v2" "test" {
 			name = "terraform-test-subnet-floating-ip"
 			description = "test subnet description"
@@ -206,7 +212,7 @@ func testFloatingIPv2ConfigWithPrivateIP(name, desc string) string {
 					}
 				}
 			}
-			depends_on = [data.nutanix_clusters.clusters]
+			depends_on = [data.nutanix_clusters_v2.clusters]
 		}
 
 		resource "nutanix_vpc_v2" "test" {
@@ -228,7 +234,7 @@ func testFloatingIPv2ConfigWithPrivateIP(name, desc string) string {
 						prefix_length = 32
 					}
 				}
-			}	
+			}
 			depends_on = [nutanix_subnet_v2.test]
 		}
 

--- a/nutanix/services/networkingv2/resource_nutanix_pbrs_v2_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_pbrs_v2_test.go
@@ -76,12 +76,15 @@ func TestAccV2NutanixPbrResource_ErrorWithPriority(t *testing.T) {
 
 func testPbrConfig(name, desc string) string {
 	return fmt.Sprintf(`
-	data "nutanix_clusters" "clusters" {}
+	data "nutanix_clusters_v2" "clusters" {}
 
 	locals {
-		cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+		cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 	}
-	
+
 	resource "nutanix_subnet_v2" "test" {
 		name = "terraform-test-subnet-vpc_%[1]s"
 		description = "test subnet description"
@@ -110,7 +113,7 @@ func testPbrConfig(name, desc string) string {
 				}
 			}
 		}
-		depends_on = [data.nutanix_clusters.clusters]
+		depends_on = [data.nutanix_clusters_v2.clusters]
 	}
 
 	resource "nutanix_vpc_v2" "test" {
@@ -147,12 +150,15 @@ func testPbrConfig(name, desc string) string {
 
 func testPbrConfigWithSrcDstn(name, desc string) string {
 	return fmt.Sprintf(`
-	data "nutanix_clusters" "clusters" {}
+	data "nutanix_clusters_v2" "clusters" {}
 
 	locals {
-		cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+		cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 	}
-	
+
 	resource "nutanix_subnet_v2" "test" {
 		name = "terraform-test-subnet-vpc_%[1]s"
 		description = "test subnet description"
@@ -181,7 +187,7 @@ func testPbrConfigWithSrcDstn(name, desc string) string {
 				}
 			}
 		}
-		depends_on = [data.nutanix_clusters.clusters]
+		depends_on = [data.nutanix_clusters_v2.clusters]
 	}
 
 	resource "nutanix_vpc_v2" "test" {
@@ -231,12 +237,15 @@ func testPbrConfigWithSrcDstn(name, desc string) string {
 
 func testPbrConfigWithDefaultPriority(name, desc string) string {
 	return fmt.Sprintf(`
-	data "nutanix_clusters" "clusters" {}
+	data "nutanix_clusters_v2" "clusters" {}
 
 	locals {
-		cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+		cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 	}
-	
+
 	resource "nutanix_subnet_v2" "test" {
 		name = "terraform-test-subnet-vpc_%[1]s"
 		description = "test subnet description"
@@ -265,7 +274,7 @@ func testPbrConfigWithDefaultPriority(name, desc string) string {
 				}
 			}
 		}
-		depends_on = [data.nutanix_clusters.clusters]
+		depends_on = [data.nutanix_clusters_v2.clusters]
 	}
 
 	resource "nutanix_vpc_v2" "test" {

--- a/nutanix/services/networkingv2/resource_nutanix_routes_v2_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_routes_v2_test.go
@@ -150,14 +150,14 @@ func TestAccV2NutanixRoutesResource_Basic(t *testing.T) {
 
 func testRouteSubnetConfig(r int) string {
 	return fmt.Sprintf(`
-	data "nutanix_clusters" "clusters" {}
+	data "nutanix_clusters_v2" "clusters" {}
 
 	locals {
 	  config  = (jsondecode(file("%[1]s")))
 	  subnets = local.config.networking.subnets
 	  cluster1 = [
-		for cluster in data.nutanix_clusters.clusters.entities :
-		cluster.metadata.uuid if cluster.service_list[0] != "PRISM_CENTRAL"
+		for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+    		cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
 	  ][0]
 	}
 
@@ -196,7 +196,7 @@ func testRouteSubnetConfig(r int) string {
 
 func testRouteVpc1Config(r int) string {
 	return testRouteSubnetConfig(r) + fmt.Sprintf(`
-	
+
 	resource "nutanix_vpc_v2" "test-1" {
 	  name        = "terraform_test_vpc_%[1]d"
 	  description = "terraform test vpc 1 to test create route"
@@ -210,7 +210,7 @@ func testRouteVpc1Config(r int) string {
 }
 
 func testRouteVpc2Config(r int) string {
-	return testRouteSubnetConfig(r) + fmt.Sprintf(`	
+	return testRouteSubnetConfig(r) + fmt.Sprintf(`
 		resource "nutanix_vpc_v2" "test-2" {
 		  name        = "terraform_test_vpc_%[1]d"
 		  description = "terraform test vpc 2 to test create route"
@@ -223,7 +223,7 @@ func testRouteVpc2Config(r int) string {
 }
 
 func testRouteTableInfoVpc1Config(r int) string {
-	return testRouteVpc1Config(r) + `	
+	return testRouteVpc1Config(r) + `
 		data "nutanix_route_tables_v2" "rt_vpc1" {
 		  filter     = "vpcReference eq '${nutanix_vpc_v2.test-1.id}'"
   		  depends_on = [nutanix_vpc_v2.test-1]
@@ -232,7 +232,7 @@ func testRouteTableInfoVpc1Config(r int) string {
 }
 
 func testRouteTableInfoVpc2Config(r int) string {
-	return testRouteVpc2Config(r) + `	
+	return testRouteVpc2Config(r) + `
 		data "nutanix_route_tables_v2" "rt_vpc2" {
 		  filter = "vpcReference eq '${nutanix_vpc_v2.test-2.id}'"
 		  depends_on = [nutanix_vpc_v2.test-2]

--- a/nutanix/services/networkingv2/resource_nutanix_subnets_v2_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_subnets_v2_test.go
@@ -98,12 +98,15 @@ func TestAccV2NutanixSubnetResource_WithExternalSubnet(t *testing.T) {
 
 func testSubnetV2Config(name, desc string) string {
 	return fmt.Sprintf(`
-		data "nutanix_clusters" "clusters" {}
+		data "nutanix_clusters_v2" "clusters" {}
 
 		locals {
-		cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+		cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 		}
-		
+
 		resource "nutanix_subnet_v2" "test" {
 			name = "%[1]s"
 			description = "%[2]s"
@@ -116,12 +119,15 @@ func testSubnetV2Config(name, desc string) string {
 
 func testSubnetV2ConfigWithIPPool(name, desc string) string {
 	return fmt.Sprintf(`
-		data "nutanix_clusters" "clusters" {}
+		data "nutanix_clusters_v2" "clusters" {}
 
 		locals {
-		cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+		cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 		}
-		
+
 		resource "nutanix_subnet_v2" "test" {
 			name = "%[1]s"
 			description = "%[2]s"
@@ -161,19 +167,22 @@ func testSubnetV2ConfigWithIPPool(name, desc string) string {
 				tftp_server_name = "10.5.0.10"
 				boot_file_name = "pxelinux.0"
 			}
-			depends_on = [data.nutanix_clusters.clusters]
+			depends_on = [data.nutanix_clusters_v2.clusters]
 		}
 `, name, desc)
 }
 
 func testSubnetV2ConfigWithExternalSubnet(name, desc string) string {
 	return fmt.Sprintf(`
-		data "nutanix_clusters" "clusters" {}
+		data "nutanix_clusters_v2" "clusters" {}
 
 		locals {
-		cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+		cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 		}
-		
+
 		resource "nutanix_subnet_v2" "test" {
 			name = "%[1]s"
 			description = "%[2]s"
@@ -202,7 +211,7 @@ func testSubnetV2ConfigWithExternalSubnet(name, desc string) string {
 					}
 				}
 			}
-		depends_on = [data.nutanix_clusters.clusters]
+		depends_on = [data.nutanix_clusters_v2.clusters]
 		}
 `, name, desc)
 }

--- a/nutanix/services/networkingv2/resource_nutanix_vpcs_v2_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_vpcs_v2_test.go
@@ -120,63 +120,16 @@ func TestAccV2NutanixVpcResource_WithTransitType(t *testing.T) {
 
 func testVpcConfig(name, desc string, vlanID int) string {
 	return fmt.Sprintf(`
-	
-	data "nutanix_clusters" "clusters" {}
+
+	data "nutanix_clusters_v2" "clusters" {}
 
 	locals {
-		cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+		cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 	}
-	
-	resource "nutanix_subnet_v2" "test" {
-		name = "terraform-test-subnet-vpc"
-		description = "test subnet description"
-		cluster_reference = local.cluster0
-		subnet_type = "VLAN"
-		network_id = %[3]d 
-		is_external = true
-		ip_config {
-			ipv4 {
-				ip_subnet {
-					ip {
-						value = "192.168.0.0"
-					}
-					prefix_length = 24
-				}
-				default_gateway_ip {
-					value = "192.168.0.1"
-				}
-				pool_list{
-					start_ip {
-						value = "192.168.0.20"
-					}
-					end_ip {
-						value = "192.168.0.30"
-					}
-				}
-			}
-		}
-		depends_on = [data.nutanix_clusters.clusters]
-	}
-	resource "nutanix_vpc_v2" "test" {
-		name =  "%[1]s"
-		description = "%[2]s"
-		external_subnets{
-		  subnet_reference = nutanix_subnet_v2.test.id
-		}
-		depends_on = [nutanix_subnet_v2.test]
-	}
-`, name, desc, vlanID)
-}
 
-func testVpcConfigWithExtRoutablePrefix(name, desc string, vlanID int) string {
-	return fmt.Sprintf(`
-	
-	data "nutanix_clusters" "clusters" {}
-
-	locals {
-		cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
-	}
-	
 	resource "nutanix_subnet_v2" "test" {
 		name = "terraform-test-subnet-vpc"
 		description = "test subnet description"
@@ -205,7 +158,60 @@ func testVpcConfigWithExtRoutablePrefix(name, desc string, vlanID int) string {
 				}
 			}
 		}
-		depends_on = [data.nutanix_clusters.clusters]
+		depends_on = [data.nutanix_clusters_v2.clusters]
+	}
+	resource "nutanix_vpc_v2" "test" {
+		name =  "%[1]s"
+		description = "%[2]s"
+		external_subnets{
+		  subnet_reference = nutanix_subnet_v2.test.id
+		}
+		depends_on = [nutanix_subnet_v2.test]
+	}
+`, name, desc, vlanID)
+}
+
+func testVpcConfigWithExtRoutablePrefix(name, desc string, vlanID int) string {
+	return fmt.Sprintf(`
+
+	data "nutanix_clusters_v2" "clusters" {}
+
+	locals {
+		cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
+	}
+
+	resource "nutanix_subnet_v2" "test" {
+		name = "terraform-test-subnet-vpc"
+		description = "test subnet description"
+		cluster_reference = local.cluster0
+		subnet_type = "VLAN"
+		network_id = %[3]d
+		is_external = true
+		ip_config {
+			ipv4 {
+				ip_subnet {
+					ip {
+						value = "192.168.0.0"
+					}
+					prefix_length = 24
+				}
+				default_gateway_ip {
+					value = "192.168.0.1"
+				}
+				pool_list{
+					start_ip {
+						value = "192.168.0.20"
+					}
+					end_ip {
+						value = "192.168.0.30"
+					}
+				}
+			}
+		}
+		depends_on = [data.nutanix_clusters_v2.clusters]
 	}
 	resource "nutanix_vpc_v2" "test" {
 		name =  "%[1]s"
@@ -241,13 +247,16 @@ func testVpcConfigWithExtRoutablePrefix(name, desc string, vlanID int) string {
 
 func testVpcConfigWithDHCP(name, desc string, vlanID int) string {
 	return fmt.Sprintf(`
-	
-	data "nutanix_clusters" "clusters" {}
+
+	data "nutanix_clusters_v2" "clusters" {}
 
 	locals {
-		cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+		cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 	}
-	
+
 	resource "nutanix_subnet_v2" "test" {
 	 	name              = "terraform-test-subnet-vpc"
 	  	description       = "test subnet description"
@@ -276,7 +285,7 @@ func testVpcConfigWithDHCP(name, desc string, vlanID int) string {
 			  }
 			}
 		  }
-		  depends_on = [data.nutanix_clusters.clusters]
+		  depends_on = [data.nutanix_clusters_v2.clusters]
 		}
 		resource "nutanix_vpc_v2" "test" {
 		  name        = "%[1]s"
@@ -296,7 +305,7 @@ func testVpcConfigWithDHCP(name, desc string, vlanID int) string {
 			  }
 			}
 		  }
-		
+
 		  externally_routable_prefixes {
 			ipv4 {
 			  ip {
@@ -314,13 +323,16 @@ func testVpcConfigWithDHCP(name, desc string, vlanID int) string {
 
 func testVpcConfigWithTransitType(name, desc string, vlanID int) string {
 	return fmt.Sprintf(`
-	
-	data "nutanix_clusters" "clusters" {}
+
+	data "nutanix_clusters_v2" "clusters" {}
 
 	locals {
-		cluster0 = data.nutanix_clusters.clusters.entities[0].metadata.uuid
+		cluster0 =  [
+			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		][0]
 	}
-	
+
 	resource "nutanix_subnet_v2" "test" {
 		name = "terraform-test-subnet-vpc"
 		description = "test subnet description"
@@ -349,7 +361,7 @@ func testVpcConfigWithTransitType(name, desc string, vlanID int) string {
 				}
 			}
 		}
-		depends_on = [data.nutanix_clusters.clusters]
+		depends_on = [data.nutanix_clusters_v2.clusters]
 	}
 	resource "nutanix_vpc_v2" "test" {
 		name =  "%[1]s"

--- a/nutanix/services/prismv2/resource_nutanix_pc_deploy_v2_test.go
+++ b/nutanix/services/prismv2/resource_nutanix_pc_deploy_v2_test.go
@@ -14,7 +14,6 @@ import (
 const resourceNameDeployPC = "nutanix_pc_deploy_v2.test"
 
 func TestAccV2NutanixDeployPcResource_Basic(t *testing.T) {
-	t.Skip("Skipping test no need to run this test on pipeline")
 	r := acctest.RandInt()
 	name := fmt.Sprintf("tf-test-deploy-pc-%d", r)
 

--- a/nutanix/services/volumesv2/data_source_nutanix_volume_groups_v2_test.go
+++ b/nutanix/services/volumesv2/data_source_nutanix_volume_groups_v2_test.go
@@ -88,7 +88,7 @@ func testAccVolumeGroupsDataSourceConfig(filepath, name, desc string) string {
 }
 
 func testAccVolumeGroupsDataSourceWithFilter(filepath, name, desc string) string {
-	return testAccVolumeGroupResourceConfig(name, desc) + fmt.Sprintf(`		
+	return testAccVolumeGroupResourceConfig(name, desc) + fmt.Sprintf(`
 	data "nutanix_volume_groups_v2" "test" {
 		filter = "name eq '%s'"
 		depends_on = [resource.nutanix_volume_group_v2.test]
@@ -99,35 +99,35 @@ func testAccVolumeGroupsDataSourceWithFilter(filepath, name, desc string) string
 func testAccVolumeGroupsDataSourceWithLimit(name, desc string, limit int) string {
 	return fmt.Sprintf(
 		`
-			data "nutanix_clusters" "clusters" {}
+			data "nutanix_clusters_v2" "clusters" {}
 
 			locals {
 				cluster1 = [
-					for cluster in data.nutanix_clusters.clusters.entities :
-					cluster.metadata.uuid if cluster.service_list[0] != "PRISM_CENTRAL"
-				][0]				
+					for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+						cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+				][0]
 			}
-	
+
 			resource "nutanix_volume_group_v2" "test1" {
 				name              = "%[1]s_1"
 				cluster_reference = local.cluster1
 				description       = "%[2]s"
 			}
-	
+
 			resource "nutanix_volume_group_v2" "test2" {
 				name              = "%[1]s_2"
 				cluster_reference = local.cluster1
 				description       = "%[2]s"
 				depends_on        = [resource.nutanix_volume_group_v2.test1]
 			}
-	
+
 			resource "nutanix_volume_group_v2" "test3" {
 				name              = "%[1]s_3"
 				cluster_reference = local.cluster1
 				description       = "%[2]s"
 				depends_on        = [resource.nutanix_volume_group_v2.test2]
 			}
-	
+
 			data "nutanix_volume_groups_v2" "test" {
 				filter     = "startswith(name, '%[1]s')"
 				limit      = %[3]d

--- a/nutanix/services/volumesv2/resource_nutanix_volume_group_v2_test.go
+++ b/nutanix/services/volumesv2/resource_nutanix_volume_group_v2_test.go
@@ -123,12 +123,12 @@ func TestAccV2NutanixVolumeGroupResource_WithAttachmentTypeAndProtocolAndDisks(t
 // VG just required attributes
 func testAccVolumeGroupV2RequiredAttributes(name string) string {
 	return fmt.Sprintf(`
-	data "nutanix_clusters" "clusters" {}
+	data "nutanix_clusters_v2" "clusters" {}
 
 	locals{
 		cluster1 = [
-			for cluster in data.nutanix_clusters.clusters.entities :
-			cluster.metadata.uuid if cluster.service_list[0] != "PRISM_CENTRAL"
+			for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+				cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
 		][0]
 	}
 
@@ -142,15 +142,15 @@ func testAccVolumeGroupV2RequiredAttributes(name string) string {
 
 func testAccVolumeGroupV2ConfigWithNoName() string {
 	return `
-		data "nutanix_clusters" "clusters" {}
-	
+		data "nutanix_clusters_v2" "clusters" {}
+
 		locals{
 			cluster1 = [
-				for cluster in data.nutanix_clusters.clusters.entities :
-				cluster.metadata.uuid if cluster.service_list[0] != "PRISM_CENTRAL"
+				for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+					cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
 			][0]
 		}
-	
+
 		resource "nutanix_volume_group_v2" "test" {
 			cluster_reference                  = local.cluster1
 		  }
@@ -160,7 +160,7 @@ func testAccVolumeGroupV2ConfigWithNoName() string {
 func testAccVolumeGroupV2ConfigWithNoClusterReference(name string) string {
 	return fmt.Sprintf(`
 	resource "nutanix_volume_group_v2" "test" {
-		name                               = "%s"	
+		name                               = "%s"
 	  }
 `, name)
 }
@@ -173,7 +173,7 @@ func testAccVolumeGroupResourceConfigWithAttachmentTypeAndProtocolAndDisks(name 
 		cluster1 =  [
 			  for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
 			  cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
-		][0]		
+		][0]
 	}
 
     data "nutanix_storage_containers_v2" "test" {
@@ -185,7 +185,7 @@ func testAccVolumeGroupResourceConfigWithAttachmentTypeAndProtocolAndDisks(name 
 		name                               = "%[1]s"
 		description                        = "%[2]s"
 		should_load_balance_vm_attachments = false
-		sharing_status                     = "SHARED"		
+		sharing_status                     = "SHARED"
 		created_by 						   = "admin"
 		cluster_reference                  = local.cluster1
 		iscsi_features {
@@ -210,7 +210,7 @@ func testAccVolumeGroupResourceConfigWithAttachmentTypeAndProtocolAndDisks(name 
 			  uris        = ["uri1","uri2"]
 			}
 			disk_storage_features {
-				flash_mode {	
+				flash_mode {
 					is_enabled = false
 				}
 			}
@@ -221,6 +221,6 @@ func testAccVolumeGroupResourceConfigWithAttachmentTypeAndProtocolAndDisks(name 
 			  iscsi_features[0].target_secret
 			]
 		}
-	  }	  
+	  }
 	`, name, desc)
 }


### PR DESCRIPTION
## TESTCASES:
- this PR including fix acceptance tests that was using old (v1) nutanix_clusters data source to fetch the clusters, change it to v2 nutanix_clusters_v2. 