### PR TITLE
Fix issues 649, 652, 831: Handle error messages, support DataSourceRef in Image, Destroy of self service app should wait until the app is deleted

### DIFF
--- a/nutanix/client/client.go
+++ b/nutanix/client/client.go
@@ -546,7 +546,11 @@ func CheckResponse(r *http.Response) error {
 	}
 
 	if c == http.StatusBadRequest {
-		return fmt.Errorf("bad Request")
+		bodyBytes, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return fmt.Errorf("bad Request: failed to read body: %w", err)
+		}
+		return fmt.Errorf("bad Request: %s", string(bodyBytes))
 	}
 
 	buf, err := ioutil.ReadAll(r.Body)

--- a/nutanix/sdks/v3/prism/prism_structs.go
+++ b/nutanix/sdks/v3/prism/prism_structs.go
@@ -977,6 +977,9 @@ type ImageResourcesDefStatus struct {
 	// Cluster reference lists
 	InitialPlacementRefList []*ReferenceValues `json:"initial_placement_ref_list,omitempty" mapstructure:"initial_placement_ref_list, omitempty"`
 
+	// Reference to the source image such as 'vm_disk'
+	DataSourceReference *Reference `json:"data_source_reference,omitempty" mapstructure:"data_source_reference,omitempty"`
+
 	// cluster reference list when request was made without refs
 	CurrentClusterReferenceList []*ReferenceValues `json:"current_cluster_reference_list,omitempty" mapstructure:"current_cluster_reference_list, omitempty"`
 

--- a/nutanix/services/selfservice/resource_nutanix_self_service_app_provision.go
+++ b/nutanix/services/selfservice/resource_nutanix_self_service_app_provision.go
@@ -621,7 +621,7 @@ func resourceNutanixCalmAppProvisionDelete(ctx context.Context, d *schema.Resour
 		_, err = conn.Service.SoftDeleteApp(ctx, d.Id())
 	} else {
 		log.Printf("[Debug] Performing hard delete on app: %s", d.Id())
-	  _, err = conn.Service.DeleteApp(ctx, d.Id())
+		_, err = conn.Service.DeleteApp(ctx, d.Id())
 	}
 
 	if err != nil {

--- a/nutanix/services/vmm/data_source_nutanix_image.go
+++ b/nutanix/services/vmm/data_source_nutanix_image.go
@@ -154,6 +154,22 @@ func DataSourceNutanixImage() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"data_source_reference": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:  schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"architecture": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -224,6 +240,16 @@ func dataSourceNutanixImageRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("state", utils.StringValue(resp.Status.State))
 	d.Set("image_type", resp.Status.Resources.ImageType)
 	d.Set("source_uri", resp.Spec.Resources.SourceURI)
+
+	data_source_reference := make(map[string]string)
+	if ref := resp.Status.Resources.DataSourceReference; ref != nil {
+		data_source_reference["uuid"] = utils.StringValue(ref.UUID)
+		data_source_reference["kind"] = utils.StringValue(ref.Kind)
+	}
+	if err := d.Set("data_source_reference", []interface{}{data_source_reference}); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.Set("size_bytes", utils.Int64Value(resp.Status.Resources.SizeBytes))
 
 	uriList := make([]string, 0, len(resp.Status.Resources.RetrievalURIList))

--- a/nutanix/services/vmm/data_source_nutanix_image.go
+++ b/nutanix/services/vmm/data_source_nutanix_image.go
@@ -164,7 +164,7 @@ func DataSourceNutanixImage() *schema.Resource {
 							Computed: true,
 						},
 						"uuid": {
-							Type:  schema.TypeString,
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 					},

--- a/nutanix/services/vmm/data_source_nutanix_image.go
+++ b/nutanix/services/vmm/data_source_nutanix_image.go
@@ -241,12 +241,12 @@ func dataSourceNutanixImageRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("image_type", resp.Status.Resources.ImageType)
 	d.Set("source_uri", resp.Spec.Resources.SourceURI)
 
-	data_source_reference := make(map[string]string)
+	dataSrcRef := make(map[string]string)
 	if ref := resp.Status.Resources.DataSourceReference; ref != nil {
-		data_source_reference["uuid"] = utils.StringValue(ref.UUID)
-		data_source_reference["kind"] = utils.StringValue(ref.Kind)
+		dataSrcRef["uuid"] = utils.StringValue(ref.UUID)
+		dataSrcRef["kind"] = utils.StringValue(ref.Kind)
 	}
-	if err := d.Set("data_source_reference", []interface{}{data_source_reference}); err != nil {
+	if err := d.Set("data_source_reference", []interface{}{dataSrcRef}); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/nutanix/services/vmm/data_source_nutanix_virtual_machine_test.go
+++ b/nutanix/services/vmm/data_source_nutanix_virtual_machine_test.go
@@ -3,8 +3,8 @@ package vmm_test
 import (
 	"fmt"
 	"os"
-	"testing"
 	"regexp"
+	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -85,13 +85,12 @@ func TestAccNutanixVirtualMachineNegativeScenario(t *testing.T) {
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVMRequestedImageSizeLess(r),
+				Config:      testAccVMRequestedImageSizeLess(r),
 				ExpectError: regexp.MustCompile("Requested image size 1048576 is less than actual size 41126400"),
 			},
 		},
 	})
 }
