### PR TITLE
In Subnets V2, IsNatEnabled should be set to false in api payload if set to false in Tf script

### DIFF
--- a/nutanix/common/common.go
+++ b/nutanix/common/common.go
@@ -1,5 +1,11 @@
 package common
 
+import (
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
 // ExpandListOfString to expand a list of interface{}
 // which is defined in the schema
 // its return a list of string
@@ -9,4 +15,21 @@ func ExpandListOfString(list []interface{}) []string {
 		stringListStr[i] = v.(string)
 	}
 	return stringListStr
+}
+
+// defined to determine whether a particular key (or configuration attribute) within a Terraform resource configuration has been explicitly set by the user.
+// Returns a Boolean (true or false). true indicates that the key was explicitly set with a non-null value; false implies it was either not set, is unknown, or explicitly set to null.
+func IsExplicitlySet(d *schema.ResourceData, key string) bool {
+	rawConfig := d.GetRawConfig() // Get raw Terraform config as cty.Value
+	if rawConfig.IsNull() || !rawConfig.IsKnown() {
+		return false // If rawConfig is null/unknown, key wasn't explicitly set
+	}
+
+	// Convert rawConfig to map and check if key exists
+	configMap := rawConfig.AsValueMap()
+	if val, exists := configMap[key]; exists {
+		log.Printf("[DEBUG] Key: %s, Value: %s", key, val)
+		return !val.IsNull() // Ensure key exists and isn't explicitly null
+	}
+	return false
 }

