### PR TITLE
Changes to add document and examples for object store management module

### DIFF
--- a/examples/nutanix_certificate_v2/main.tf
+++ b/examples/nutanix_certificate_v2/main.tf
@@ -1,6 +1,20 @@
-#Here we will get and list permissions
-#the variable "" present in terraform.tfvars file.
-#Note - Replace appropriate values of variables in terraform.tfvars file as per setup
+
+
+
+
+# This Terraform script will do:
+# 1. Deploy an object store with one worker node
+# 2. Create Certificate for an object store
+# 3. List all certificates for an object store
+# 4. Fetch certificate details for an object store
+
+
+# NOTE:
+# 1. Before Deleting object store, make sure to delete buckets inside it
+#    Currently, we are not supporting delete bucket API in terraform
+# 2. Object store Update is used only to resume deployment of object store when it fails,
+#    the state will be OBJECT_STORE_DEPLOYMENT_FAILED, update will resume the deployment
+
 
 terraform {
   required_providers {
@@ -19,14 +33,6 @@ provider "nutanix" {
   port     = var.nutanix_port
   insecure = true
 }
-
-
-# This Terraform script will do:
-# 1. Deploy an object store with one worker node
-# 2. Create Certificate for an object store
-# 3. List all certificates for an object store
-# 4. Fetch certificate details for an object store
-
 
 # subnet name to be used for object store
 locals {
@@ -110,8 +116,3 @@ data "nutanix_certificate_v2" "fetch" {
   ext_id              = nutanix_object_store_certificate_v2.example.id
   depends_on          = [nutanix_object_store_certificate_v2.example]
 }
-
-
-
-# NOTE: Before Deleting object store, make sure to delete buckets inside it
-# Currently, we are not supporting delete bucket API in terraform

--- a/examples/nutanix_certificate_v2/main.tf
+++ b/examples/nutanix_certificate_v2/main.tf
@@ -1,0 +1,117 @@
+#Here we will get and list permissions
+#the variable "" present in terraform.tfvars file.
+#Note - Replace appropriate values of variables in terraform.tfvars file as per setup
+
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = "2.3.0"
+    }
+  }
+}
+
+#defining nutanix configuration
+provider "nutanix" {
+  username = var.nutanix_username
+  password = var.nutanix_password
+  endpoint = var.nutanix_endpoint
+  port     = var.nutanix_port
+  insecure = true
+}
+
+
+# This Terraform script will do:
+# 1. Deploy an object store with one worker node
+# 2. Create Certificate for an object store
+# 3. List all certificates for an object store
+# 4. Fetch certificate details for an object store
+
+
+# subnet name to be used for object store
+locals {
+  subnetName = "objects.800"
+}
+
+# Fetching cluster and subnet details
+data "nutanix_clusters_v2" "clusters" {}
+
+data "nutanix_subnets_v2" "subnets" {
+  filter = "name eq '${local.subnetName}'"
+}
+
+# Fetching cluster and subnet ext_id
+locals {
+  clusterExtId = [
+    for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+    cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+  ][0]
+  subnetExtId = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+}
+
+# Deploying an object store
+resource "nutanix_object_store_v2" "example" {
+  name                     = "tf-example-os"
+  description              = "terraform create object store example"
+  deployment_version       = "5.1.1"
+  domain                   = "msp.pc-idbc.nutanix.com"
+  num_worker_nodes         = 1
+  cluster_ext_id           = local.clusterExtId
+  total_capacity_gib       = 20 * pow(1024, 3) # 20 GB
+  public_network_reference = local.subnetExtId
+  public_network_ips {
+    ipv4 {
+      value = "10.44.77.123"
+    }
+  }
+  storage_network_reference = local.subnetExtId
+  storage_network_dns_ip {
+    ipv4 {
+      value = "10.44.77.124"
+    }
+  }
+  storage_network_vip {
+    ipv4 {
+      value = "10.44.77.125"
+    }
+  }
+}
+
+# This is example of creating certificate for object store
+# check API Ref for more details
+# create object_store_cert.json file, file content :]
+# {
+#   "alternateIps": [
+#     {
+#       "ipv4": {
+#         "value": "10.44.77.123"
+#       }
+#     }
+#   ]
+# }
+
+# Creating certificate for object store
+resource "nutanix_object_store_certificate_v2" "example" {
+  object_store_ext_id = nutanix_object_store_v2.example.id
+  # path to certificate json file
+  path = "./object_store_cert.json"
+}
+
+
+#List all certificates for object store
+data "nutanix_certificates_v2" "list" {
+  object_store_ext_id = nutanix_object_store_v2.example.id
+  depends_on          = [nutanix_object_store_certificate_v2.example]
+}
+
+# fetching certificate details for object store
+data "nutanix_certificate_v2" "fetch" {
+  object_store_ext_id = nutanix_object_store_v2.example.id
+  ext_id              = nutanix_object_store_certificate_v2.example.id
+  depends_on          = [nutanix_object_store_certificate_v2.example]
+}
+
+
+
+# NOTE: Before Deleting object store, make sure to delete buckets inside it
+# Currently, we are not supporting delete bucket API in terraform

--- a/examples/nutanix_certificate_v2/terraform.tfvars
+++ b/examples/nutanix_certificate_v2/terraform.tfvars
@@ -1,0 +1,8 @@
+#replace the values as per setup configuration
+nutanix_username = "admin"
+nutanix_password = "Nutanix/123456"
+nutanix_endpoint = "10.xx.xx.xx"
+nutanix_port     = 9440
+
+#replace this values as per the setup
+operationUUID = "00000000-0000-0000-0000-000000000000"

--- a/examples/nutanix_certificate_v2/variables.tf
+++ b/examples/nutanix_certificate_v2/variables.tf
@@ -1,0 +1,17 @@
+
+#variable definitions
+variable "nutanix_username" {
+  type = string
+}
+variable "nutanix_password" {
+  type = string
+}
+variable "nutanix_endpoint" {
+  type = string
+}
+variable "nutanix_port" {
+  type = string
+}
+variable "operationUUID" {
+  type = string
+}

