### PR TITLE
Revert test results segregation from test execution

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -162,15 +162,11 @@ jobs:
               set -o pipefail  # Ensure failure detection in pipelines
               TF_LOG="ERROR" TF_ACC=1 go test ./... -v ${TESTARGS} -timeout 500m -coverprofile c.out -covermode=count TEST_EXIT_CODE=$? | tee test_output.log
               
-              if [ "$TEST_EXIT_CODE" -ne 0 ]; then
-                echo "Test Case Execution Failed" >> $GITHUB_ENV
-                echo "REACTION_TYPE=confused" >> $GITHUB_ENV
-                exit 1  # Fail the stage
-              fi
-      
-      - name: Test Results
-        run: |
-             # Ensure test output exists
+              # Debug: Check if the file exists before proceeding
+              echo "Checking if test_output.log exists..."
+              ls -l test_output.log || echo "test_output.log NOT FOUND!"
+
+              # Ensure test output exists
               if [ ! -f test_output.log ]; then
                   echo "No test output found!"
                   echo "REACTION_TYPE=confused" >> $GITHUB_ENV
@@ -243,6 +239,12 @@ jobs:
                           echo "==========================================================================================================================================================="
                       fi
                   done
+              fi
+
+              if [ "$TEST_EXIT_CODE" -ne 0 ]; then
+                echo "Test Case Execution Failed" >> $GITHUB_ENV
+                echo "REACTION_TYPE=confused" >> $GITHUB_ENV
+                exit 1  # Fail the stage
               fi
 
       - name: Code Coverage Check


### PR DESCRIPTION
In previous commit we have segregated the test results part from testcase execution to make the pipeline more modular. But for some reason Test Summary stage is failing, until we debug the issue I'm reverting the previous changes.