### PR TITLE
Fix issue 835: provider plugin panic when trying to add multiple security policies

### DIFF
--- a/nutanix/common/common.go
+++ b/nutanix/common/common.go
@@ -1,9 +1,7 @@
 package common
 
 import (
-	"fmt"
 	"log"
-	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -38,16 +36,4 @@ func IsExplicitlySet(d *schema.ResourceData, key string) bool {
 		return !val.IsNull() // Ensure key exists and isn't explicitly null
 	}
 	return false
-}
-
-// ExtIdValidation checks if a given string is a valid UUID.
-// It uses a regular expression to validate the UUID format.
-var uuidRegex = regexp.MustCompile(`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`)
-
-func ExtIDValidation(val interface{}, key string) (warns []string, errs []error) {
-	v := val.(string)
-	if !uuidRegex.MatchString(v) {
-		errs = append(errs, fmt.Errorf("%q must be a valid Ext ID: got %q", key, v))
-	}
-	return
 }

--- a/nutanix/common/common.go
+++ b/nutanix/common/common.go
@@ -44,7 +44,7 @@ func IsExplicitlySet(d *schema.ResourceData, key string) bool {
 // It uses a regular expression to validate the UUID format.
 var uuidRegex = regexp.MustCompile(`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`)
 
-func ExtIdValidation(val interface{}, key string) (warns []string, errs []error) {
+func ExtIDValidation(val interface{}, key string) (warns []string, errs []error) {
 	v := val.(string)
 	if !uuidRegex.MatchString(v) {
 		errs = append(errs, fmt.Errorf("%q must be a valid Ext ID: got %q", key, v))

--- a/nutanix/common/common.go
+++ b/nutanix/common/common.go
@@ -12,13 +12,13 @@ import (
 // which is defined in the schema
 // its return a list of string
 func ExpandListOfString(list []interface{}) []string {
-	stringListStr := make([]string, len(list))
+	stringListStr := make([]string, 0)
 	for i, v := range list {
 		if v == nil || v == "" {
 			log.Printf("[DEBUG] Skipping nil or empty value at index %d", i)
 			continue // Skip nil or empty values
 		}
-		stringListStr[i] = v.(string)
+		stringListStr = append(stringListStr, v.(string))
 	}
 	return stringListStr
 }

--- a/nutanix/common/common.go
+++ b/nutanix/common/common.go
@@ -1,7 +1,9 @@
 package common
 
 import (
+	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -12,6 +14,10 @@ import (
 func ExpandListOfString(list []interface{}) []string {
 	stringListStr := make([]string, len(list))
 	for i, v := range list {
+		if v == nil || v == "" {
+			log.Printf("[DEBUG] Skipping nil or empty value at index %d", i)
+			continue // Skip nil or empty values
+		}
 		stringListStr[i] = v.(string)
 	}
 	return stringListStr
@@ -32,4 +38,16 @@ func IsExplicitlySet(d *schema.ResourceData, key string) bool {
 		return !val.IsNull() // Ensure key exists and isn't explicitly null
 	}
 	return false
+}
+
+// ExtIdValidation checks if a given string is a valid UUID.
+// It uses a regular expression to validate the UUID format.
+var uuidRegex = regexp.MustCompile(`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`)
+
+func ExtIdValidation(val interface{}, key string) (warns []string, errs []error) {
+	v := val.(string)
+	if !uuidRegex.MatchString(v) {
+		errs = append(errs, fmt.Errorf("%q must be a valid Ext ID: got %q", key, v))
+	}
+	return
 }

--- a/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go
@@ -14,6 +14,7 @@ import (
 	import4 "github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4/models/prism/v4/config"
 	import2 "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/prism/v4/config"
 	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/common"
 	"github.com/terraform-providers/terraform-provider-nutanix/utils"
 )
 
@@ -77,14 +78,16 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 													Type:     schema.TypeList,
 													Required: true,
 													Elem: &schema.Schema{
-														Type: schema.TypeString,
+														Type:         schema.TypeString,
+														ValidateFunc: common.ExtIdValidation,
 													},
 												},
 												"second_isolation_group": {
 													Type:     schema.TypeList,
 													Required: true,
 													Elem: &schema.Schema{
-														Type: schema.TypeString,
+														Type:         schema.TypeString,
+														ValidateFunc: common.ExtIdValidation,
 													},
 												},
 											},
@@ -99,7 +102,8 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 													Type:     schema.TypeList,
 													Required: true,
 													Elem: &schema.Schema{
-														Type: schema.TypeString,
+														Type:         schema.TypeString,
+														ValidateFunc: common.ExtIdValidation,
 													},
 												},
 												"src_allow_spec": {
@@ -127,7 +131,8 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 													Optional: true,
 													Computed: true,
 													Elem: &schema.Schema{
-														Type: schema.TypeString,
+														Type:         schema.TypeString,
+														ValidateFunc: common.ExtIdValidation,
 													},
 												},
 												"src_subnet": {
@@ -173,7 +178,8 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 													Optional: true,
 													Computed: true,
 													Elem: &schema.Schema{
-														Type: schema.TypeString,
+														Type:         schema.TypeString,
+														ValidateFunc: common.ExtIdValidation,
 													},
 												},
 												"dest_address_group_references": {
@@ -181,7 +187,8 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 													Optional: true,
 													Computed: true,
 													Elem: &schema.Schema{
-														Type: schema.TypeString,
+														Type:         schema.TypeString,
+														ValidateFunc: common.ExtIdValidation,
 													},
 												},
 												"service_group_references": {
@@ -189,7 +196,8 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 													Optional: true,
 													Computed: true,
 													Elem: &schema.Schema{
-														Type: schema.TypeString,
+														Type:         schema.TypeString,
+														ValidateFunc: common.ExtIdValidation,
 													},
 												},
 												"is_all_protocol_allowed": {
@@ -276,7 +284,8 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 													Computed: true,
 													Optional: true,
 													Elem: &schema.Schema{
-														Type: schema.TypeString,
+														Type:         schema.TypeString,
+														ValidateFunc: common.ExtIdValidation,
 													},
 												},
 											},
@@ -309,7 +318,8 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 																						Type:     schema.TypeList,
 																						Required: true,
 																						Elem: &schema.Schema{
-																							Type: schema.TypeString,
+																							Type:         schema.TypeString,
+																							ValidateFunc: common.ExtIdValidation,
 																						},
 																					},
 																				},
@@ -472,7 +482,7 @@ func ResourceNutanixNetworkSecurityPolicyV2Create(ctx context.Context, d *schema
 		spec.Scope = &p
 	}
 	if vpcRef, ok := d.GetOk("vpc_reference"); ok {
-		spec.VpcReferences = expandStringList(vpcRef.([]interface{}))
+		spec.VpcReferences = common.ExpandListOfString(vpcRef.([]interface{}))
 	}
 
 	aJSON, _ := json.MarshalIndent(spec, "", "  ")
@@ -685,7 +695,7 @@ func ResourceNutanixNetworkSecurityPolicyV2Update(ctx context.Context, d *schema
 		updatedSpec.Scope = &p
 	}
 	if d.HasChange("vpc_reference") {
-		updatedSpec.VpcReferences = expandStringList(d.Get("vpc_reference").([]interface{}))
+		updatedSpec.VpcReferences = common.ExpandListOfString(d.Get("vpc_reference").([]interface{}))
 	}
 
 	aJSON, _ := json.MarshalIndent(updatedSpec, "", "  ")
@@ -791,10 +801,10 @@ func expandOneOfNetworkSecurityPolicyRuleSpec(pr interface{}) *import1.OneOfNetw
 			isoVal := isoI[0].(map[string]interface{})
 
 			if firstIso, ok := isoVal["first_isolation_group"]; ok && len(firstIso.([]interface{})) > 0 {
-				iso.FirstIsolationGroup = expandStringList(firstIso.([]interface{}))
+				iso.FirstIsolationGroup = common.ExpandListOfString(firstIso.([]interface{}))
 			}
 			if secIso, ok := isoVal["second_isolation_group"]; ok && len(secIso.([]interface{})) > 0 {
-				iso.SecondIsolationGroup = expandStringList(secIso.([]interface{}))
+				iso.SecondIsolationGroup = common.ExpandListOfString(secIso.([]interface{}))
 			}
 			policyRules.SetValue(*iso)
 		}