--- a/nutanix/services/networkingv2/resource_nutanix_subnets_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_subnets_v2.go
@@ -493,7 +493,8 @@ func ResourceNutanixSubnetV2Create(ctx context.Context, d *schema.ResourceData, 
 	if vpcRef, ok := d.GetOk("vpc_reference"); ok {
 		inputSpec.VpcReference = utils.StringPtr(vpcRef.(string))
 	}
-	if isNat, ok := d.GetOk("is_nat_enabled"); ok {
+
+	if isNat, ok := d.GetOkExists("is_nat_enabled"); ok {
 		inputSpec.IsNatEnabled = utils.BoolPtr(isNat.(bool))
 	}
 	if isExt, ok := d.GetOk("is_external"); ok {
@@ -536,6 +537,8 @@ func ResourceNutanixSubnetV2Create(ctx context.Context, d *schema.ResourceData, 
 	if ipConfig, ok := d.GetOk("ip_config"); ok {
 		inputSpec.IpConfig = expandIPConfig(ipConfig.([]interface{}))
 	}
+	aJSON, _ := json.MarshalIndent(inputSpec, "", " ")
+	log.Printf("[DEBUG] Subnets body : %s", string(aJSON))
 
 	resp, err := conn.SubnetAPIInstance.CreateSubnet(&inputSpec)
 	if err != nil {

--- a/nutanix/services/networkingv2/resource_nutanix_subnets_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_subnets_v2.go
@@ -538,7 +538,7 @@ func ResourceNutanixSubnetV2Create(ctx context.Context, d *schema.ResourceData, 
 		inputSpec.IpConfig = expandIPConfig(ipConfig.([]interface{}))
 	}
 	aJSON, _ := json.MarshalIndent(inputSpec, "", " ")
-	log.Printf("[DEBUG] Subnets body : %s", string(aJSON))
+	log.Printf("[DEBUG] Subnets create payload : %s", string(aJSON))
 
 	resp, err := conn.SubnetAPIInstance.CreateSubnet(&inputSpec)
 	if err != nil {

--- a/nutanix/services/networkingv2/resource_nutanix_subnets_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_subnets_v2.go
@@ -13,6 +13,7 @@ import (
 	import1 "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/networking/v4/config"
 	import4 "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/prism/v4/config"
 	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/common"
 	"github.com/terraform-providers/terraform-provider-nutanix/utils"
 )
 
@@ -493,12 +494,13 @@ func ResourceNutanixSubnetV2Create(ctx context.Context, d *schema.ResourceData, 
 	if vpcRef, ok := d.GetOk("vpc_reference"); ok {
 		inputSpec.VpcReference = utils.StringPtr(vpcRef.(string))
 	}
-
-	if isNat, ok := d.GetOkExists("is_nat_enabled"); ok {
-		inputSpec.IsNatEnabled = utils.BoolPtr(isNat.(bool))
+	if common.IsExplicitlySet(d, "is_nat_enabled") {
+		isNat := d.Get("is_nat_enabled").(bool)
+		inputSpec.IsNatEnabled = utils.BoolPtr(isNat)
 	}
-	if isExt, ok := d.GetOk("is_external"); ok {
-		inputSpec.IsExternal = utils.BoolPtr(isExt.(bool))
+	if common.IsExplicitlySet(d, "is_external") {
+		isExt := d.Get("is_external").(bool)
+		inputSpec.IsExternal = utils.BoolPtr(isExt)
 	}
 	if reservedIPAdd, ok := d.GetOk("reserved_ip_addresses"); ok {
 		inputSpec.ReservedIpAddresses = expandIPAddress(reservedIPAdd.([]interface{}))
@@ -533,12 +535,12 @@ func ResourceNutanixSubnetV2Create(ctx context.Context, d *schema.ResourceData, 
 	if ipUsage, ok := d.GetOk("ip_usage"); ok {
 		inputSpec.IpUsage = expandIPUsage(ipUsage)
 	}
-
 	if ipConfig, ok := d.GetOk("ip_config"); ok {
 		inputSpec.IpConfig = expandIPConfig(ipConfig.([]interface{}))
 	}
+
 	aJSON, _ := json.MarshalIndent(inputSpec, "", " ")
-	log.Printf("[DEBUG] Subnets create payload : %s", string(aJSON))
+	log.Printf("[DEBUG] Subnet create payload : %s", string(aJSON))
 
 	resp, err := conn.SubnetAPIInstance.CreateSubnet(&inputSpec)
 	if err != nil {

--- a/nutanix/services/networkingv2/resource_nutanix_subnets_v2_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_subnets_v2_test.go
@@ -299,4 +299,3 @@ resource "nutanix_subnet_v2" "test" {
 }
 `, name, desc)
 }
-

--- a/nutanix/services/networkingv2/resource_nutanix_subnets_v2_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_subnets_v2_test.go
@@ -96,6 +96,60 @@ func TestAccV2NutanixSubnetResource_WithExternalSubnet(t *testing.T) {
 	})
 }
 
+func TestAccV2NutanixSubnetResource_isNatEnableFalse(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("tf-test-subnet-%d", r)
+	desc := "test subnet description"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testSubnetV2ConfigIsNatEnableFalse(name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameSubnet, "name", name),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "description", desc),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "subnet_type", "OVERLAY"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "is_external", "true"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "is_nat_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.default_gateway_ip.0.value", "192.168.0.1"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.ip_subnet.0.ip.0.value", "192.168.0.0"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.ip_subnet.0.prefix_length", "24"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.pool_list.0.start_ip.0.value", "192.168.0.20"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.pool_list.0.end_ip.0.value", "192.168.0.30"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixSubnetResource_isNatEnableTrue(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("tf-test-subnet-%d", r)
+	desc := "test subnet description"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testSubnetV2ConfigIsNatEnableTrue(name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameSubnet, "name", name),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "description", desc),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "subnet_type", "OVERLAY"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "is_external", "true"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "is_nat_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.default_gateway_ip.0.value", "192.168.0.1"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.ip_subnet.0.ip.0.value", "192.168.0.0"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.ip_subnet.0.prefix_length", "24"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.pool_list.0.start_ip.0.value", "192.168.0.20"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.pool_list.0.end_ip.0.value", "192.168.0.30"),
+				),
+			},
+		},
+	})
+}
+
 func testSubnetV2Config(name, desc string) string {
 	return fmt.Sprintf(`
 		data "nutanix_clusters_v2" "clusters" {}
@@ -213,5 +267,105 @@ func testSubnetV2ConfigWithExternalSubnet(name, desc string) string {
 			}
 		depends_on = [data.nutanix_clusters_v2.clusters]
 		}
+`, name, desc)
+}
+
+func testSubnetV2ConfigIsNatEnableFalse(name, desc string) string {
+	return fmt.Sprintf(`
+data "nutanix_clusters_v2" "clusters" {}
+
+locals {
+  clusterExtId = [
+    for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+    cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+  ][0]
+}
+
+resource "nutanix_vpc_v2" "test" {
+  name        = "test_vpc_%[1]s"
+  description = "test vpc %[2]s"
+  vpc_type   = "TRANSIT"
+}
+
+resource "nutanix_subnet_v2" "test" {
+  name 				= "%[1]s"
+  description		= "%[2]s"
+  cluster_reference = local.clusterExtId
+  vpc_reference     = nutanix_vpc_v2.test.id
+  subnet_type       = "OVERLAY"
+  is_nat_enabled    = false
+  is_external       = true
+  ip_config {
+    ipv4 {
+      ip_subnet {
+        ip {
+          value = "192.168.0.0"
+        }
+        prefix_length = 24
+      }
+      default_gateway_ip {
+        value = "192.168.0.1"
+      }
+      pool_list {
+        start_ip {
+          value = "192.168.0.20"
+        }
+        end_ip {
+          value = "192.168.0.30"
+        }
+      }
+    }
+  }
+}
+`, name, desc)
+}
+
+func testSubnetV2ConfigIsNatEnableTrue(name, desc string) string {
+	return fmt.Sprintf(`
+data "nutanix_clusters_v2" "clusters" {}
+
+locals {
+  clusterExtId = [
+    for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+    cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+  ][0]
+}
+
+resource "nutanix_vpc_v2" "test" {
+  name        = "test_vpc_%[1]s"
+  description = "test vpc %[2]s"
+  vpc_type   = "TRANSIT"
+}
+
+resource "nutanix_subnet_v2" "test" {
+  name 				= "%[1]s"
+  description		= "%[2]s"
+  cluster_reference = local.clusterExtId
+  vpc_reference     = nutanix_vpc_v2.test.id
+  subnet_type       = "OVERLAY"
+  is_nat_enabled    = true
+  is_external       = true
+  ip_config {
+    ipv4 {
+      ip_subnet {
+        ip {
+          value = "192.168.0.0"
+        }
+        prefix_length = 24
+      }
+      default_gateway_ip {
+        value = "192.168.0.1"
+      }
+      pool_list {
+        start_ip {
+          value = "192.168.0.20"
+        }
+        end_ip {
+          value = "192.168.0.30"
+        }
+      }
+    }
+  }
+}
 `, name, desc)
 }

--- a/nutanix/services/networkingv2/resource_nutanix_subnets_v2_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_subnets_v2_test.go
@@ -90,6 +90,12 @@ func TestAccV2NutanixSubnetResource_WithExternalSubnet(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceNameSubnet, "ip_usage.#"),
 					resource.TestCheckResourceAttrSet(resourceNameSubnet, "cluster_reference"),
 					resource.TestCheckResourceAttr(resourceNameSubnet, "is_external", "true"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "is_nat_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.default_gateway_ip.0.value", "192.168.0.1"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.ip_subnet.0.ip.0.value", "192.168.0.0"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.ip_subnet.0.prefix_length", "24"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.pool_list.0.start_ip.0.value", "192.168.0.20"),
+					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.pool_list.0.end_ip.0.value", "192.168.0.30"),
 				),
 			},
 		},
@@ -112,33 +118,6 @@ func TestAccV2NutanixSubnetResource_isNatEnableFalse(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameSubnet, "subnet_type", "OVERLAY"),
 					resource.TestCheckResourceAttr(resourceNameSubnet, "is_external", "true"),
 					resource.TestCheckResourceAttr(resourceNameSubnet, "is_nat_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.default_gateway_ip.0.value", "192.168.0.1"),
-					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.ip_subnet.0.ip.0.value", "192.168.0.0"),
-					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.ip_subnet.0.prefix_length", "24"),
-					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.pool_list.0.start_ip.0.value", "192.168.0.20"),
-					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.pool_list.0.end_ip.0.value", "192.168.0.30"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccV2NutanixSubnetResource_isNatEnableTrue(t *testing.T) {
-	r := acctest.RandInt()
-	name := fmt.Sprintf("tf-test-subnet-%d", r)
-	desc := "test subnet description"
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { acc.TestAccPreCheck(t) },
-		Providers: acc.TestAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testSubnetV2ConfigIsNatEnableTrue(name, desc),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceNameSubnet, "name", name),
-					resource.TestCheckResourceAttr(resourceNameSubnet, "description", desc),
-					resource.TestCheckResourceAttr(resourceNameSubnet, "subnet_type", "OVERLAY"),
-					resource.TestCheckResourceAttr(resourceNameSubnet, "is_external", "true"),
-					resource.TestCheckResourceAttr(resourceNameSubnet, "is_nat_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.default_gateway_ip.0.value", "192.168.0.1"),
 					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.ip_subnet.0.ip.0.value", "192.168.0.0"),
 					resource.TestCheckResourceAttr(resourceNameSubnet, "ip_config.0.ipv4.0.ip_subnet.0.prefix_length", "24"),
@@ -244,6 +223,7 @@ func testSubnetV2ConfigWithExternalSubnet(name, desc string) string {
 			subnet_type = "VLAN"
 			network_id = 122
 			is_external = true
+			is_nat_enabled = true
 			ip_config {
 				ipv4 {
 					ip_subnet {
@@ -320,52 +300,3 @@ resource "nutanix_subnet_v2" "test" {
 `, name, desc)
 }
 
-func testSubnetV2ConfigIsNatEnableTrue(name, desc string) string {
-	return fmt.Sprintf(`
-data "nutanix_clusters_v2" "clusters" {}
-
-locals {
-  clusterExtId = [
-    for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
-    cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
-  ][0]
-}
-
-resource "nutanix_vpc_v2" "test" {
-  name        = "test_vpc_%[1]s"
-  description = "test vpc %[2]s"
-  vpc_type   = "TRANSIT"
-}
-
-resource "nutanix_subnet_v2" "test" {
-  name 				= "%[1]s"
-  description		= "%[2]s"
-  cluster_reference = local.clusterExtId
-  vpc_reference     = nutanix_vpc_v2.test.id
-  subnet_type       = "OVERLAY"
-  is_nat_enabled    = true
-  is_external       = true
-  ip_config {
-    ipv4 {
-      ip_subnet {
-        ip {
-          value = "192.168.0.0"
-        }
-        prefix_length = 24
-      }
-      default_gateway_ip {
-        value = "192.168.0.1"
-      }
-      pool_list {
-        start_ip {
-          value = "192.168.0.20"
-        }
-        end_ip {
-          value = "192.168.0.30"
-        }
-      }
-    }
-  }
-}
-`, name, desc)
-}


### PR DESCRIPTION
Currently, we are not able to create external NoNat overlay subnet. By default is_nat_enabled is true even if its set to false in TF Script.

This is due to bug in TF sdk https://github.com/hashicorp/terraform/issues/4936 where its set `exists` as false when attribute is having zero value. And in API by default NAT is enabled if no value is sent 

Have update code to check the attribute existence and set.