### PR TITLE
Add support for executing individual testcase/package

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -139,9 +139,9 @@ jobs:
                   elif [ "$provider" = "era" ]
                       then
                           runFlag+="TestAccEra*"
-                  else 
-                          echo "Invalid provider=$provider given in arguments."
-                          exit 1
+                  else
+                      echo "running individual testcase"
+                      runFlag+="$provider"
                   fi
                   if [ $index -lt $((n-1)) ]
                       then

--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -140,7 +140,7 @@ jobs:
                       then
                           runFlag+="TestAccEra*"
                   else
-                      echo "running individual testcase"
+                      echo "running individual testcase/package"
                       runFlag+="$provider"
                   fi
                   if [ $index -lt $((n-1)) ]


### PR DESCRIPTION
As of now there is no support for executing individual testcase/package
For Example: If user wanted to execute TestAccV2NutanixRolesResource(which is from a specific module), user can send a command `/ok-to-test TestAccV2NutanixRolesResource*`.

Removed the existing code, even though if user send a invalid argument to run testcases, It's a no-op.