@@ -806,7 +816,7 @@ func expandOneOfNetworkSecurityPolicyRuleSpec(pr interface{}) *import1.OneOfNetw
 			appVal := appI[0].(map[string]interface{})
 
 			if secGroup, ok := appVal["secured_group_category_references"]; ok && len(secGroup.([]interface{})) > 0 {
-				app.SecuredGroupCategoryReferences = expandStringList(secGroup.([]interface{}))
+				app.SecuredGroupCategoryReferences = common.ExpandListOfString(secGroup.([]interface{}))
 			}
 			if srcAllow, ok := appVal["src_allow_spec"]; ok && len(srcAllow.(string)) > 0 {
 				const two, three = 2, 3
@@ -829,10 +839,10 @@ func expandOneOfNetworkSecurityPolicyRuleSpec(pr interface{}) *import1.OneOfNetw
 				app.DestAllowSpec = &p
 			}
 			if srcCatRef, ok := appVal["src_category_references"]; ok && len(srcCatRef.([]interface{})) > 0 {
-				app.SrcCategoryReferences = expandStringList(srcCatRef.([]interface{}))
+				app.SrcCategoryReferences = common.ExpandListOfString(srcCatRef.([]interface{}))
 			}
 			if destCatRef, ok := appVal["dest_category_references"]; ok && len(destCatRef.([]interface{})) > 0 {
-				app.DestCategoryReferences = expandStringList(destCatRef.([]interface{}))
+				app.DestCategoryReferences = common.ExpandListOfString(destCatRef.([]interface{}))
 			}
 			if srcSubnet, ok := appVal["src_subnet"]; ok && len(srcSubnet.([]interface{})) > 0 {
 				app.SrcSubnet = expandIPv4AddressMicroseg(srcSubnet)
@@ -841,13 +851,13 @@ func expandOneOfNetworkSecurityPolicyRuleSpec(pr interface{}) *import1.OneOfNetw
 				app.DestSubnet = expandIPv4AddressMicroseg(destSubnet)
 			}
 			if srcAddGrpRef, ok := appVal["src_address_group_references"]; ok && len(srcAddGrpRef.([]interface{})) > 0 {
-				app.SrcAddressGroupReferences = expandStringList(srcAddGrpRef.([]interface{}))
+				app.SrcAddressGroupReferences = common.ExpandListOfString(srcAddGrpRef.([]interface{}))
 			}
 			if destAddGrpRef, ok := appVal["dest_address_group_references"]; ok && len(destAddGrpRef.([]interface{})) > 0 {
-				app.DestAddressGroupReferences = expandStringList(destAddGrpRef.([]interface{}))
+				app.DestAddressGroupReferences = common.ExpandListOfString(destAddGrpRef.([]interface{}))
 			}
 			if serviceGrpRef, ok := appVal["service_group_references"]; ok && len(serviceGrpRef.([]interface{})) > 0 {
-				app.ServiceGroupReferences = expandStringList(serviceGrpRef.([]interface{}))
+				app.ServiceGroupReferences = common.ExpandListOfString(serviceGrpRef.([]interface{}))
 			}
 			if allProto, ok := appVal["is_all_protocol_allowed"]; ok {
 				app.IsAllProtocolAllowed = utils.BoolPtr(allProto.(bool))
@@ -875,7 +885,7 @@ func expandOneOfNetworkSecurityPolicyRuleSpec(pr interface{}) *import1.OneOfNetw
 			intraVal := intraI[0].(map[string]interface{})
 
 			if secGroup, ok := intraVal["secured_group_category_references"]; ok && len(secGroup.([]interface{})) > 0 {
-				intra.SecuredGroupCategoryReferences = expandStringList(secGroup.([]interface{}))
+				intra.SecuredGroupCategoryReferences = common.ExpandListOfString(secGroup.([]interface{}))
 			}
 			if secGroupAction, ok := intraVal["secured_group_action"]; ok && len(secGroupAction.(string)) > 0 {
 				const two, three = 2, 3
@@ -961,7 +971,7 @@ func expandIsolationGroup(isolationGroup []interface{}) []import1.IsolationGroup
 			iso := import1.IsolationGroup{}
 
 			if groupCat, ok := val["group_category_references"]; ok && len(groupCat.([]interface{})) > 0 {
-				iso.GroupCategoryReferences = expandStringList(groupCat.([]interface{}))
+				iso.GroupCategoryReferences = common.ExpandListOfString(groupCat.([]interface{}))
 			}
 			isolations[k] = iso
 		}

--- a/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go
@@ -78,16 +78,14 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 													Type:     schema.TypeList,
 													Required: true,
 													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: common.ExtIdValidation,
+														Type: schema.TypeString,
 													},
 												},
 												"second_isolation_group": {
 													Type:     schema.TypeList,
 													Required: true,
 													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: common.ExtIdValidation,
+														Type: schema.TypeString,
 													},
 												},
 											},