-
 
 func testAccVMDataSourceWithDiskContainer(vmName, containerUUID string) string {
 	return fmt.Sprintf(`

--- a/nutanix/services/vmm/data_source_nutanix_virtual_machine_test.go
+++ b/nutanix/services/vmm/data_source_nutanix_virtual_machine_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -74,6 +75,23 @@ func TestAccNutanixVirtualMachineDataSource_withDiskContainer(t *testing.T) {
 		},
 	})
 }
+
+func TestAccNutanixVirtualMachineNegativeScenario(t *testing.T) {
+	// This test is to check the requested image size less than the disk size
+	// and it should return an error which internally also tests issues/649
+	r := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() {},
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVMRequestedImageSizeLess(r),
+				ExpectError: regexp.MustCompile("Requested image size 1048576 is less than actual size 41126400"),
+			},
+		},
+	})
+}
+
 
 func testAccVMDataSourceWithDiskContainer(vmName, containerUUID string) string {
 	return fmt.Sprintf(`
@@ -193,5 +211,47 @@ func testAccVMDataSourceConfigWithDisk(r int) string {
 		vm_id = "${nutanix_virtual_machine.vm1.id}"
 	}
 
+	`, r)
+}
+
+func testAccVMRequestedImageSizeLess(r int) string {
+	// This test is to check the requested image size less than the disk size
+	return fmt.Sprintf(`
+	data "nutanix_clusters" "clusters" {}
+
+	locals {
+			cluster_ext_id = "${data.nutanix_clusters.clusters.entities.0.service_list.0 == "PRISM_CENTRAL"
+			? data.nutanix_clusters.clusters.entities.1.metadata.uuid : data.nutanix_clusters.clusters.entities.0.metadata.uuid}"
+	}
+
+	resource "nutanix_image" "cirros-034-disk" {
+				name = "cirros-034-disk-%[1]d"
+				source_uri  = "http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img"
+				description = "heres a tiny linux image, not an iso, but a real disk!"
+	}
+
+	resource "nutanix_virtual_machine" "vm1" {
+	name = "test-example-%[1]d"
+	cluster_uuid= data.nutanix_clusters.clusters.entities.0.metadata.uuid
+	num_vcpus_per_socket = 2
+	num_sockets     = 2
+	memory_size_mib   = 1000
+	disk_list {
+			data_source_reference = {
+				kind = "image"
+				uuid = nutanix_image.cirros-034-disk.id
+			}
+			device_properties {
+				disk_address = {
+					device_index = 0
+					adapter_type = "SCSI"
+				}
+
+				device_type = "DISK"
+			}
+			disk_size_mib   = 1
+			disk_size_bytes = 1
+	}
+	}
 	`, r)
 }

--- a/nutanix/services/vmm/data_source_nutanix_virtual_machine_test.go
+++ b/nutanix/services/vmm/data_source_nutanix_virtual_machine_test.go
@@ -76,22 +76,6 @@ func TestAccNutanixVirtualMachineDataSource_withDiskContainer(t *testing.T) {
 	})
 }
 
-func TestAccNutanixVirtualMachineNegativeScenario(t *testing.T) {
-	// This test is to check the requested image size less than the disk size
-	// and it should return an error which internally also tests issues/649
-	r := acctest.RandInt()
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() {},
-		Providers: acc.TestAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccVMRequestedImageSizeLess(r),
-				ExpectError: regexp.MustCompile("Requested image size 1048576 is less than actual size 41126400"),
-			},
-		},
-	})
-}
-
 func testAccVMDataSourceWithDiskContainer(vmName, containerUUID string) string {
 	return fmt.Sprintf(`
 		data "nutanix_clusters" "clusters" {}
@@ -210,47 +194,5 @@ func testAccVMDataSourceConfigWithDisk(r int) string {
 		vm_id = "${nutanix_virtual_machine.vm1.id}"
 	}
 
-	`, r)
-}
-
-func testAccVMRequestedImageSizeLess(r int) string {
-	// This test is to check the requested image size less than the disk size
-	return fmt.Sprintf(`
-	data "nutanix_clusters" "clusters" {}
-
-	locals {
-			cluster_ext_id = "${data.nutanix_clusters.clusters.entities.0.service_list.0 == "PRISM_CENTRAL"
-			? data.nutanix_clusters.clusters.entities.1.metadata.uuid : data.nutanix_clusters.clusters.entities.0.metadata.uuid}"
-	}
-
-	resource "nutanix_image" "cirros-034-disk" {
-				name = "cirros-034-disk-%[1]d"
-				source_uri  = "http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img"
-				description = "heres a tiny linux image, not an iso, but a real disk!"
-	}
-
-	resource "nutanix_virtual_machine" "vm1" {
-	name = "test-example-%[1]d"
-	cluster_uuid= data.nutanix_clusters.clusters.entities.0.metadata.uuid
-	num_vcpus_per_socket = 2
-	num_sockets     = 2
-	memory_size_mib   = 1000
-	disk_list {
-			data_source_reference = {
-				kind = "image"
-				uuid = nutanix_image.cirros-034-disk.id
-			}
-			device_properties {
-				disk_address = {
-					device_index = 0
-					adapter_type = "SCSI"
-				}
-
-				device_type = "DISK"
-			}
-			disk_size_mib   = 1
-			disk_size_bytes = 1
-	}
-	}
 	`, r)
 }

--- a/nutanix/services/vmm/data_source_nutanix_virtual_machine_test.go
+++ b/nutanix/services/vmm/data_source_nutanix_virtual_machine_test.go
@@ -3,7 +3,6 @@ package vmm_test
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"

--- a/nutanix/services/vmm/resource_nutanix_image.go
+++ b/nutanix/services/vmm/resource_nutanix_image.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
-	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
 	v3 "github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v3/prism"
 	"github.com/terraform-providers/terraform-provider-nutanix/utils"
@@ -175,15 +175,15 @@ func ResourceNutanixImage() *schema.Resource {
 				},
 			},
 			"source_uri": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"source_path", "data_source_reference"},
 			},
 			"source_path": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"source_uri", "data_source_reference"},
 			},
 			"version": {
@@ -195,9 +195,9 @@ func ResourceNutanixImage() *schema.Resource {
 				},
 			},
 			"data_source_reference": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
+				Type:          schema.TypeList,
+				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"source_uri", "source_path"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -207,9 +207,9 @@ func ResourceNutanixImage() *schema.Resource {
 							Computed: true,
 						},
 						"uuid": {
-							Type:  schema.TypeString,
-							Optional: true,
-							Computed: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
 							ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`), "must be a valid UUID"),
 						},
 					},
