### PR TITLE
Add support for import of resource nutanix_pbr_v2

### DIFF
--- a/nutanix/services/networkingv2/resource_nutanix_pbrs_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_pbrs_v2.go
@@ -21,6 +21,9 @@ func ResourceNutanixPbrsV2() *schema.Resource {
 		ReadContext:   ResourceNutanixPbrsV2Read,
 		UpdateContext: ResourceNutanixPbrsV2Update,
 		DeleteContext: ResourceNutanixPbrsV2Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"ext_id": {
 				Optional: true,

--- a/website/docs/r/pbrs_v2.html.markdown
+++ b/website/docs/r/pbrs_v2.html.markdown
@@ -125,5 +125,11 @@ The following attributes are exported:
 * `metadata`: Metadata associated with this resource.
 * `vpc`: VPC name for projections
 
+## Import
+This helps to manage existing entities which are not created through terraform. Routing Policy can be imported using the `UUID`.  eg,
+
+`
+terraform import nutanix_pbr_v2.pbr_import <UUID>
+`
 
 See detailed information in [Nutanix Routing Policy v4](https://developers.nutanix.com/api-reference?namespace=networking&version=v4.0).


### PR DESCRIPTION
Add support for import of resource nutanix_pbr_v2.

Tested following flows,
1.  Created a VPC(By default 2 routing policies will be created)
2.  Get the UUID of routing policy with name "virtual-network-allow-all"
3.  Import the policy with UUID `terraform import nutanix_pbr_v2.pbr_import <UUID>`
4. Add the description and update policy action_type  from "PERMIT" to  "DENY".
5. Update  the priority from 10 to 99.
6. Update destination address_type from "ANY" to "EXTERNAL".
7. Do a destroy. delete is succesfull.

Sample script used
```
data "nutanix_clusters_v2" "clusters" {}

locals {
  cluster0 =  [
      for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
      cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
  ][0]
}

resource "nutanix_subnet_v2" "test" {
  name = "terraform-test-subnet-vpc-2"
  description = "test subnet description"
  cluster_reference = local.cluster0
  subnet_type = "VLAN"
  network_id = 112
  is_external = true
  ip_config {
    ipv4 {
      ip_subnet {
        ip {
          value = "192.168.0.0"
        }
        prefix_length = 24
      }
      default_gateway_ip {
        value = "192.168.0.1"
      }
      pool_list{
        start_ip {
          value = "192.168.0.20"
        }
        end_ip {
          value = "192.168.0.30"
        }
      }
    }
  }
  depends_on = [data.nutanix_clusters_v2.clusters]
}

resource "nutanix_vpc_v2" "test" {
  name =  "pbr_vpc_akhil_final_test"
  description = "pbr_vpc"
  external_subnets{
    subnet_reference = nutanix_subnet_v2.test.id
  }
  depends_on = [nutanix_subnet_v2.test]
}

# Data source to list all PBRs for the given VPC
data "nutanix_pbrs_v2" "list_pbrs" {
  filter = "vpcExtId eq '${nutanix_vpc_v2.test.id}'"
}


locals {
  pbr_10_uuid = try(
    [for p in data.nutanix_pbrs_v2.list_pbrs.routing_policies : p.ext_id if p.name == "virtual-network-allow-all"][0],
    ""
  )
}

# Output for verification
output "priority_10_pbr_ext_id" {
  value = local.pbr_10_uuid
}

# This been added after import.
resource "nutanix_pbr_v2" "import_pbr" {
  name        = "virtual-network-allow-all"
  vpc_ext_id  = nutanix_vpc_v2.test.id
  priority    = 99
  policies {
    policy_match {
      source {
        address_type = "ANY"
      }
      destination {
        address_type = "ANY"
      }
      protocol_type = "ANY"
    }
    policy_action {
      action_type = "DENY"
    }
  }
}
```