@@ -102,8 +100,7 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 													Type:     schema.TypeList,
 													Required: true,
 													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: common.ExtIdValidation,
+														Type: schema.TypeString,
 													},
 												},
 												"src_allow_spec": {
@@ -131,8 +128,7 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 													Optional: true,
 													Computed: true,
 													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: common.ExtIdValidation,
+														Type: schema.TypeString,
 													},
 												},
 												"src_subnet": {
@@ -178,8 +174,7 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 													Optional: true,
 													Computed: true,
 													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: common.ExtIdValidation,
+														Type: schema.TypeString,
 													},
 												},
 												"dest_address_group_references": {
@@ -187,8 +182,7 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 													Optional: true,
 													Computed: true,
 													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: common.ExtIdValidation,
+														Type: schema.TypeString,
 													},
 												},
 												"service_group_references": {
@@ -196,8 +190,7 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 													Optional: true,
 													Computed: true,
 													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: common.ExtIdValidation,
+														Type: schema.TypeString,
 													},
 												},
 												"is_all_protocol_allowed": {
@@ -284,8 +277,7 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 													Computed: true,
 													Optional: true,
 													Elem: &schema.Schema{
-														Type:         schema.TypeString,
-														ValidateFunc: common.ExtIdValidation,
+														Type: schema.TypeString,
 													},
 												},
 											},
