### PR TITLE
fix v2 test cases name to be run only with v2 test case

### DIFF
--- a/nutanix/services/dataprotectionv2/data_source_nutanix_vm_recovery_point_info_v2_test.go
+++ b/nutanix/services/dataprotectionv2/data_source_nutanix_vm_recovery_point_info_v2_test.go
@@ -12,7 +12,7 @@ import (
 
 const datasourceNameVMRecoveryPoint = "data.nutanix_vm_recovery_point_info_v2.test"
 
-func TestAccNutanixVmRecoveryPointV2Datasource_VmRecoveryPoint(t *testing.T) {
+func TestAccV2NutanixVmRecoveryPointDatasource_VmRecoveryPoint(t *testing.T) {
 	r := acctest.RandInt()
 	name := fmt.Sprintf("tf-test-recovery-point-%d", r)
 	vmName := fmt.Sprintf("tf-test-rp-vm-%d", r)
@@ -39,7 +39,7 @@ func TestAccNutanixVmRecoveryPointV2Datasource_VmRecoveryPoint(t *testing.T) {
 	})
 }
 
-func TestAccNutanixVmRecoveryPointV2Datasource_VmRecoveryPointWithAppConsProps(t *testing.T) {
+func TestAccV2NutanixVmRecoveryPointDatasource_VmRecoveryPointWithAppConsProps(t *testing.T) {
 	t.Skip("Skipping this test case as it is failing due to missing app consistent properties in get request")
 	r := acctest.RandInt()
 	name := fmt.Sprintf("tf-test-recovery-point-%d", r)
@@ -72,7 +72,7 @@ func TestAccNutanixVmRecoveryPointV2Datasource_VmRecoveryPointWithAppConsProps(t
 }
 
 func testVMRecoveryPointDatasourceConfigWithVMRecoveryPoint(name, expirationTime string) string {
-	return testRecoveryPointsResourceConfigWithVMRecoveryPoints(name, expirationTime) + `	
+	return testRecoveryPointsResourceConfigWithVMRecoveryPoints(name, expirationTime) + `
 	data "nutanix_vm_recovery_point_info_v2" "test" {
 	  recovery_point_ext_id = nutanix_recovery_points_v2.test.ext_id
 	  ext_id                = nutanix_recovery_points_v2.test.vm_recovery_points[0].ext_id

--- a/nutanix/services/iamv2/data_source_nutanix_user_groups_v2_test.go
+++ b/nutanix/services/iamv2/data_source_nutanix_user_groups_v2_test.go
@@ -10,7 +10,7 @@ import (
 
 const datasourceNameUserGroups = "data.nutanix_user_groups_v2.test"
 
-func TestAccNutanixUserGroupsV2Datasource_Basic(t *testing.T) {
+func TestAccV2NutanixUserGroupsDatasource_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
@@ -26,7 +26,7 @@ func TestAccNutanixUserGroupsV2Datasource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccNutanixUserGroupsV2Datasource_WithFilter(t *testing.T) {
+func TestAccV2NutanixUserGroupsDatasource_WithFilter(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
@@ -46,7 +46,7 @@ func TestAccNutanixUserGroupsV2Datasource_WithFilter(t *testing.T) {
 	})
 }
 
-func TestAccNutanixUserGroupsV2Datasource_WithLimit(t *testing.T) {
+func TestAccV2NutanixUserGroupsDatasource_WithLimit(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
@@ -98,7 +98,7 @@ func testUserGroupsDatasourceV4WithFilterConfig(filepath string) string {
 		name = local.user_groups.name
 		distinguished_name = local.user_groups.distinguished_name
 	  }
-	  
+
 	  data "nutanix_user_groups_v2" "test" {
 		filter     = "name eq '${local.user_groups.name}'"
 		depends_on = [resource.nutanix_user_groups_v2.test]


### PR DESCRIPTION
#TESTCASE
change test cases name to be run only with v2 test cases, current behavior its run with v1: 
- TestAccNutanixVmRecoveryPointV2Datasource_VmRecoveryPoint --> TestAccV2NutanixVmRecoveryPointDatasource_VmRecoveryPointWithAppConsProps
- TestAccNutanixVmRecoveryPointV2Datasource_VmRecoveryPoint --> TestAccV2NutanixVmRecoveryPointDatasource_VmRecoveryPoint
- TestAccNutanixUserGroupsV2Datasource_Basic -->TestAccV2NutanixUserGroupsDatasource_Basic
- TestAccNutanixUserGroupsV2Datasource_WithFilter--> TestAccV2NutanixUserGroupsDatasource_WithFilter
- TestAccNutanixUserGroupsV2Datasource_WithLimit --> TestAccV2NutanixUserGroupsDatasource_WithLimit