### PR TITLE
Fix nutanix_virtual_machine_v2 cannot read guest customization config for windows 

### DIFF
--- a/examples/virtual_machine_v2/main.tf
+++ b/examples/virtual_machine_v2/main.tf
@@ -367,6 +367,59 @@ resource "nutanix_virtual_machine_v2" "example-11" {
 }
 
 
+# create virtual machine with gest customization sysprep script
+resource "nutanix_virtual_machine_v2" "example-12" {
+  name                 = "example-vm-12"
+  num_cores_per_socket = 1
+  num_sockets          = 1
+  cluster {
+    ext_id = local.cluster_ext_id
+  }
+  disks {
+    disk_address {
+      bus_type = "SCSI"
+      index    = 0
+    }
+    backing_info {
+      vm_disk {
+        disk_size_bytes = "1073741824"
+        storage_container {
+          ext_id = data.nutanix_storage_containers_v2.sc.storage_containers[0].ext_id
+        }
+      }
+    }
+  }
+  nics {
+    network_info {
+      nic_type = "NORMAL_NIC"
+      subnet {
+        ext_id = data.nutanix_subnets_v2.vm-subnet.subnets[0].ext_id
+      }
+      vlan_mode = "ACCESS"
+    }
+  }
+  guest_customization {
+    config {
+      sysprep {
+        install_type = "PREPARED"
+        sysprep_script {
+          unattend_xml {
+            value = base64encode(file(var.unattend_xml_path)) # encoded unattend_xml file value or base64 encoded string value
+          }
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      guest_customization, cd_roms
+    ]
+  }
+}
+
+
+
 # list all virtual machines
 data "nutanix_virtual_machines_v2" "vms" {}
 

--- a/examples/virtual_machine_v2/variables.tf
+++ b/examples/virtual_machine_v2/variables.tf
@@ -25,3 +25,6 @@ variable "disk_sizes" {
 variable "image_name" {
   type = string
 }
+variable "unattend_xml_path" {
+  type = string
+}

--- a/nutanix/services/vmmv2/main_test.go
+++ b/nutanix/services/vmmv2/main_test.go
@@ -2,7 +2,10 @@ package vmmv2_test
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"os"
 	"testing"
 )
@@ -10,9 +13,10 @@ import (
 type TestConfig struct {
 	// Volumes config
 	VMM struct {
-		ImageName  string `json:"image_name"`
-		AssignedIP string `json:"assigned_ip"`
-		Subnet     struct {
+		ImageName   string `json:"image_name"`
+		AssignedIP  string `json:"assigned_ip"`
+		UnattendXML string `json:"unattend_xml"`
+		Subnet      struct {
 			NetworkID int    `json:"network_id"`
 			IP        string `json:"ip"`
 			Prefix    int    `json:"prefix"`
@@ -36,6 +40,11 @@ type TestConfig struct {
 }
 
 var testVars TestConfig
+var (
+	path, _             = os.Getwd()
+	filepath            = path + "/../../../test_config_v2.json"
+	untendedXmlFilePath = path + "/../../../unattendxml.txt"
+)
 
 func loadVars(filepath string, varStuct interface{}) {
 	// Read test_config_v2.json from home current path
@@ -55,5 +64,36 @@ func loadVars(filepath string, varStuct interface{}) {
 func TestMain(m *testing.M) {
 	log.Println("Do some crazy stuff before tests!")
 	loadVars("../../../test_config_v2.json", &testVars)
+	downloadFile(testVars.VMM.UnattendXML, untendedXmlFilePath)
 	os.Exit(m.Run())
+}
+
+// downloadFile downloads a file from a given URL and saves it to the specified path.
+func downloadFile(url, destinationFilePath string) error {
+	// Send HTTP request
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to download file: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check for non-200 responses
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("bad status: %s", resp.Status)
+	}
+
+	// Create the destination file
+	out, err := os.Create(destinationFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+	defer out.Close()
+
+	// Copy data from response to file
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to copy data: %w", err)
+	}
+
+	return nil
 }

--- a/nutanix/services/vmmv2/main_test.go
+++ b/nutanix/services/vmmv2/main_test.go
@@ -43,7 +43,7 @@ var testVars TestConfig
 var (
 	path, _             = os.Getwd()
 	filepath            = path + "/../../../test_config_v2.json"
-	untendedXmlFilePath = path + "/../../../unattendxml.txt"
+	untendedXMLFilePath = path + "/../../../unattendxml.txt"
 )
 
 func loadVars(filepath string, varStuct interface{}) {
@@ -64,7 +64,7 @@ func loadVars(filepath string, varStuct interface{}) {
 func TestMain(m *testing.M) {
 	log.Println("Do some crazy stuff before tests!")
 	loadVars("../../../test_config_v2.json", &testVars)
-	downloadFile(testVars.VMM.UnattendXML, untendedXmlFilePath)
+	downloadFile(testVars.VMM.UnattendXML, untendedXMLFilePath)
 	os.Exit(m.Run())
 }
 

--- a/nutanix/services/vmmv2/resource_nutanix_template_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_template_v2.go
@@ -2625,7 +2625,7 @@ func expandTemplateUnattendXML(unattendXML interface{}) *vmmConfig.Unattendxml {
 		unattendXMLData := unattendXML.([]interface{})
 
 		if len(unattendXMLData) > 0 {
-			if value, ok := unattendXMLData[0].(map[string]interface{})["unattend_xml"]; ok {
+			if value, ok := unattendXMLData[0].(map[string]interface{})["value"]; ok {
 				unattendXMLObj.Value = utils.StringPtr(value.(string))
 			}
 		}

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -1432,10 +1432,11 @@ func schemaForGuestCustomization() *schema.Schema {
 														Computed: true,
 														Elem: &schema.Resource{
 															Schema: map[string]*schema.Schema{
+																// this value is required but not present in API reference
+																// the create vm request fails if this is not provided or is empty
 																"value": {
 																	Type:     schema.TypeString,
-																	Optional: true,
-																	Computed: true,
+																	Required: true,
 																},
 															},
 														},

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
@@ -1415,10 +1415,9 @@ data "nutanix_clusters_v2" "clusters" {}
 
 locals {
 	cluster0 = [
-	for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
-	cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+		cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
 	][0]
-	gs = base64encode("#cloud-config\nusers:\n  - name: ubuntu\n    ssh-authorized-keys:\n      - ssh-rsa DUMMYSSH mypass\n    sudo: ['ALL=(ALL) NOPASSWD:ALL']")
 	config = jsondecode(file("%[3]s"))
 	vmm = local.config.vmm
 }
@@ -1469,7 +1468,7 @@ resource "nutanix_virtual_machine_v2" "test"{
 			install_type = "PREPARED"
 				sysprep_script {
 					unattend_xml {
-						value = file("%[4]s") # unattend_xml file value
+						value = file("%[4]s") # unattend_xml file value, value is encoded in base64
 					}
 			}
 		}

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
@@ -1482,7 +1482,7 @@ resource "nutanix_virtual_machine_v2" "test"{
 		]
 	}
 }
-`, r, desc, filepath, untendedXmlFilePath)
+`, r, desc, filepath, untendedXMLFilePath)
 }
 
 func testVmsV4ConfigWithCloudInitWithCustomKeys(r int, desc string) string {

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
@@ -2,7 +2,6 @@ package vmmv2_test
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"testing"
 
@@ -12,11 +11,6 @@ import (
 )
 
 const resourceNameVms = "nutanix_virtual_machine_v2.test"
-
-var (
-	path, _  = os.Getwd()
-	filepath = path + "/../../../test_config_v2.json"
-)
 
 func TestAccV2NutanixVmsResource_Basic(t *testing.T) {
 	r := acctest.RandInt()
@@ -425,6 +419,39 @@ func TestAccV2NutanixVmsResource_WithCloudInit(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceNameVms, "nics.#"),
 					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
 					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixVmsResource_WithSysprep(t *testing.T) {
+	r := acctest.RandInt()
+	desc := "test vm description"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testVmsV4ConfigWithSysprep(r, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "name", fmt.Sprintf("tf-test-vm-%d", r)),
+					resource.TestCheckResourceAttr(resourceNameVms, "num_cores_per_socket", "1"),
+					resource.TestCheckResourceAttr(resourceNameVms, "description", desc),
+					resource.TestCheckResourceAttr(resourceNameVms, "num_sockets", "1"),
+					resource.TestCheckResourceAttrSet(resourceNameVms, "create_time"),
+					resource.TestCheckResourceAttrSet(resourceNameVms, "update_time"),
+					resource.TestCheckResourceAttr(resourceNameVms, "protection_type", "UNPROTECTED"),
+					resource.TestCheckResourceAttr(resourceNameVms, "is_agent_vm", "false"),
+					resource.TestCheckResourceAttr(resourceNameVms, "machine_type", "PC"),
+					resource.TestCheckResourceAttrSet(resourceNameVms, "disks.#"),
+					resource.TestCheckResourceAttr(resourceNameVms, "disks.0.disk_address.0.bus_type", "SCSI"),
+					resource.TestCheckResourceAttr(resourceNameVms, "disks.0.disk_address.0.index", "0"),
+					resource.TestCheckResourceAttrSet(resourceNameVms, "nics.#"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttrSet(resourceNameVms, "cd_roms.#"),
+					resource.TestCheckResourceAttr(resourceNameVms, "cd_roms.0.iso_type", "GUEST_CUSTOMIZATION"),
 				),
 			},
 		},
@@ -1380,6 +1407,82 @@ func testVmsV4ConfigWithCloudInit(r int, desc string) string {
 			}
 		}
 `, r, desc, filepath)
+}
+
+func testVmsV4ConfigWithSysprep(r int, desc string) string {
+	return fmt.Sprintf(`
+data "nutanix_clusters_v2" "clusters" {}
+
+locals {
+	cluster0 = [
+	for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+	cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+	][0]
+	gs = base64encode("#cloud-config\nusers:\n  - name: ubuntu\n    ssh-authorized-keys:\n      - ssh-rsa DUMMYSSH mypass\n    sudo: ['ALL=(ALL) NOPASSWD:ALL']")
+	config = jsondecode(file("%[3]s"))
+	vmm = local.config.vmm
+}
+
+data "nutanix_storage_containers_v2" "ngt-sc" {
+	filter = "clusterExtId eq '${local.cluster0}'"
+	limit = 1
+}
+
+data "nutanix_subnets_v2" "subnets" {
+	filter = "name eq '${local.vmm.subnet_name}'"
+}
+
+resource "nutanix_virtual_machine_v2" "test"{
+	name= "tf-test-vm-%[1]d"
+	description =  "%[2]s"
+	num_cores_per_socket = 1
+	num_sockets = 1
+	cluster {
+		ext_id = local.cluster0
+	}
+	disks{
+		disk_address{
+			bus_type = "SCSI"
+			index = 0
+		}
+		backing_info{
+			vm_disk{
+				disk_size_bytes = "1073741824"
+				storage_container{
+					ext_id = data.nutanix_storage_containers_v2.ngt-sc.storage_containers[0].ext_id
+				}
+			}
+		}
+	}
+	nics{
+		network_info{
+			nic_type = "NORMAL_NIC"
+			subnet{
+				ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+			}
+			vlan_mode = "ACCESS"
+		}
+	}
+	guest_customization {
+		config {
+		sysprep {
+			install_type = "PREPARED"
+				sysprep_script {
+					unattend_xml {
+						value = file("%[4]s") # unattend_xml file value
+					}
+			}
+		}
+		}
+	}
+
+	lifecycle{
+		ignore_changes = [
+			guest_customization, cd_roms
+		]
+	}
+}
+`, r, desc, filepath, untendedXmlFilePath)
 }
 
 func testVmsV4ConfigWithCloudInitWithCustomKeys(r int, desc string) string {

--- a/test_config_v2.json
+++ b/test_config_v2.json
@@ -131,6 +131,7 @@
     "image_url": "",
     "subnet_name": "",
     "assigned_ip": "",
+    "unattend_xml": "",
     "subnet": {
       "network_id": 534,
       "ip": "",

--- a/website/docs/r/virtual_machine_v2.html.markdown
+++ b/website/docs/r/virtual_machine_v2.html.markdown
@@ -181,7 +181,7 @@ The `guest_customization` attribute supports the following:
 * `install_type`: (Optional) Indicates whether the guest will be freshly installed using this unattend configuration, or this unattend configuration will be applied to a pre-prepared image. Values allowed is 'PREPARED', 'FRESH'.
 * `sysprep_script`: (Optional) Object either UnattendXml or CustomKeyValues
 * `sysprep_script.unattend_xml`: (Optional) xml object
-* `sysprep_script.unattend_xml.value`: (Optional) xml object base64 encoded value
+* `sysprep_script.unattend_xml.value`: (Optional) base64 encoded sysprep unattended xml
 * `sysprep_script.custom_key_values`: (Optional) The list of the individual KeyValuePair elements.
 
 
@@ -190,7 +190,7 @@ The `guest_customization` attribute supports the following:
 * `metadata`: The contents of the meta_data configuration for cloud-init. This can be formatted as YAML or JSON. The value must be base64 encoded. Default value is 'CONFIG_DRIVE_V2'.
 * `cloud_init_script`: (Optional) The script to use for cloud-init.
 * `cloud_init_script.user_data`: (Optional) user data object
-* `cloud_init_script.user_data.value`: (Optional) user data object base64 encoded value
+* `cloud_init_script.user_data.value`: (Optional) base64 encoded cloud init script as string
 * `cloud_init_script.custom_keys`: (Optional) The list of the individual KeyValuePair elements.
 
 #### custom_keys

--- a/website/docs/r/virtual_machine_v2.html.markdown
+++ b/website/docs/r/virtual_machine_v2.html.markdown
@@ -181,6 +181,7 @@ The `guest_customization` attribute supports the following:
 * `install_type`: (Optional) Indicates whether the guest will be freshly installed using this unattend configuration, or this unattend configuration will be applied to a pre-prepared image. Values allowed is 'PREPARED', 'FRESH'.
 * `sysprep_script`: (Optional) Object either UnattendXml or CustomKeyValues
 * `sysprep_script.unattend_xml`: (Optional) xml object
+* `sysprep_script.unattend_xml.value`: (Optional) xml object base64 encoded value
 * `sysprep_script.custom_key_values`: (Optional) The list of the individual KeyValuePair elements.
 
 
@@ -189,6 +190,7 @@ The `guest_customization` attribute supports the following:
 * `metadata`: The contents of the meta_data configuration for cloud-init. This can be formatted as YAML or JSON. The value must be base64 encoded. Default value is 'CONFIG_DRIVE_V2'.
 * `cloud_init_script`: (Optional) The script to use for cloud-init.
 * `cloud_init_script.user_data`: (Optional) user data object
+* `cloud_init_script.user_data.value`: (Optional) user data object base64 encoded value
 * `cloud_init_script.custom_keys`: (Optional) The list of the individual KeyValuePair elements.
 
 #### custom_keys


### PR DESCRIPTION
Fix issue #791: 
- Ensure the correct `sysprep_script` value is read while expanding the provided configuration and preparing the VM create payload 