@@ -318,8 +310,7 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 																						Type:     schema.TypeList,
 																						Required: true,
 																						Elem: &schema.Schema{
-																							Type:         schema.TypeString,
-																							ValidateFunc: common.ExtIdValidation,
+																							Type: schema.TypeString,
 																						},
 																					},
 																				},

--- a/nutanix/services/networkingv2/resource_nutanix_subnets_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_subnets_v2.go
@@ -846,7 +846,7 @@ func expandDhcpOptions(pr []interface{}) *import1.DhcpOptions {
 			dhcpOps.DomainName = utils.StringPtr(dn.(string))
 		}
 		if searchDomain, ok := val["search_domains"]; ok && len(searchDomain.([]interface{})) > 0 {
-			dhcpOps.SearchDomains = expandStringList(searchDomain.([]interface{}))
+			dhcpOps.SearchDomains = common.ExpandListOfString(searchDomain.([]interface{}))
 		}
 		if tftp, ok := val["tftp_server_name"]; ok && len(tftp.(string)) > 0 {
 			dhcpOps.TftpServerName = utils.StringPtr(tftp.(string))
@@ -1117,7 +1117,7 @@ func expandExternalSubnet(pr []interface{}) []import1.ExternalSubnet {
 				sub.ExternalIps = expandIPAddress(extips.([]interface{}))
 			}
 			if gatewayNodes, ok := val["gateway_nodes"]; ok && len(gatewayNodes.([]interface{})) > 0 {
-				sub.GatewayNodes = expandStringList(gatewayNodes.([]interface{}))
+				sub.GatewayNodes = common.ExpandListOfString(gatewayNodes.([]interface{}))
 			}
 			if activeGatewayNode, ok := val["active_gateway_node"]; ok && len(activeGatewayNode.([]interface{})) > 0 {
 				sub.ActiveGatewayNodes = expandGatewayNodeReference(activeGatewayNode)
@@ -1353,18 +1353,6 @@ func expandIPv6Pool(pr []interface{}) []import1.IPv6Pool {
 			pools[k] = pool
 		}
 		return pools
-	}
-	return nil
-}
-
-func expandStringList(pr []interface{}) []string {
-	if len(pr) > 0 {
-		strList := make([]string, len(pr))
-
-		for k, v := range pr {
-			strList[k] = v.(string)
-		}
-		return strList
 	}
 	return nil
 }


### PR DESCRIPTION
passing an empty string ("") as a UUID reference in your resource configuration, like this:
try(data.nutanix_categories_v2.app_type[count.index].categories[0].ext_id, "")

The empty string is what's causing the issue.

validation added on expand method to ignore empty or nil values 