--- a/examples/object_store_v2/main.tf
+++ b/examples/object_store_v2/main.tf
@@ -1,0 +1,142 @@
+#Here we will get and list permissions
+#the variable "" present in terraform.tfvars file.
+#Note - Replace appropriate values of variables in terraform.tfvars file as per setup
+
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = "2.3.0"
+    }
+  }
+}
+
+#defining nutanix configuration
+provider "nutanix" {
+  username = var.nutanix_username
+  password = var.nutanix_password
+  endpoint = var.nutanix_endpoint
+  port     = var.nutanix_port
+  insecure = true
+}
+
+
+# This Terraform script will do:
+# 1. Deploy an object store with one worker node
+# 2. Create Certificate for an object store
+# 3. List all certificates for an object store
+# 4. Fetch certificate details for an object store
+# 5. List all object stores
+# 6. List all object store with filter
+# 7. List all object store with limit
+# 8. Fetch object store details using ext_id
+
+
+# subnet name to be used for object store
+locals {
+  subnetName = "objects.800"
+}
+
+# Fetching cluster and subnet details
+data "nutanix_clusters_v2" "clusters" {}
+
+data "nutanix_subnets_v2" "subnets" {
+  filter = "name eq '${local.subnetName}'"
+}
+
+# Fetching cluster and subnet ext_id
+locals {
+  clusterExtId = [
+    for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+    cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+  ][0]
+  subnetExtId = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+}
+
+# Deploying an object store
+resource "nutanix_object_store_v2" "example" {
+  name                     = "tf-example-os"
+  description              = "terraform create object store example"
+  deployment_version       = "5.1.1"
+  domain                   = "msp.pc-idbc.nutanix.com"
+  num_worker_nodes         = 1
+  cluster_ext_id           = local.clusterExtId
+  total_capacity_gib       = 20 * pow(1024, 3) # 20 GB
+  public_network_reference = local.subnetExtId
+  public_network_ips {
+    ipv4 {
+      value = "10.44.77.123"
+    }
+  }
+  storage_network_reference = local.subnetExtId
+  storage_network_dns_ip {
+    ipv4 {
+      value = "10.44.77.124"
+    }
+  }
+  storage_network_vip {
+    ipv4 {
+      value = "10.44.77.125"
+    }
+  }
+}
+
+# This is example of creating certificate for object store
+# check API Ref for more details
+# create object_store_cert.json file, file content :]
+# {
+#   "alternateIps": [
+#     {
+#       "ipv4": {
+#         "value": "10.44.77.123"
+#       }
+#     }
+#   ]
+# }
+
+# Creating certificate for object store
+resource "nutanix_object_store_certificate_v2" "example" {
+  object_store_ext_id = nutanix_object_store_v2.example.id
+  # path to certificate json file
+  path = "./object_store_cert.json"
+}
+
+
+#List all certificates for object store
+data "nutanix_certificates_v2" "list" {
+  object_store_ext_id = nutanix_object_store_v2.example.id
+  depends_on          = [nutanix_object_store_certificate_v2.example]
+}
+
+# fetching certificate details for object store
+data "nutanix_certificate_v2" "fetch" {
+  object_store_ext_id = nutanix_object_store_v2.example.id
+  ext_id              = nutanix_object_store_certificate_v2.example.id
+  depends_on          = [nutanix_object_store_certificate_v2.example]
+}
+
+
+# List all object stores
+data "nutanix_object_stores_v2" "list" {
+  depends_on = [nutanix_object_store_v2.example]
+}
+
+# List all object stores with filter
+data "nutanix_object_stores_v2" "filter" {
+  filter = "name eq '${nutanix_object_store_v2.example.name}'"
+}
+
+# List all object stores with limit
+data "nutanix_object_stores_v2" "limit" {
+  limit      = 1
+  depends_on = [nutanix_object_store_v2.example]
+}
+
+# Fetch object store details using ext_id
+data "nutanix_object_store_v2" "fetch" {
+  ext_id = nutanix_object_store_v2.example.id
+}
+
+
+# NOTE: Before Deleting object store, make sure to delete buckets inside it
+# Currently, we are not supporting delete bucket API in terraform

--- a/examples/object_store_v2/terraform.tfvars
+++ b/examples/object_store_v2/terraform.tfvars
@@ -1,0 +1,8 @@
+#replace the values as per setup configuration
+nutanix_username = "admin"
+nutanix_password = "Nutanix/123456"
+nutanix_endpoint = "10.xx.xx.xx"
+nutanix_port     = 9440
+
+#replace this values as per the setup
+operationUUID = "00000000-0000-0000-0000-000000000000"

--- a/examples/object_store_v2/variables.tf
+++ b/examples/object_store_v2/variables.tf
@@ -1,0 +1,17 @@
+
+#variable definitions
+variable "nutanix_username" {
+  type = string
+}
+variable "nutanix_password" {
+  type = string
+}
+variable "nutanix_endpoint" {
+  type = string
+}
+variable "nutanix_port" {
+  type = string
+}
+variable "operationUUID" {
+  type = string
+}

