### PR TITLE
Add hypervisor_isos attribute to support adding hypervisor details while deploying node using FC

### DIFF
--- a/nutanix/sdks/v3/fc/fc_structs.go
+++ b/nutanix/sdks/v3/fc/fc_structs.go
@@ -195,6 +195,7 @@ type HypervisorIsoDetails struct {
 	URL              *string `json:"url,omitempty"`
 	HypervProductKey *string `json:"hyperv_product_key,omitempty"`
 	Sha256sum        *string `json:"sha256sum,omitempty"`
+	HypervisorType   *string `json:"hypervisor_type,omitempty"`
 }
 
 // format of Node to be Imaged
@@ -221,18 +222,19 @@ type Node struct {
 
 // Input to Create a cluster
 type CreateClusterInput struct {
-	ClusterExternalIP     *string                `json:"cluster_external_ip,omitempty"`
-	CommonNetworkSettings *CommonNetworkSettings `json:"common_network_settings,omitempty"`
-	HypervisorIsoDetails  *HypervisorIsoDetails  `json:"hypervisor_iso_details,omitempty"`
-	StorageNodeCount      *int                   `json:"storage_node_count,omitempty"`
-	RedundancyFactor      *int                   `json:"redundancy_factor,omitempty"`
-	ClusterName           *string                `json:"cluster_name,omitempty"`
-	AosPackageURL         *string                `json:"aos_package_url,omitempty"`
-	ClusterSize           *int                   `json:"cluster_size,omitempty"`
-	AosPackageSha256sum   *string                `json:"aos_package_sha256sum,omitempty"`
-	Timezone              *string                `json:"timezone,omitempty"`
-	NodesList             []*Node                `json:"nodes_list,omitempty"`
-	SkipClusterCreation   bool                   `json:"skip_cluster_creation,omitempty"`
+	ClusterExternalIP     *string                 `json:"cluster_external_ip,omitempty"`
+	CommonNetworkSettings *CommonNetworkSettings  `json:"common_network_settings,omitempty"`
+	HypervisorIsoDetails  *HypervisorIsoDetails   `json:"hypervisor_iso_details,omitempty"`
+	HypervisorIsos        *[]HypervisorIsoDetails `json:"hypervisor_isos,omitempty"`
+	StorageNodeCount      *int                    `json:"storage_node_count,omitempty"`
+	RedundancyFactor      *int                    `json:"redundancy_factor,omitempty"`
+	ClusterName           *string                 `json:"cluster_name,omitempty"`
+	AosPackageURL         *string                 `json:"aos_package_url,omitempty"`
+	ClusterSize           *int                    `json:"cluster_size,omitempty"`
+	AosPackageSha256sum   *string                 `json:"aos_package_sha256sum,omitempty"`
+	Timezone              *string                 `json:"timezone,omitempty"`
+	NodesList             []*Node                 `json:"nodes_list,omitempty"`
+	SkipClusterCreation   bool                    `json:"skip_cluster_creation,omitempty"`
 }
 
 // Response of cluster creation

--- a/nutanix/services/foundationCentral/resource_nutanix_foundation_central_image_nodes.go
+++ b/nutanix/services/foundationCentral/resource_nutanix_foundation_central_image_nodes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
 	fc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v3/fc"
 	"github.com/terraform-providers/terraform-provider-nutanix/utils"
@@ -98,6 +99,36 @@ func ResourceNutanixFCImageCluster() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
+						},
+					},
+				},
+			},
+			"hypervisor_isos": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"hyperv_sku": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"url": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"hyperv_product_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"sha256sum": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"hypervisor_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"kvm", "hyperv", "esx"}, false),
 						},
 					},
 				},
@@ -673,20 +704,22 @@ func expandNetworklist(pr interface{}) []string {
 	return c
 }
 