@@ -799,9 +799,9 @@ func resourceNutanixImageInstanceResourceV0() *schema.Resource {
 							Computed: true,
 						},
 						"uuid": {
-							Type:  schema.TypeString,
-							Optional: true,
-							Computed: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
 							ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`), "must be a valid UUID"),
 						},
 					},

--- a/nutanix/services/vmm/resource_nutanix_image.go
+++ b/nutanix/services/vmm/resource_nutanix_image.go
@@ -441,10 +441,9 @@ func resourceNutanixImageRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	data_source_reference := make(map[string]string)
-	if resp.Status.Resources.DataSourceReference != nil {
-		data_source_reference["uuid"] = utils.StringValue(resp.Status.Resources.DataSourceReference.UUID)
-		data_source_reference["kind"] = utils.StringValue(resp.Status.Resources.DataSourceReference.Kind)
-		data_source_reference["name"] = utils.StringValue(resp.Status.Resources.DataSourceReference.Name)
+	if ref := resp.Status.Resources.DataSourceReference; ref != nil {
+		data_source_reference["uuid"] = utils.StringValue(ref.UUID)
+		data_source_reference["kind"] = utils.StringValue(ref.Kind)
 	}
 	if err = d.Set("data_source_reference", []interface{}{data_source_reference}); err != nil {
 		return diag.Errorf("error setting data_source_reference for image UUID(%s), %s", d.Id(), err)

--- a/nutanix/services/vmm/resource_nutanix_image.go
+++ b/nutanix/services/vmm/resource_nutanix_image.go
@@ -178,11 +178,13 @@ func ResourceNutanixImage() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ConflictsWith: []string{"source_path", "data_source_reference"},
 			},
 			"source_path": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ConflictsWith: []string{"source_uri", "data_source_reference"},
 			},
 			"version": {
 				Type:     schema.TypeMap,
@@ -196,13 +198,9 @@ func ResourceNutanixImage() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
+				ConflictsWith: []string{"source_uri", "source_path"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
 						"kind": {
 							Type:     schema.TypeString,
 							Optional: true,

--- a/nutanix/services/vmm/resource_nutanix_image.go
+++ b/nutanix/services/vmm/resource_nutanix_image.go
@@ -432,20 +432,20 @@ func resourceNutanixImageRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("error setting retrieval_uri_list for image UUID(%s), %s", d.Id(), err)
 	}
 
-	if err := d.Set("cluster_references", flattenArrayOfReferenceValues(resp.Status.Resources.InitialPlacementRefList)); err != nil {
+	if err = d.Set("cluster_references", flattenArrayOfReferenceValues(resp.Status.Resources.InitialPlacementRefList)); err != nil {
 		return diag.FromErr(err)
 	}
 
-	if err := d.Set("current_cluster_reference_list", flattenArrayOfReferenceValues(resp.Status.Resources.CurrentClusterReferenceList)); err != nil {
+	if err = d.Set("current_cluster_reference_list", flattenArrayOfReferenceValues(resp.Status.Resources.CurrentClusterReferenceList)); err != nil {
 		return diag.FromErr(err)
 	}
 
-	data_source_reference := make(map[string]string)
+	dataSrcRef := make(map[string]string)
 	if ref := resp.Status.Resources.DataSourceReference; ref != nil {
-		data_source_reference["uuid"] = utils.StringValue(ref.UUID)
-		data_source_reference["kind"] = utils.StringValue(ref.Kind)
+		dataSrcRef["uuid"] = utils.StringValue(ref.UUID)
+		dataSrcRef["kind"] = utils.StringValue(ref.Kind)
 	}
-	if err = d.Set("data_source_reference", []interface{}{data_source_reference}); err != nil {
+	if err = d.Set("data_source_reference", []interface{}{dataSrcRef}); err != nil {
 		return diag.Errorf("error setting data_source_reference for image UUID(%s), %s", d.Id(), err)
 	}
 

--- a/nutanix/services/vmm/resource_nutanix_image_test.go
+++ b/nutanix/services/vmm/resource_nutanix_image_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -17,6 +18,7 @@ import (
 )
 
 const resourceName = "nutanix_image.acctest-test"
+const datasourceNameWithDataSource = "data.nutanix_image.image-vm-disk"
 
 func TestAccNutanixImage_basic(t *testing.T) {
 	rInt := acctest.RandInt()
@@ -170,6 +172,59 @@ func TestAccNutanixImage_uploadLocal(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNutanixImageExists("nutanix_image.acctest-testLocal"),
 					resource.TestCheckResourceAttr("nutanix_image.acctest-testLocal", "description", "new description"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNutanixImage_WithInvalidConfig(t *testing.T) {
+	r := acctest.RandInt()
+	description := fmt.Sprintf("UbuntuServer-%d", r)
+	name := fmt.Sprintf("UbuntuServer-%d", r)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() {},
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNutanixImageNegativeConfig(name, description),
+				ExpectError: regexp.MustCompile("Conflicting configuration arguments"),
+			},
+		},
+	})
+}
+
+func TestAccNutanixImage_WithDataSourceRefInvalidUUID(t *testing.T) {
+	r := acctest.RandInt()
+	description := fmt.Sprintf("UbuntuServer-%d", r)
+	name := fmt.Sprintf("UbuntuServer-%d", r)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() {},
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNutanixImageNegativeConfigInvalidUUID(name, description),
+				ExpectError: regexp.MustCompile("Invalid disk data source reference"),
+			},
+		},
+	})
+}
+
+func TestAccNutanixImage_WithDataSourceRef(t *testing.T) {
+	rInt := acctest.RandInt()
+	r := acctest.RandInt()
+	description := fmt.Sprintf("UbuntuServer-%d", r)
+	name := fmt.Sprintf("UbuntuServer-%d", r)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() {},
+		Providers:    acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNutanixImageDataSourceRefConfig(name, description, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceNameWithDataSource, "name", name),
+					resource.TestCheckResourceAttr(datasourceNameWithDataSource, "description", description),
+					testAccCheckNutanixImageExists(datasourceNameWithDataSource),
 				),
 			},
 		},
@@ -411,4 +466,97 @@ func testAccNutanixImageConfigWithLargeImageURL(r int) string {
 			source_uri  = "http://archive.ubuntu.com/ubuntu/dists/bionic/main/installer-amd64/current/images/netboot/mini.iso"
 		}
 	`, r)
