### PR TITLE
Add changes to install sshpass as part of pipeline

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -54,9 +54,9 @@ jobs:
           go mod tidy
           go mod vendor
 
-      - name: Install unzip
+      - name: Install unzip and sshpass
         run: |
-          sudo apt-get update && sudo apt-get install -y unzip
+          sudo apt-get update && sudo apt-get install -y unzip sshpass
 
       - name: Setup Terraform v1.10.5
         run: |


### PR DESCRIPTION
Why we need sshpass?
Clusters tests are dependent on sshpass to reset the cluster password. So inorder to run the cluster tests on pipeline we need sshpass to be installed.