-func expandHyperVisorIsoDetails(d *schema.ResourceData) *fc.HypervisorIsoDetails {
-	hid := fc.HypervisorIsoDetails{}
-	resourceData, ok := d.GetOk("hypervisor_iso_details")
-	if !ok {
+func expandHyperVisorIsoDetails(config interface{}) *[]fc.HypervisorIsoDetails {
+
+	if config.([]interface{}) == nil && len(config.([]interface{})) == 0 {
 		return nil
 	}
-	settingsMap := resourceData.([]interface{})[0].(map[string]interface{})
+	settingsMap := config.([]interface{})[0].(map[string]interface{})
 
+	hid := fc.HypervisorIsoDetails{}
 	hid.HypervSku = utils.StringPtr(settingsMap["hyperv_sku"].(string))
 	hid.URL = utils.StringPtr(settingsMap["url"].(string))
 	hid.HypervProductKey = utils.StringPtr(settingsMap["hyperv_product_key"].(string))
 	hid.Sha256sum = utils.StringPtr(settingsMap["sha256sum"].(string))
-
-	return &hid
+	hid.HypervisorType = utils.StringPtr(settingsMap["hypervisor_type"].(string))
+	var hypervisorIsos []fc.HypervisorIsoDetails
+	hypervisorIsos = append(hypervisorIsos, hid)
+	return &hypervisorIsos
 }
 
 func expandNodesList(d *schema.ResourceData) []*fc.Node {
@@ -830,8 +863,21 @@ func resourceNutanixFCImageClusterCreate(ctx context.Context, d *schema.Resource
 		req.SkipClusterCreation = skipClusterCreation.(bool)
 	}
 
+	if hypervisorIsos, ok := d.GetOk("hypervisor_isos"); ok {
+		h := expandHyperVisorIsoDetails(hypervisorIsos)
+		if h != nil {
+			req.HypervisorIsos = h
+		}
+	}
+
+	if hypervisorIsos, ok := d.GetOk("hypervisor_iso_details"); ok {
+		h := expandHyperVisorIsoDetails(hypervisorIsos)
+		if h != nil {
+			req.HypervisorIsoDetails = &(*h)[0]
+		}
+	}
+
 	req.CommonNetworkSettings = expandCommonNetworkSettings(d)
-	req.HypervisorIsoDetails = expandHyperVisorIsoDetails(d)
 	req.NodesList = expandNodesList(d)
 
 	// Poll to Check whether Nodes are Available for Imaging - Node Detail GET Call

--- a/nutanix/services/foundationCentral/resource_nutanix_foundation_central_image_nodes.go
+++ b/nutanix/services/foundationCentral/resource_nutanix_foundation_central_image_nodes.go
@@ -705,12 +705,10 @@ func expandNetworklist(pr interface{}) []string {
 }
 
 func expandHyperVisorIsoDetails(config interface{}) *[]fc.HypervisorIsoDetails {
-
 	if config.([]interface{}) == nil && len(config.([]interface{})) == 0 {
 		return nil
 	}
 	settingsMap := config.([]interface{})[0].(map[string]interface{})
-
 	hid := fc.HypervisorIsoDetails{}
 	hid.HypervSku = utils.StringPtr(settingsMap["hyperv_sku"].(string))
 	hid.URL = utils.StringPtr(settingsMap["url"].(string))

--- a/website/docs/r/foundation_central_image_cluster.html.markdown
+++ b/website/docs/r/foundation_central_image_cluster.html.markdown
@@ -87,6 +87,12 @@ resource "nutanix_foundation_central_image_cluster" "img2"{
     }
     aos_package_url="<URL>"
 
+    // required for deploying AOS >= v6.8
+    hypervisor_isos{
+      url="<hypervisor-installer-link>"
+      sha256sum="<hypervisor-installer-checksum>"
+      hypervisor_type = "kvm"
+    }
     //pass true to skip cluster creation
     skip_cluster_creation = true
 
@@ -102,7 +108,8 @@ The following arguments are supported:
 
 * `cluster_external_ip`: External management ip of the cluster.
 * `common_network_settings`: Common network settings across the nodes in the cluster. 
-* `hypervisor_iso_details`: Details of the hypervisor iso.
+* `hypervisor_iso_details`: Details of the hypervisor iso. (Deprecated)
+* `hypervisor_isos`: Details of the hypervisor iso. Required for deploying node with AOS >= 6.8
 * `storage_node_count`: Number of storage only nodes in the cluster. AHV iso for storage node will be taken from aos package.
 * `redundancy_factor`: Redundancy factor of the cluster.
 * `cluster_name`: Name of the cluster.
@@ -123,6 +130,13 @@ The following arguments are supported:
 * `url`: (Required) URL to download hypervisor iso. Required only if imaging is needed. 
 * `hyperv_product_key`: Product key for hyperv isos. Required only if the hypervisor type is hyperv and product key is mandatory (ex: for volume license).
 * `sha256sum`: sha256sum of the hypervisor iso.
+
+### hypervisor isos
+* `hyperv_sku`: SKU of hyperv to be installed if hypervisor_type is hyperv.
+* `url`: (Required) URL to download hypervisor iso. Required only if imaging is needed. 
+* `hyperv_product_key`: Product key for hyperv isos. Required only if the hypervisor type is hyperv and product key is mandatory (ex: for volume license).
+* `sha256sum`: sha256sum of the hypervisor iso.
+* `hypervisor_type`: Hypervisor type. Only supports "kvm", "esx" and "hyperv"
 
 ### node list
 * `cvm_gateway`: Gateway of the cvm.


### PR DESCRIPTION
Add hypervisor_isos attribute to support adding hypervisor details while deploying node using FC.
This is required for AOS >= 6.8 as AHV is not bundled with AOS packages anymore