--- a/website/docs/d/object_store_certificate_v2.html.markdown
+++ b/website/docs/d/object_store_certificate_v2.html.markdown
@@ -1,0 +1,76 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_certificate_v2 "
+sidebar_current: "docs-nutanix-datasource-object-store-certificate-v2"
+description: |-
+  Get the details of the SSL certificate which can be used to connect to an Object store.
+
+
+---
+
+# nutanix_certificate_v2
+
+Get the details of the SSL certificate which can be used to connect to an Object store.
+
+
+## Example Usage
+
+```hcl
+data "nutanix_certificate_v2" "example"{
+  object_store_ext_id = "ac91151a-28b4-4ffe-b150-6bcb2ec80cd4"
+  ext_id              = "ef0a9a54-e7e1-42e2-a59f-de779ec1c9ea"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `object_store_ext_id`: -(Required) The UUID of the Object store.
+- `ext_id`: -(Required) The UUID of the certificate of an Object store.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `tenant_id`: - A globally unique identifier that represents the tenant that owns this entity. The system automatically assigns it, and it and is immutable from an API consumer perspective (some use cases may cause this Id to change - For instance, a use case may require the transfer of ownership of the entity, but these cases are handled automatically on the server).
+- `ext_id`: - A globally unique identifier of an instance that is suitable for external consumption.
+- `links`: - A HATEOAS style link for the response. Each link contains a user-friendly name identifying the link and an address for retrieving the particular resource.
+- `metadata`: - Metadata associated with this resource.
+- `alternate_fqdns`: - The list of alternate FQDNs for accessing the Object store. The FQDNs must consist of at least 2 parts separated by a '.'. Each part can contain upper and lower case letters, digits, hyphens or underscores but must begin and end with a letter. Each part can be up to 63 characters long. For e.g 'objects-0.pc_nutanix.com'.
+- `alternate_ips`: - A list of the IPs included as Subject Alternative Names (SANs) in the certificate. The IPs must be among the public IPs of the Object store (publicNetworkIps).
+
+### Links
+The `links` argument exports the following:
+
+* `href`: - The URL at which the entity described by the link can be accessed.
+* `rel`: - A name that identifies the relationship of the link to the object that is returned by the URL. The unique value of "self" identifies the URL for the object.
+
+### Metadata
+The `metadata` argument exports the following:
+
+- `owner_reference_id`: - A globally unique identifier that represents the owner of this resource.
+- `owner_user_name`: - The userName of the owner of this resource.
+- `project_reference_id`: - A globally unique identifier that represents the project this resource belongs to.
+- `project_name`: - The name of the project this resource belongs to.
+- `category_ids`: - A list of globally unique identifiers that represent all the categories the resource is associated with.
+
+
+### Alternate FQDNs
+The `alternate_fqdns` argument exports the following:
+
+- `value`: - The fully qualified domain name of the host.
+
+### Alternate IPs
+The `alternate_ips` argument exports the following:
+- `ipv4`: An unique address that identifies a device on the internet or a local network in IPv4 format.
+- `ipv6`: An unique address that identifies a device on the internet or a local network in IPv6 format.
+
+
+### IPv4, IPv6
+The `ipv4` and `ipv6` argument exports the following:
+- `value`: - The IPv4/IPv6 address of the host.
+- `prefix_length`: - The prefix length of the network to which this host IPv4 address belongs. Default for IPv4 is 32 and for IPv6 is 128.
+
+See detailed information in [Nutanix Get the details of an Object store certificate V4 ](https://developers.nutanix.com/api-reference?namespace=objects&version=v4.0#tag/ObjectStores/operation/getCertificateById).

--- a/website/docs/d/object_store_certificates_v2.html.markdown
+++ b/website/docs/d/object_store_certificates_v2.html.markdown
@@ -1,0 +1,91 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_certificates_v2 "
+sidebar_current: "docs-nutanix-datasource-object-store-certificates-v2"
+description: |-
+  Get a list of the SSL certificates which can be used to access an Object store.
+
+
+---
+
+# nutanix_certificates_v2
+
+Get a list of the SSL certificates which can be used to access an Object store.
+
+
+
+
+## Example Usage
+
+```hcl
+data "nutanix_certificates_v2" "example"{
+  object_store_ext_id = "ac91151a-28b4-4ffe-b150-6bcb2ec80cd4"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `object_store_ext_id`: -(Required) The UUID of the Object store.
+* `page`: -(Optional) A URL query parameter that specifies the page number of the result set. It must be a positive integer between 0 and the maximum number of pages that are available for that resource. Any number out of this range might lead to no results. Default value is 0.
+* `limit`: -(Optional) A URL query parameter that specifies the total number of records returned in the result set. Must be a positive integer between 1 and 100. Any number out of this range will lead to a validation error. If the limit is not provided, a default value of 50 records will be returned in the result set. Default value is 50.
+* `filter`: -(Optional) A URL query parameter that allows clients to filter a collection of resources. The expression specified with \$filter is evaluated for each resource in the collection, and only items where the expression evaluates to true are included in the response. Expression specified with the \$filter must conform to the OData V4.01 URL conventions. The filter can be applied to the following fields:
+    - alternateFqdns/value
+    - alternateIps/ipv4/value
+* `select`: -(Optional)  URL query parameter that allows clients to request a specific set of properties for each entity or complex type. Expression specified with the $select must conform to the OData V4.01 URL conventions. If a $select expression consists of a single select item that is an asterisk (i.e., *), then all properties on the matching resource will be returned.
+    - alternateFqdns
+    - alternateFqdns/value
+    - alternateIps
+    - alternateIps/ipv4/value
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `certificates`: - list of the SSL certificates which can be used to access an Object store.
+
+### Certificates
+The `certificates` argument exports the following:
+
+- `tenant_id`: - A globally unique identifier that represents the tenant that owns this entity. The system automatically assigns it, and it and is immutable from an API consumer perspective (some use cases may cause this Id to change - For instance, a use case may require the transfer of ownership of the entity, but these cases are handled automatically on the server).
+- `ext_id`: - A globally unique identifier of an instance that is suitable for external consumption.
+- `links`: - A HATEOAS style link for the response. Each link contains a user-friendly name identifying the link and an address for retrieving the particular resource.
+- `metadata`: - Metadata associated with this resource.
+- `alternate_fqdns`: - The list of alternate FQDNs for accessing the Object store. The FQDNs must consist of at least 2 parts separated by a '.'. Each part can contain upper and lower case letters, digits, hyphens or underscores but must begin and end with a letter. Each part can be up to 63 characters long. For e.g 'objects-0.pc_nutanix.com'.
+- `alternate_ips`: - A list of the IPs included as Subject Alternative Names (SANs) in the certificate. The IPs must be among the public IPs of the Object store (publicNetworkIps).
+
+### Links
+The `links` argument exports the following:
+
+* `href`: - The URL at which the entity described by the link can be accessed.
+* `rel`: - A name that identifies the relationship of the link to the object that is returned by the URL. The unique value of "self" identifies the URL for the object.
+
+### Metadata
+The `metadata` argument exports the following:
+
+- `owner_reference_id`: - A globally unique identifier that represents the owner of this resource.
+- `owner_user_name`: - The userName of the owner of this resource.
+- `project_reference_id`: - A globally unique identifier that represents the project this resource belongs to.
+- `project_name`: - The name of the project this resource belongs to.
+- `category_ids`: - A list of globally unique identifiers that represent all the categories the resource is associated with.
+
+
+### Alternate FQDNs
+The `alternate_fqdns` argument exports the following:
+
+- `value`: - The fully qualified domain name of the host.
+
+### Alternate IPs
+The `alternate_ips` argument exports the following:
+- `ipv4`: An unique address that identifies a device on the internet or a local network in IPv4 format.
+- `ipv6`: An unique address that identifies a device on the internet or a local network in IPv6 format.
+
+
+### IPv4, IPv6
+The `ipv4` and `ipv6` argument exports the following:
+- `value`: - The IPv4/IPv6 address of the host.
+- `prefix_length`: - The prefix length of the network to which this host IPv4 address belongs. Default for IPv4 is 32 and for IPv6 is 128.
+
+See detailed information in [Nutanix Get a list of the SSL certificates of an Object store V4 ](https://developers.nutanix.com/api-reference?namespace=objects&version=v4.0#tag/ObjectStores/operation/listCertificatesByObjectstoreId).

--- a/website/docs/d/object_store_v2.html.markdown
+++ b/website/docs/d/object_store_v2.html.markdown
@@ -1,0 +1,106 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_object_store_v2 "
+sidebar_current: "docs-nutanix-datasource-object-store-v2"
+description: |-
+  Get an Object store for the provided UUID
+---
+
+# nutanix_object_store_v2
+
+Get an Object store for the provided UUID
+
+## Example Usage
+
+```hcl
+data "nutanix_object_store_v2" "example"{
+  ext_id = "95eb5f66-f547-4aea-9af8-b580e2060693"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `ext_id`: -(Required) The UUID of the Object store.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `tenant_id`: - A globally unique identifier that represents the tenant that owns this entity. The system automatically assigns it, and it and is immutable from an API consumer perspective (some use cases may cause this Id to change - For instance, a use case may require the transfer of ownership of the entity, but these cases are handled automatically on the server).
+- `ext_id`: - A globally unique identifier of an instance that is suitable for external consumption.
+- `links`: - A HATEOAS style link for the response. Each link contains a user-friendly name identifying the link and an address for retrieving the particular resource.
+- `metadata`: - Metadata associated with this resource.
+- `name`: - The name of the Object store.
+- `creation_time`: - The time when the Object store was created.
+- `last_update_time`: - The time when the Object store was last updated.
+- `description`: - A brief description of the Object store.
+- `deployment_version`: - The deployment version of the Object store.
+- `domain`: - The DNS domain/subdomain the Object store belongs to. All the Object stores under one Prism Central must have the same domain name. The domain name must consist of at least 2 parts separated by a '.'. Each part can contain upper and lower case letters, digits, hyphens, or underscores. Each part can be up to 63 characters long. The domain must begin and end with an alphanumeric character. For example - 'objects-0.pc_nutanix.com'.
+- `region`: - The region in which the Object store is deployed.
+- `num_worker_nodes`: - The number of worker nodes (VMs) to be created for the Object store. Each worker node requires 10 vCPUs and 32 GiB of memory.
+- `cluster_ext_id`: - UUID of the AHV or ESXi cluster.
+- `storage_network_reference`: - Reference to the Storage Network of the Object store. This is the subnet UUID for an AHV cluster or the IPAM name for an ESXi cluster.
+- `storage_network_vip`: - An unique address that identifies a device on the internet or a local network in IPv4 or IPv6 format.
+- `storage_network_dns_ip`: - An unique address that identifies a device on the internet or a local network in IPv4 or IPv6 format.
+- `public_network_reference`: - Public network reference of the Object store. This is the subnet UUID for an AHV cluster or the IPAM name for an ESXi cluster.
+- `public_network_ips`: - A list of static IP addresses used as public IPs to access the Object store.
+- `total_capacity_gib`: - Size of the Object store in GiB.
+- `state`: - Enum for the state of the Object store.
+    | Enum                                   | Description                                                     |
+    |----------------------------------------|-----------------------------------------------------------------|
+    | `DEPLOYING_OBJECT_STORE`             | The Object store is being deployed.                             |
+    | `OBJECT_STORE_DEPLOYMENT_FAILED`     | The Object store deployment has failed.                         |
+    | `DELETING_OBJECT_STORE`              | A deployed Object store is being deleted.                       |
+    | `OBJECT_STORE_OPERATION_FAILED`      | There was an error while performing an operation on the Object store. |
+    | `UNDEPLOYED_OBJECT_STORE`            | The Object store is not deployed.                               |
+    | `OBJECT_STORE_OPERATION_PENDING`     | There is an ongoing operation on the Object store.              |
+    | `OBJECT_STORE_AVAILABLE`            | There are no ongoing operations on the deployed Object store.   |
+    | `OBJECT_STORE_CERT_CREATION_FAILED`  | Creating the Object store certificate has failed.               |
+    | `CREATING_OBJECT_STORE_CERT`         | A certificate is being created for the Object store.            |
+    | `OBJECT_STORE_DELETION_FAILED`       | There was an error deleting the Object store.                   |
+  
+
+- `certificate_ext_ids`: - A list of the UUIDs of the certificates of an Object store.
+
+### Links
+The `links` argument exports the following:
+
+* `href`: - The URL at which the entity described by the link can be accessed.
+* `rel`: - A name that identifies the relationship of the link to the object that is returned by the URL. The unique value of "self" identifies the URL for the object.
+
+### Metadata
+The `metadata` argument exports the following:
+
+- `owner_reference_id`: - A globally unique identifier that represents the owner of this resource.
+- `owner_user_name`: - The userName of the owner of this resource.
+- `project_reference_id`: - A globally unique identifier that represents the project this resource belongs to.
+- `project_name`: - The name of the project this resource belongs to.
+- `category_ids`: - A list of globally unique identifiers that represent all the categories the resource is associated with.
+
+
+### Storage Network VIP
+The `storage_network_vip` argument exports the following:
+
+- `ipv4`: An unique address that identifies a device on the internet or a local network in IPv4 format.
+- `ipv6`: An unique address that identifies a device on the internet or a local network in IPv6 format.
+
+### Storage Network DNS IP
+The `storage_network_dns_ip` argument exports the following:
+- `ipv4`: An unique address that identifies a device on the internet or a local network in IPv4 format.
+- `ipv6`: An unique address that identifies a device on the internet or a local network in IPv6 format.
+
+### Public Network IPs
+The `public_network_ips` argument exports the following:
+- `ipv4`: An unique address that identifies a device on the internet or a local network in IPv4 format.
+- `ipv6`: An unique address that identifies a device on the internet or a local network in IPv6 format.
+
+
+### IPv4, IPv6
+The `ipv4` and `ipv6` argument exports the following:
+- `value`: - The IPv4/IPv6 address of the host.
+- `prefix_length`: - The prefix length of the network to which this host IPv4 address belongs. Default for IPv4 is 32 and for IPv6 is 128.
+
+See detailed information in [Nutanix Get Object Store V4 ](https://developers.nutanix.com/api-reference?namespace=objects&version=v4.0#tag/ObjectStores/operation/getObjectstoreById).

--- a/website/docs/d/object_stores_v2.html.markdown
+++ b/website/docs/d/object_stores_v2.html.markdown
@@ -1,0 +1,178 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_object_stores_v2 "
+sidebar_current: "docs-nutanix-datasource-object-stores-v2"
+description: |-
+  Get an Object store for the provided UUID
+---
+
+# nutanix_object_stores_v2
+
+Get an Object store for the provided UUID
+
+## Example Usage
+
+```hcl
+data "nutanix_object_stores_v2" "list"{
+}
+
+data "nutanix_object_stores_v2" "filter"{
+  filter = "name eq 'object_store_example'"
+}
+
+data "nutanix_object_stores_v2" "limit"{
+  limit = 10
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `page`: -(Optional) A URL query parameter that specifies the page number of the result set. It must be a positive integer between 0 and the maximum number of pages that are available for that resource. Any number out of this range might lead to no results. Default value is 0.
+* `limit`: -(Optional) A URL query parameter that specifies the total number of records returned in the result set. Must be a positive integer between 1 and 100. Any number out of this range will lead to a validation error. If the limit is not provided, a default value of 50 records will be returned in the result set. Default value is 50.
+* `filter`: -(Optional) A URL query parameter that allows clients to filter a collection of resources. The expression specified with \$filter is evaluated for each resource in the collection, and only items where the expression evaluates to true are included in the response. Expression specified with the \$filter must conform to the OData V4.01 URL conventions. The filter can be applied to the following fields:
+    - certificateExtIds
+    - clusterExtId
+    - creationTime
+    - deploymentVersion
+    - description
+    - domain
+    - lastUpdateTime
+    - name
+    - numWorkerNodes
+    - publicNetworkIps/ipv4/value
+    - publicNetworkIps/ipv6/value
+    - publicNetworkReference
+    - region
+    - storageNetworkDnsIp/ipv4/value
+    - storageNetworkDnsIp/ipv6/value
+    - storageNetworkReference
+    - storageNetworkVip/ipv4/value
+    - storageNetworkVip/ipv6/value
+    - totalCapacityGiB
+
+
+* `order_by`: A URL query parameter that allows clients to specify the sort criteria for the returned list of objects. Resources can be sorted in ascending order using asc or descending order using desc. If asc or desc are not specified, the resources will be sorted in ascending order by default. The orderby can be applied to the following fields:
+    - clusterExtId
+    - creationTime
+    - deploymentVersion
+    - description
+    - domain
+    - lastUpdateTime
+    - name
+    - numWorkerNodes
+    - publicNetworkReference
+    - region
+    - storageNetworkReference
+    - totalCapacityGiB
+
+- `expand`: -(Optional) A URL query parameter that allows clients to request related resources when a resource that satisfies a particular request is retrieved. Each expanded item is evaluated relative to the entity containing the property being expanded. Other query options can be applied to an expanded property by appending a semicolon-separated list of query options, enclosed in parentheses, to the property name. Permissible system query options are \$filter, \$select and \$orderby. The following expansion keys are supported:
+    - certificates
+* `select`: A URL query parameter that allows clients to request a specific set of properties for each entity or complex type. Expression specified with the \$select must conform to the OData V4.01 URL conventions. If a \$select expression consists of a single select item that is an asterisk (i.e., *), then all properties on the matching resource will be returned. it can be applied to the following fields:
+    - certificateExtIds
+    - clusterExtId
+    - creationTime
+    - deploymentVersion
+    - description
+    - domain
+    - lastUpdateTime
+    - name
+    - numWorkerNodes
+    - publicNetworkIps
+    - publicNetworkIps/ipv4/value
+    - publicNetworkReference
+    - region
+    - state
+    - storageNetworkDnsIp
+    - storageNetworkDnsIp/ipv4/value
+    - storageNetworkReference
+    - storageNetworkVip
+    - storageNetworkVip/ipv4/value
+    - totalCapacityGiB
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `object_stores`: - A list of Object stores.
+
+### Object Stores
+the `object_stores` contains the following attributes:
+
+- `tenant_id`: - A globally unique identifier that represents the tenant that owns this entity. The system automatically assigns it, and it and is immutable from an API consumer perspective (some use cases may cause this Id to change - For instance, a use case may require the transfer of ownership of the entity, but these cases are handled automatically on the server).
+- `ext_id`: - A globally unique identifier of an instance that is suitable for external consumption.
+- `links`: - A HATEOAS style link for the response. Each link contains a user-friendly name identifying the link and an address for retrieving the particular resource.
+- `metadata`: - Metadata associated with this resource.
+- `name`: - The name of the Object store.
+- `creation_time`: - The time when the Object store was created.
+- `last_update_time`: - The time when the Object store was last updated.
+- `description`: - A brief description of the Object store.
+- `deployment_version`: - The deployment version of the Object store.
+- `domain`: - The DNS domain/subdomain the Object store belongs to. All the Object stores under one Prism Central must have the same domain name. The domain name must consist of at least 2 parts separated by a '.'. Each part can contain upper and lower case letters, digits, hyphens, or underscores. Each part can be up to 63 characters long. The domain must begin and end with an alphanumeric character. For example - 'objects-0.pc_nutanix.com'.
+- `region`: - The region in which the Object store is deployed.
+- `num_worker_nodes`: - The number of worker nodes (VMs) to be created for the Object store. Each worker node requires 10 vCPUs and 32 GiB of memory.
+- `cluster_ext_id`: - UUID of the AHV or ESXi cluster.
+- `storage_network_reference`: - Reference to the Storage Network of the Object store. This is the subnet UUID for an AHV cluster or the IPAM name for an ESXi cluster.
+- `storage_network_vip`: - An unique address that identifies a device on the internet or a local network in IPv4 or IPv6 format.
+- `storage_network_dns_ip`: - An unique address that identifies a device on the internet or a local network in IPv4 or IPv6 format.
+- `public_network_reference`: - Public network reference of the Object store. This is the subnet UUID for an AHV cluster or the IPAM name for an ESXi cluster.
+- `public_network_ips`: - A list of static IP addresses used as public IPs to access the Object store.
+- `total_capacity_gib`: - Size of the Object store in GiB.
+- `state`: - Enum for the state of the Object store.
+    | Enum                                   | Description                                                     |
+    |----------------------------------------|-----------------------------------------------------------------|
+    | `DEPLOYING_OBJECT_STORE`             | The Object store is being deployed.                             |
+    | `OBJECT_STORE_DEPLOYMENT_FAILED`     | The Object store deployment has failed.                         |
+    | `DELETING_OBJECT_STORE`              | A deployed Object store is being deleted.                       |
+    | `OBJECT_STORE_OPERATION_FAILED`      | There was an error while performing an operation on the Object store. |
+    | `UNDEPLOYED_OBJECT_STORE`            | The Object store is not deployed.                               |
+    | `OBJECT_STORE_OPERATION_PENDING`     | There is an ongoing operation on the Object store.              |
+    | `OBJECT_STORE_AVAILABLE`            | There are no ongoing operations on the deployed Object store.   |
+    | `OBJECT_STORE_CERT_CREATION_FAILED`  | Creating the Object store certificate has failed.               |
+    | `CREATING_OBJECT_STORE_CERT`         | A certificate is being created for the Object store.            |
+    | `OBJECT_STORE_DELETION_FAILED`       | There was an error deleting the Object store.                   |
+
+- `certificate_ext_ids`: - A list of the UUIDs of the certificates of an Object store.
+
+### Links
+The `links` argument exports the following:
+
+* `href`: - The URL at which the entity described by the link can be accessed.
+* `rel`: - A name that identifies the relationship of the link to the object that is returned by the URL. The unique value of "self" identifies the URL for the object.
+
+### Metadata
+The `metadata` argument exports the following:
+
+- `owner_reference_id`: - A globally unique identifier that represents the owner of this resource.
+- `owner_user_name`: - The userName of the owner of this resource.
+- `project_reference_id`: - A globally unique identifier that represents the project this resource belongs to.
+- `project_name`: - The name of the project this resource belongs to.
+- `category_ids`: - A list of globally unique identifiers that represent all the categories the resource is associated with.
+
+
+### Storage Network VIP
+The `storage_network_vip` argument exports the following:
+
+- `ipv4`: An unique address that identifies a device on the internet or a local network in IPv4 format.
+- `ipv6`: An unique address that identifies a device on the internet or a local network in IPv6 format.
+
+### Storage Network DNS IP
+The `storage_network_dns_ip` argument exports the following:
+- `ipv4`: An unique address that identifies a device on the internet or a local network in IPv4 format.
+- `ipv6`: An unique address that identifies a device on the internet or a local network in IPv6 format.
+
+### Public Network IPs
+The `public_network_ips` argument exports the following:
+- `ipv4`: An unique address that identifies a device on the internet or a local network in IPv4 format.
+- `ipv6`: An unique address that identifies a device on the internet or a local network in IPv6 format.
+
+
+### IPv4, IPv6
+The `ipv4` and `ipv6` argument exports the following:
+- `value`: - The IPv4/IPv6 address of the host.
+- `prefix_length`: - The prefix length of the network to which this host IPv4 address belongs. Default for IPv4 is 32 and for IPv6 is 128.
+
+See detailed information in [Nutanix List Object Stores V4 ](https://developers.nutanix.com/api-reference?namespace=objects&version=v4.0#tag/ObjectStores/operation/listObjectstores).

--- a/website/docs/r/object_store_certificate_v2.html.markdown
+++ b/website/docs/r/object_store_certificate_v2.html.markdown
@@ -1,0 +1,79 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_certificate_v2 "
+sidebar_current: "docs-nutanix-resource-object-store-certificate-v2"
+description: |-
+  Create a SSL certificate for an Object store
+
+---
+
+# nutanix_certificate_v2
+
+This operation creates a new default certificate and keys. It also creates the alternate FQDNs and alternate IPs for the Object store. The certificate of an Object store can be created when it is in a OBJECT_STORE_AVAILABLE or OBJECT_STORE_CERT_CREATION_FAILED state. If the publicCert, privateKey, and ca values are provided in the request body, these values are used to create the new certificate. If these values are not provided, a new certificate will be generated if 'shouldGenerate' is set to true and if it is set to false, the existing certificate will be used as the new certificate. Optionally, a list of additional alternate FQDNs and alternate IPs can be provided. These alternateFqdns and alternateIps must be included in the CA certificate if it has been provided.
+
+
+
+## Example Usage
+
+```hcl
+data "nutanix_certificate_v2" "example"{
+  object_store_ext_id = "ac91151a-28b4-4ffe-b150-6bcb2ec80cd4"
+  ext_id              = "ef0a9a54-e7e1-42e2-a59f-de779ec1c9ea"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `object_store_ext_id`: -(Required) The UUID of the Object store.
+- `ext_id`: -(Required) The UUID of the certificate of an Object store.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `path`: -(Required) Path to a JSON file which contains the public certificates, private key, and CA certificate or chain, along with a list of alternate FQDNs and alternate IPs to create a certificate for the Object store.
+
+The Content of the JSON file :
+| Field           | Description                                                                                                                                                                                                 |
+|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `alternateFqdns` | The list of alternate FQDNs for accessing the Object store. The FQDNs must consist of at least 2 parts separated by a '.'. Each part can contain upper and lower case letters, digits, hyphens or underscores but must begin and end with a letter. Each part can be up to 63 characters long. For example: `objects-0.pc_nutanix.com`. |
+| `alternateIps`   | A list of the IPs included as Subject Alternative Names (SANs) in the certificate. The IPs must be among the public IPs of the Object store (`publicNetworkIps`).                                        |
+| `ca`             | The CA certificate or chain to upload.                                                                                                                                                                    |
+| `publicCert`     | The public certificate to upload.                                                                                                                                                                          |
+| `privateKey`     | The private key to upload.                                                                                                                                                                                 |
+| `shouldGenerate` | If true, a new certificate is generated with the provided alternate FQDNs and IPs.                                                                                                                        |
+
+## JSON Example
+```json
+{
+  "alternateFqdns": [
+    {
+      "value": "fqdn1.example.com"
+    },
+    {
+      "value": "fqdn2.example.com"
+    }
+  ],
+  "alternateIps": [
+    {
+      "ipv4": {
+        "value": "192.168.1.1"
+      }
+    },
+    {
+      "ipv4": {
+         "value": "192.168.1.2"
+      }
+    }
+  ],
+  "shouldGenerate": true,
+  "ca": "-----BEGIN CERTIFICATE-----\nMIIDzTCCArWgAwIBAgIUI...\n-----END CERTIFICATE-----",
+  "publicCert": "-----BEGIN CERTIFICATE-----\nMIIDzTCCArWgAwIBAgIUI...\n-----END CERTIFICATE-----",
+  "privateKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIDzTCCArWgAwIBAgIUI...\n-----END RSA PRIVATE KEY-----"
+}
+```
+
+See detailed information in [Nutanix Create a SSL certificate for an Object store V4 ](https://developers.nutanix.com/api-reference?namespace=objects&version=v4.0#tag/ObjectStores/operation/createCertificate).

--- a/website/docs/r/object_store_v2.html.markdown
+++ b/website/docs/r/object_store_v2.html.markdown
@@ -1,0 +1,202 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_object_store_v2 "
+sidebar_current: "docs-nutanix-resource-object-store-v2"
+description: |-
+  Run the prechecks, create and start the deployment of an Object store on Prism Central.
+---
+
+# nutanix_object_store_v2
+
+Run the prechecks, create and start the deployment of an Object store on Prism Central.
+
+> ⚠️ **Warning:** Before deleting the Object Store, make sure to delete all buckets inside it manually.
+> Currently, the Terraform provider does not support the Delete Bucket API.
+
+> ⚠️ **Warning:** The Object Store **update** operation is intended **only** to resume a failed deployment.
+> It should be used when the Object Store is in the `OBJECT_STORE_DEPLOYMENT_FAILED` state.
+> Triggering an update in this state will attempt to resume the deployment process.
+
+
+## Example Usage
+
+```hcl
+resource "nutanix_object_store_v2" "example"{
+  name                     = "tf-example-os"
+  description              = "terraform create object store example"
+  deployment_version       = "5.1.1"
+  domain                   = "msp.pc-idbc.nutanix.com"
+  num_worker_nodes         = 1
+  cluster_ext_id           = "ba250e3e-1db1-4950-917f-a9e2ea35b8e3"
+  total_capacity_gib       = 20 * pow(1024, 3)
+  public_network_reference = "57c4caf1-67e3-457e-8265-6d872f2a3135"
+  public_network_ips {
+    ipv4 {
+      value = "10.44.77.123"
+    }
+  }
+  storage_network_reference = "57c4caf1-67e3-457e-8265-6d872f2a3135"
+  storage_network_dns_ip {
+    ipv4 {
+      value = "10.44.77.124"
+    }
+  }
+  storage_network_vip {
+    ipv4 {
+      value = "10.44.77.125"
+    }
+  }
+}
+
+# Deploying Object Store in draft state
+resource "nutanix_object_store_v2" "example-draft" {
+  name                     = "tf-draft-os"
+  description              = "terraform deploy object store draft example"
+  deployment_version       = "5.1.1"
+  domain                   = "msp.pc-idbc.nutanix.com"
+  num_worker_nodes         = 1
+  cluster_ext_id           = "ba250e3e-1db1-4950-917f-a9e2ea35b8e3"
+  total_capacity_gib       = 20 * pow(1024, 3)
+  public_network_reference = "57c4caf1-67e3-457e-8265-6d872f2a3135"
+  state                    = "UNDEPLOYED_OBJECT_STORE"
+  public_network_ips {
+    ipv4 {
+      value = "10.44.77.126"
+    }
+  }
+  storage_network_reference = "57c4caf1-67e3-457e-8265-6d872f2a3135"
+  storage_network_dns_ip {
+    ipv4 {
+      value = "10.44.77.127"
+    }
+  }
+  storage_network_vip {
+    ipv4 {
+      value = "10.44.77.128"
+    }
+  }
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `metadata`: -(Optional) Metadata associated with this resource.
+- `name`: -(Required) The name of the Object store.
+- `description`: -(Optional) A brief description of the Object store.
+- `deployment_version`: -(Optional) The deployment version of the Object store.
+- `domain`: -(Optional) The DNS domain/subdomain the Object store belongs to. All the Object stores under one Prism Central must have the same domain name. The domain name must consist of at least 2 parts separated by a '.'. Each part can contain upper and lower case letters, digits, hyphens, or underscores. Each part can be up to 63 characters long. The domain must begin and end with an alphanumeric character. For example - 'objects-0.pc_nutanix.com'.
+- `region`: -(Optional) The region in which the Object store is deployed.
+- `num_worker_nodes`: -(Optional) The number of worker nodes (VMs) to be created for the Object store. Each worker node requires 10 vCPUs and 32 GiB of memory.
+- `cluster_ext_id`: -(Optional) UUID of the AHV or ESXi cluster.
+- `storage_network_reference`: -(Optional) Reference to the Storage Network of the Object store. This is the subnet UUID for an AHV cluster or the IPAM name for an ESXi cluster.
+- `storage_network_vip`: -(Optional) An unique address that identifies a device on the internet or a local network in IPv4 or IPv6 format.
+- `storage_network_dns_ip`: -(Optional) An unique address that identifies a device on the internet or a local network in IPv4 or IPv6 format.
+- `public_network_reference`: -(Optional) Public network reference of the Object store. This is the subnet UUID for an AHV cluster or the IPAM name for an ESXi cluster.
+- `public_network_ips`: -(Optional) A list of static IP addresses used as public IPs to access the Object store.
+- `total_capacity_gib`: -(Optional) Size of the Object store in GiB.
+- `state`: -(Optional) Enum for the state of the Object store.
+    | Enum                                   | Description                                                     |
+    |----------------------------------------|-----------------------------------------------------------------|
+    | `DEPLOYING_OBJECT_STORE`             | The Object store is being deployed.                             |
+    | `OBJECT_STORE_DEPLOYMENT_FAILED`     | The Object store deployment has failed.                         |
+    | `DELETING_OBJECT_STORE`              | A deployed Object store is being deleted.                       |
+    | `OBJECT_STORE_OPERATION_FAILED`      | There was an error while performing an operation on the Object store. |
+    | `UNDEPLOYED_OBJECT_STORE`            | The Object store is not deployed.                               |
+    | `OBJECT_STORE_OPERATION_PENDING`     | There is an ongoing operation on the Object store.              |
+    | `OBJECT_STORE_AVAILABLE`            | There are no ongoing operations on the deployed Object store.   |
+    | `OBJECT_STORE_CERT_CREATION_FAILED`  | Creating the Object store certificate has failed.               |
+    | `CREATING_OBJECT_STORE_CERT`         | A certificate is being created for the Object store.            |
+    | `OBJECT_STORE_DELETION_FAILED`       | There was an error deleting the Object store.                   |
+
+
+### Metadata
+The `metadata` argument supports the following:
+
+- `owner_reference_id`: -(Optional) A globally unique identifier that represents the owner of this resource.
+- `owner_user_name`: -(Optional) The userName of the owner of this resource.
+- `project_reference_id`: -(Optional) A globally unique identifier that represents the project this resource belongs to.
+- `project_name`: -(Optional) The name of the project this resource belongs to.
+- `category_ids`: -(Optional) A list of globally unique identifiers that represent all the categories the resource is associated with.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `tenant_id`: - A globally unique identifier that represents the tenant that owns this entity. The system automatically assigns it, and it and is immutable from an API consumer perspective (some use cases may cause this Id to change - For instance, a use case may require the transfer of ownership of the entity, but these cases are handled automatically on the server).
+- `ext_id`: - A globally unique identifier of an instance that is suitable for external consumption.
+- `links`: - A HATEOAS style link for the response. Each link contains a user-friendly name identifying the link and an address for retrieving the particular resource.
+- `metadata`: - Metadata associated with this resource.
+- `name`: - The name of the Object store.
+- `creation_time`: - The time when the Object store was created.
+- `last_update_time`: - The time when the Object store was last updated.
+- `description`: - A brief description of the Object store.
+- `deployment_version`: - The deployment version of the Object store.
+- `domain`: - The DNS domain/subdomain the Object store belongs to. All the Object stores under one Prism Central must have the same domain name. The domain name must consist of at least 2 parts separated by a '.'. Each part can contain upper and lower case letters, digits, hyphens, or underscores. Each part can be up to 63 characters long. The domain must begin and end with an alphanumeric character. For example - 'objects-0.pc_nutanix.com'.
+- `region`: - The region in which the Object store is deployed.
+- `num_worker_nodes`: - The number of worker nodes (VMs) to be created for the Object store. Each worker node requires 10 vCPUs and 32 GiB of memory.
+- `cluster_ext_id`: - UUID of the AHV or ESXi cluster.
+- `storage_network_reference`: - Reference to the Storage Network of the Object store. This is the subnet UUID for an AHV cluster or the IPAM name for an ESXi cluster.
+- `storage_network_vip`: - An unique address that identifies a device on the internet or a local network in IPv4 or IPv6 format.
+- `storage_network_dns_ip`: - An unique address that identifies a device on the internet or a local network in IPv4 or IPv6 format.
+- `public_network_reference`: - Public network reference of the Object store. This is the subnet UUID for an AHV cluster or the IPAM name for an ESXi cluster.
+- `public_network_ips`: - A list of static IP addresses used as public IPs to access the Object store.
+- `total_capacity_gib`: - Size of the Object store in GiB.
+- `state`: - Enum for the state of the Object store.
+    | Enum                                   | Description                                                     |
+    |----------------------------------------|-----------------------------------------------------------------|
+    | `"DEPLOYING_OBJECT_STORE"`             | The Object store is being deployed.                             |
+    | `"OBJECT_STORE_DEPLOYMENT_FAILED"`     | The Object store deployment has failed.                         |
+    | `"DELETING_OBJECT_STORE"`              | A deployed Object store is being deleted.                       |
+    | `"OBJECT_STORE_OPERATION_FAILED"`      | There was an error while performing an operation on the Object store. |
+    | `"UNDEPLOYED_OBJECT_STORE"`            | The Object store is not deployed.                               |
+    | `"OBJECT_STORE_OPERATION_PENDING"`     | There is an ongoing operation on the Object store.              |
+    | `"OBJECT_STORE_AVAILABLE"`            | There are no ongoing operations on the deployed Object store.   |
+    | `"OBJECT_STORE_CERT_CREATION_FAILED"`  | Creating the Object store certificate has failed.               |
+    | `"CREATING_OBJECT_STORE_CERT"`         | A certificate is being created for the Object store.            |
+    | `"OBJECT_STORE_DELETION_FAILED"`       | There was an error deleting the Object store.                   |
+
+- `certificate_ext_ids`: - A list of the UUIDs of the certificates of an Object store.
+
+### Links
+The `links` argument exports the following:
+
+* `href`: - The URL at which the entity described by the link can be accessed.
+* `rel`: - A name that identifies the relationship of the link to the object that is returned by the URL. The unique value of "self" identifies the URL for the object.
+
+### Metadata
+The `metadata` argument exports the following:
+
+- `owner_reference_id`: - A globally unique identifier that represents the owner of this resource.
+- `owner_user_name`: - The userName of the owner of this resource.
+- `project_reference_id`: - A globally unique identifier that represents the project this resource belongs to.
+- `project_name`: - The name of the project this resource belongs to.
+- `category_ids`: - A list of globally unique identifiers that represent all the categories the resource is associated with.
+
+
+### Storage Network VIP
+The `storage_network_vip` argument exports the following:
+
+- `ipv4`: An unique address that identifies a device on the internet or a local network in IPv4 format.
+- `ipv6`: An unique address that identifies a device on the internet or a local network in IPv6 format.
+
+### Storage Network DNS IP
+The `storage_network_dns_ip` argument exports the following:
+- `ipv4`: An unique address that identifies a device on the internet or a local network in IPv4 format.
+- `ipv6`: An unique address that identifies a device on the internet or a local network in IPv6 format.
+
+### Public Network IPs
+The `public_network_ips` argument exports the following:
+- `ipv4`: An unique address that identifies a device on the internet or a local network in IPv4 format.
+- `ipv6`: An unique address that identifies a device on the internet or a local network in IPv6 format.
+
+
+### IPv4, IPv6
+The `ipv4` and `ipv6` argument exports the following:
+- `value`: - The IPv4/IPv6 address of the host.
+- `prefix_length`: - The prefix length of the network to which this host IPv4 address belongs. Default for IPv4 is 32 and for IPv6 is 128.
+
+See detailed information in [Nutanix Get Object Store V4 ](https://developers.nutanix.com/api-reference?namespace=objects&version=v4.0#tag/ObjectStores/operation/getObjectstoreById).


### PR DESCRIPTION
Added docs and examples for object stores management  module.
Data source docs & examples added:

- nutanix_object_store_v2
- nutanix_object_stores_v2
- nutanix_object_store_certificate_v2
- nutanix_object_store_certificates_v2

Resource docs & examples added:

- nutanix_object_store_v2
- nutanix_object_store_certificate_v2