+}
+
+
+func testAccNutanixImageNegativeConfig(name string, description string) string {
+	return fmt.Sprintf(`
+		resource "nutanix_image" "negative-test" {
+			name        = "%s"
+			description = "%s"
+			source_uri  = "http://archive.ubuntu.com/ubuntu/dists/bionic/main/installer-amd64/current/images/netboot/mini.iso"
+			image_type = "DISK_IMAGE"
+	    data_source_reference {
+		    kind = "vm_disk"
+		    uuid = "56ae9a88-daec-46a5-964f-e05a13b2cabb"
+			}
+		}
+	`, name, description)
+}
+
+func testAccNutanixImageNegativeConfigInvalidUUID(name string, description string) string {
+	return fmt.Sprintf(`
+		resource "nutanix_image" "negative-test-invalid-uuid" {
+			name        = "%s"
+			description = "%s"
+			image_type = "DISK_IMAGE"
+	    data_source_reference {
+		    kind = "vm_disk"
+		    uuid = "56ae9a88-daec-46a5-964f-e05a13b2cabb"
+			}
+		}
+	`, name, description)
+}
+
+func testAccNutanixImageDataSourceRefConfig(name string, description string, r int) string {
+	return fmt.Sprintf(`
+	  data "nutanix_clusters" "clusters" {}
+
+		locals {
+				cluster_ext_id = "${data.nutanix_clusters.clusters.entities.0.service_list.0 == "PRISM_CENTRAL"
+				? data.nutanix_clusters.clusters.entities.1.metadata.uuid : data.nutanix_clusters.clusters.entities.0.metadata.uuid}"
+		}
+
+	  resource "nutanix_image" "cirros-034-disk" {
+         name = "cirros-034-disk"
+         source_uri  = "http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img"
+         description = "heres a tiny linux image, not an iso, but a real disk!"
+    }
+
+		# create a VM to install NGT
+		resource "nutanix_virtual_machine_v2" "vm-disk" {
+			name                 = "vm-example-%d"
+			description          = "vm to test ngt installation"
+			num_cores_per_socket = 1
+			num_sockets          = 1
+			memory_size_bytes    = 4 * 1024 * 1024 * 1024
+			cluster {
+				ext_id = local.cluster_ext_id
+			}
+
+			disks {
+				disk_address {
+					bus_type = "SCSI"
+					index    = 0
+				}
+				backing_info {
+					vm_disk {
+						data_source {
+							reference {
+								image_reference {
+									image_ext_id = nutanix_image.cirros-034-disk.id
+								}
+							}
+						}
+						disk_size_bytes = 20 * 1024 * 1024 * 1024
+					}
+				}
+			}
+			power_state = "OFF"
+	}
+
+	resource "nutanix_image" "create-image-vm-disk" {
+		name        = "%s"
+		description = "%s"
+		image_type = "DISK_IMAGE"
+		data_source_reference {
+			kind = "vm_disk"
+			uuid = nutanix_virtual_machine_v2.vm-disk.disks[0].ext_id
+		}
+	}
+
+	data "nutanix_image" "image-vm-disk" {
+		image_id = nutanix_image.create-image-vm-disk.id
+	}
+	`, r, name, description)
 }

