### PR TITLE
skip pc restore tests based on skip_pc_restore_test variable

### DIFF
--- a/nutanix/services/prismv2/main_test.go
+++ b/nutanix/services/prismv2/main_test.go
@@ -35,6 +35,7 @@ type TestConfig struct {
 		Unregister struct {
 			PcExtID string `json:"pc_ext_id"`
 		} `json:"unregister"`
+		SkipPCRestoreTest bool `json:"skip_pc_restore_test"`
 	} `json:"prism"`
 }
 

--- a/nutanix/services/prismv2/resource_nutanix_pc_restore_v2_test.go
+++ b/nutanix/services/prismv2/resource_nutanix_pc_restore_v2_test.go
@@ -20,7 +20,7 @@ func TestAccV2NutanixRestorePCResource_ClusterLocationRestorePC(t *testing.T) {
 		// We are skipping the PC restore tests because they require powering off the PC VM,
 		// which could affect the execution of other test cases running in parallel.
 		// The PC restore test cases can be run separately.
-		t.Skip("Skipping PC restore test")
+		t.Skip("Skipping PC restore test: We are skipping the PC restore tests because they require powering off the PC VM, which could affect the execution of other test cases running in parallel. The PC restore test cases can be run separately.")
 	}
 	var backupTargetExtID, domainManagerExtID, restoreSourceExtID = new(string), new(string), new(string)
 	var restorePcConfig string
@@ -143,7 +143,7 @@ func TestAccV2NutanixRestorePCResource_ObjectRestoreSourceRestorePC(t *testing.T
 		// We are skipping the PC restore tests because they require powering off the PC VM,
 		// which could affect the execution of other test cases running in parallel.
 		// The PC restore test cases can be run separately.
-		t.Skip("Skipping PC restore test")
+		t.Skip("Skipping PC restore test: We are skipping the PC restore tests because they require powering off the PC VM, which could affect the execution of other test cases running in parallel. The PC restore test cases can be run separately.")
 	}
 	var backupTargetExtID, domainManagerExtID, restoreSourceExtID = new(string), new(string), new(string)
 	var restorePcConfig string

--- a/nutanix/services/prismv2/resource_nutanix_pc_restore_v2_test.go
+++ b/nutanix/services/prismv2/resource_nutanix_pc_restore_v2_test.go
@@ -16,6 +16,9 @@ import (
 const resourceNameRestorePC = "nutanix_pc_restore_v2.test"
 
 func TestAccV2NutanixRestorePCResource_ClusterLocationRestorePC(t *testing.T) {
+	if testVars.Prism.SkipPCRestoreTest {
+		t.Skip("Skipping PC restore test")
+	}
 	var backupTargetExtID, domainManagerExtID, restoreSourceExtID = new(string), new(string), new(string)
 	var restorePcConfig string
 
@@ -133,6 +136,9 @@ func TestAccV2NutanixRestorePCResource_ClusterLocationRestorePC(t *testing.T) {
 }
 
 func TestAccV2NutanixRestorePCResource_ObjectRestoreSourceRestorePC(t *testing.T) {
+	if testVars.Prism.SkipPCRestoreTest {
+		t.Skip("Skipping PC restore test")
+	}
 	var backupTargetExtID, domainManagerExtID, restoreSourceExtID = new(string), new(string), new(string)
 	var restorePcConfig string
 

--- a/nutanix/services/prismv2/resource_nutanix_pc_restore_v2_test.go
+++ b/nutanix/services/prismv2/resource_nutanix_pc_restore_v2_test.go
@@ -17,6 +17,9 @@ const resourceNameRestorePC = "nutanix_pc_restore_v2.test"
 
 func TestAccV2NutanixRestorePCResource_ClusterLocationRestorePC(t *testing.T) {
 	if testVars.Prism.SkipPCRestoreTest {
+		// We are skipping the PC restore tests because they require powering off the PC VM,
+		// which could affect the execution of other test cases running in parallel.
+		// The PC restore test cases can be run separately.
 		t.Skip("Skipping PC restore test")
 	}
 	var backupTargetExtID, domainManagerExtID, restoreSourceExtID = new(string), new(string), new(string)
@@ -137,6 +140,9 @@ func TestAccV2NutanixRestorePCResource_ClusterLocationRestorePC(t *testing.T) {
 
 func TestAccV2NutanixRestorePCResource_ObjectRestoreSourceRestorePC(t *testing.T) {
 	if testVars.Prism.SkipPCRestoreTest {
+		// We are skipping the PC restore tests because they require powering off the PC VM,
+		// which could affect the execution of other test cases running in parallel.
+		// The PC restore test cases can be run separately.
 		t.Skip("Skipping PC restore test")
 	}
 	var backupTargetExtID, domainManagerExtID, restoreSourceExtID = new(string), new(string), new(string)

--- a/test_config_v2.json
+++ b/test_config_v2.json
@@ -277,7 +277,8 @@
       "pe_ip": "",
       "ssh_user": "",
       "ssh_password": ""
-    }
+    },
+    "skip_pc_restore_test": true
   },
   "data_protection": {
     "local_cluster_pe": "",


### PR DESCRIPTION
## TESTCASES 

Skip the `TestAccV2NutanixRestorePCResource` test cases based on a variable defined in` test_confog_v2`. We are skipping the PC restore tests because they require powering off the PC VM, which will affect the execution of other test cases running in parallel and it will fail. The PC restore test cases can be run separately.