### PR TITLE
Use current branch instead of defaulting to master for workflow execute.

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -10,11 +10,11 @@ jobs:
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - run: echo "🔎 The name of your branch is ${{ github.event.client_payload.pull_request.head.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
         uses: actions/checkout@v4
         with:
-          ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
+          ref: ${{ github.event.client_payload.pull_request.head.ref }}  # This ensures it checks out the PR branch
 
       - name: Remove Cached Go Versions
         run: |

--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -16,6 +16,10 @@ jobs:
         with:
           ref: ${{ github.event.client_payload.pull_request.head.ref }}  # This ensures it checks out the PR branch
 
+      - name: Debug: Verify Checked Out Branch
+        run: |
+          git rev-parse --abbrev-ref HEAD
+
       - name: Remove Cached Go Versions
         run: |
           sudo rm -rf /home/ubuntu/actions-runner/_work/_tool/go


### PR DESCRIPTION
Workflow is checking out a merge commit (refs/pull/.../merge), which doesn't actually check out the source branch of the pull request. Instead, it checks out the temporary merge commit that GitHub creates. To ensure that your workflow checks out the PR source branch (instead of master), updated the checkout step.