--- a/nutanix/services/vmm/resource_nutanix_image_test.go
+++ b/nutanix/services/vmm/resource_nutanix_image_test.go
@@ -5,10 +5,10 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
-	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -187,7 +187,7 @@ func TestAccNutanixImage_WithInvalidConfig(t *testing.T) {
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNutanixImageNegativeConfig(name, description),
+				Config:      testAccNutanixImageNegativeConfig(name, description),
 				ExpectError: regexp.MustCompile("Conflicting configuration arguments"),
 			},
 		},
@@ -203,7 +203,7 @@ func TestAccNutanixImage_WithDataSourceRefInvalidUUID(t *testing.T) {
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNutanixImageNegativeConfigInvalidUUID(name, description),
+				Config:      testAccNutanixImageNegativeConfigInvalidUUID(name, description),
 				ExpectError: regexp.MustCompile("Invalid disk data source reference"),
 			},
 		},
@@ -216,8 +216,8 @@ func TestAccNutanixImage_WithDataSourceRef(t *testing.T) {
 	description := fmt.Sprintf("UbuntuServer-%d", r)
 	name := fmt.Sprintf("UbuntuServer-%d", r)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() {},
-		Providers:    acc.TestAccProviders,
+		PreCheck:  func() {},
+		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNutanixImageDataSourceRefConfig(name, description, rInt),
@@ -467,7 +467,6 @@ func testAccNutanixImageConfigWithLargeImageURL(r int) string {
 		}
 	`, r)
 }
-
 
 func testAccNutanixImageNegativeConfig(name string, description string) string {
 	return fmt.Sprintf(`

--- a/nutanix/services/vmm/resource_nutanix_virtual_machine_test.go
+++ b/nutanix/services/vmm/resource_nutanix_virtual_machine_test.go
@@ -641,6 +641,22 @@ func TestAccNutanixVirtualMachine_SecureBootWithNoMachineType(t *testing.T) {
 	})
 }
 
+func TestAccNutanixVirtualMachineNegativeScenario(t *testing.T) {
+	// This test is to check the requested image size less than the disk size
+	// and it should return an error which internally also tests issues/649
+	r := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() {},
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccVMRequestedImageSizeLess(r),
+				ExpectError: regexp.MustCompile("Requested image size 1048576 is less than actual size 41126400"),
+			},
+		},
+	})
+}
+
 func testAccCheckNutanixVirtualMachineExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1607,4 +1623,46 @@ func testAccNutanixVMConfigWithSecureBootWithNoMachineType(name, desc, mem strin
 		}
 		  
 	`, name, desc, mem)
+}
+
+func testAccVMRequestedImageSizeLess(r int) string {
+	// This test is to check the requested image size less than the disk size
+	return fmt.Sprintf(`
+	data "nutanix_clusters" "clusters" {}
+
+	locals {
+			cluster_ext_id = "${data.nutanix_clusters.clusters.entities.0.service_list.0 == "PRISM_CENTRAL"
+			? data.nutanix_clusters.clusters.entities.1.metadata.uuid : data.nutanix_clusters.clusters.entities.0.metadata.uuid}"
+	}
+
+	resource "nutanix_image" "cirros-034-disk" {
+				name = "cirros-034-disk-%[1]d"
+				source_uri  = "http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img"
+				description = "heres a tiny linux image, not an iso, but a real disk!"
+	}
+
+	resource "nutanix_virtual_machine" "vm1" {
+	name = "test-example-%[1]d"
+	cluster_uuid= data.nutanix_clusters.clusters.entities.0.metadata.uuid
+	num_vcpus_per_socket = 2
+	num_sockets     = 2
+	memory_size_mib   = 1000
+	disk_list {
+			data_source_reference = {
+				kind = "image"
+				uuid = nutanix_image.cirros-034-disk.id
+			}
+			device_properties {
+				disk_address = {
+					device_index = 0
+					adapter_type = "SCSI"
+				}
+
+				device_type = "DISK"
+			}
+			disk_size_mib   = 1
+			disk_size_bytes = 1
+	}
+	}
+	`, r)
 }

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -18,6 +18,17 @@ resource "nutanix_image" "test" {
   description = "Ubuntu"
   source_uri  = "http://archive.ubuntu.com/ubuntu/dists/bionic/main/installer-amd64/current/images/netboot/mini.iso"
 }
+
+# Create image with data_source_reference
+resource "nutanix_image" "create_image_with_data_source_reference" {
+  name        = "Sql Server Image"
+  description = "Sql Server"
+  image_type = "DISK_IMAGE"
+  data_source_reference {
+    kind = "vm_disk"
+    uuid = "<uuid of the vm from which image need to be created>"
+  }
+}
 ```
 
 ## Argument Reference
@@ -44,6 +55,12 @@ The version attribute supports the following:
 
 * `product_name`: - (Optional) Name of the producer/distribution of the image. For example windows or red hat.
 * `product_version`: - (Optional) Version string for the disk image.
+
+### Data Source Reference
+The data_source_reference attribute supports the following:
+* uuid: - UUID of the source
+* kind: - The kind name(Default value: vm_disk)
+
 
 ## Attributes Reference
 

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -26,7 +26,7 @@ resource "nutanix_image" "create_image_with_data_source_reference" {
   image_type = "DISK_IMAGE"
   data_source_reference {
     kind = "vm_disk"
-    uuid = "<uuid of the vm from which image need to be created>"
+    uuid = "<uuid of the vm disk>"
   }
 }
 ```


### PR DESCRIPTION
This PR contains 3 fixes,
1. https://github.com/nutanix/terraform-provider-nutanix/issues/649
2. https://github.com/nutanix/terraform-provider-nutanix/issues/652
3. https://github.com/nutanix/terraform-provider-nutanix/issues/831

**We have added the following changes,**
1. Add support for using data source reference in image module.
2. Destroy of self service app should wait until it's deleted.
3. Error messages should be shown properly incase of Bad Request.

For all the scenarios, added the testcases, corresponding doc changes.