### PR TITLE
Fix issue 681 : add examples for protection rule, categories and recovery plan 

### DIFF
--- a/examples/categories/main.tf
+++ b/examples/categories/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = "1.9.5"
+    }
+  }
+}
+
+#defining nutanix configuration
+provider "nutanix" {
+  username = var.nutanix_username
+  password = var.nutanix_password
+  endpoint = var.nutanix_endpoint
+  port     = 9440
+  insecure = true
+}
+
+
+# Create a category key
+resource "nutanix_category_key" "example-category-key" {
+  name        = "app-support"              # this value can be updated
+  description = "App Support Category Key" # this value can be updated
+}
+
+# Create a category value
+resource "nutanix_category_value" "example-category-value" {
+  name        = nutanix_category_key.example-category-key.id
+  description = "Example Category Value" # this value can be updated
+  value       = "example-value"          # this value can be updated
+}
+
+# Get the category key by name
+data "nutanix_category_key" "get_key" {
+  name = nutanix_category_key.example-category-key.name
+}

--- a/examples/categories/terraform.tfvars
+++ b/examples/categories/terraform.tfvars
@@ -1,0 +1,4 @@
+#define values to the variables to be used in terraform file
+nutanix_username = "admin"
+nutanix_password = "password"
+nutanix_endpoint = "10.xx.xx.xx"

--- a/examples/categories/variables.tf
+++ b/examples/categories/variables.tf
@@ -1,0 +1,10 @@
+#define the type of variables to be used in terraform file
+variable "nutanix_username" {
+  type = string
+}
+variable "nutanix_password" {
+  type = string
+}
+variable "nutanix_endpoint" {
+  type = string
+}

--- a/examples/protection_rule/main.tf
+++ b/examples/protection_rule/main.tf
@@ -1,0 +1,67 @@
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = "1.9.5"
+    }
+  }
+}
+
+#defining nutanix configuration
+provider "nutanix" {
+  username = var.nutanix_username
+  password = var.nutanix_password
+  endpoint = var.nutanix_endpoint
+  port     = 9440
+  insecure = true
+}
+
+
+data "nutanix_clusters" "clusters" {}
+
+locals {
+  cluster_uuid = (data.nutanix_clusters.clusters.entities.0.service_list.0 == "PRISM_CENTRAL"
+  ? data.nutanix_clusters.clusters.entities.1.metadata.uuid : data.nutanix_clusters.clusters.entities.0.metadata.uuid)
+}
+
+resource "nutanix_protection_rule" "protection_rule_example" {
+  name        = "protection-rule-example"
+  description = "This is a sample protection rule for demonstration purposes."
+  ordered_availability_zone_list {
+    availability_zone_url = var.source_az_url
+    cluster_uuid          = local.cluster_uuid
+  }
+  ordered_availability_zone_list {
+    availability_zone_url = var.target_az_url
+    cluster_uuid          = var.target_cluster_uuid
+  }
+
+  availability_zone_connectivity_list {
+    source_availability_zone_index      = 0
+    destination_availability_zone_index = 1
+    snapshot_schedule_list {
+      recovery_point_objective_secs = 3600
+      snapshot_type                 = "CRASH_CONSISTENT"
+      local_snapshot_retention_policy {
+        num_snapshots = 4
+      }
+    }
+  }
+  availability_zone_connectivity_list {
+    source_availability_zone_index      = 1
+    destination_availability_zone_index = 0
+    snapshot_schedule_list {
+      recovery_point_objective_secs = 3600
+      snapshot_type                 = "CRASH_CONSISTENT"
+      local_snapshot_retention_policy {
+        num_snapshots = 4
+      }
+    }
+  }
+  category_filter {
+    params {
+      name   = "Environment"
+      values = ["Dev"]
+    }
+  }
+}

--- a/examples/protection_rule/terraform.tfvars
+++ b/examples/protection_rule/terraform.tfvars
@@ -1,0 +1,5 @@
+#define values to the variables to be used in terraform file
+nutanix_username = "admin"
+nutanix_password = "password"
+nutanix_endpoint = "10.xx.xx.xx"
+nutanix_port = 9440

--- a/examples/protection_rule/variables.tf
+++ b/examples/protection_rule/variables.tf
@@ -1,0 +1,25 @@
+#define the type of variables to be used in terraform file
+variable "nutanix_username" {
+  type = string
+}
+variable "nutanix_password" {
+  type = string
+}
+variable "nutanix_endpoint" {
+  type = string
+}
+variable "nutanix_port" {
+  type = string
+}
+variable "source_cluster_uuid" {
+  type = string
+}
+variable "target_cluster_uuid" {
+  type = string
+}
+variable "source_az_url" {
+  type = string
+}
+variable "target_az_url" {
+  type = string
+}

--- a/examples/recovery_plan/main.tf
+++ b/examples/recovery_plan/main.tf
@@ -1,0 +1,150 @@
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = "1.9.5"
+    }
+  }
+}
+
+#defining nutanix configuration
+provider "nutanix" {
+  username = var.nutanix_username
+  password = var.nutanix_password
+  endpoint = var.nutanix_endpoint
+  port     = 9440
+  insecure = true
+}
+
+# Example 1: Create a recovery plan with stage list
+resource "nutanix_recovery_plan" "recovery_plan_stage_list" {
+  name        = "tf-example-recovery-plan-stage-list"
+  description = "This is a sample recovery plan with stage list for demonstration purposes."
+  stage_list {
+    stage_work {
+      recover_entities {
+        entity_info_list {
+          categories {
+            name  = "Environment"
+            value = "Dev"
+          }
+        }
+      }
+    }
+    stage_uuid      = "ab788130-0820-4d07-a1b5-b0ba4d3a4254"
+    delay_time_secs = 0
+  }
+  parameters {}
+}
+
+
+# Example 2: Create a recovery plan with stage list and network mapping
+
+
+data "nutanix_clusters" "clusters" {}
+
+locals {
+  clusterUUID = (data.nutanix_clusters.clusters.entities.0.service_list.0 == "PRISM_CENTRAL"
+  ? data.nutanix_clusters.clusters.entities.1.metadata.uuid : data.nutanix_clusters.clusters.entities.0.metadata.uuid)
+}
+
+resource "nutanix_virtual_machine" "vm1" {
+  name         = "test-dou-vm"
+  cluster_uuid = local.clusterUUID
+
+  boot_device_order_list = ["DISK", "CDROM"]
+  boot_type              = "LEGACY"
+  num_vcpus_per_socket   = 1
+  num_sockets            = 1
+  memory_size_mib        = 186
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
+
+  categories {
+    name  = "Environment"
+    value = "Staging"
+  }
+}
+
+resource "nutanix_recovery_plan" "recovery_plan_with_network" {
+  name        = "recovery-plan-example-with-network"
+  description = "This is a sample recovery plan with network mapping for demonstration purposes."
+  stage_list {
+    stage_work {
+      recover_entities {
+        entity_info_list {
+          any_entity_reference_name = nutanix_virtual_machine.vm1.name
+          any_entity_reference_kind = "vm"
+          any_entity_reference_uuid = nutanix_virtual_machine.vm1.id
+        }
+      }
+    }
+    stage_uuid      = "ab788130-0820-4d07-a1b5-b0ba4d3a4254"
+    delay_time_secs = 0
+  }
+  parameters {
+    network_mapping_list {
+      availability_zone_network_mapping_list {
+        availability_zone_url = var.source_az_url
+        recovery_network {
+          name = "vlan.800"
+          subnet_list {
+            gateway_ip                  = "10.38.2.129"
+            prefix_length               = 24
+            external_connectivity_state = "DISABLED"
+          }
+        }
+        test_network {
+          name = "vlan.800"
+          subnet_list {
+            gateway_ip                  = "192.168.0.1"
+            prefix_length               = 24
+            external_connectivity_state = "DISABLED"
+          }
+        }
+        cluster_reference_list {
+          kind = "cluster"
+          uuid = var.source_cluster_uuid
+        }
+      }
+      availability_zone_network_mapping_list {
+        availability_zone_url = var.target_az_url
+        recovery_network {
+          name = "vlan.800"
+          subnet_list {
+            gateway_ip                  = "10.38.4.65"
+            prefix_length               = 24
+            external_connectivity_state = "DISABLED"
+          }
+        }
+        test_network {
+          name = "vlan.800"
+          subnet_list {
+            gateway_ip                  = "192.168.0.1"
+            prefix_length               = 24
+            external_connectivity_state = "DISABLED"
+          }
+        }
+        cluster_reference_list {
+          kind = "cluster"
+          uuid = var.target_cluster_uuid
+        }
+      }
+    }
+  }
+}
+
+
+# Get Recovery Plan by UUID
+data "nutanix_recovery_plan" "get_recovery_plan" {
+  recovery_plan_id = nutanix_recovery_plan.recovery_plan_with_network.id
+}
+
+# List Recovery Plans
+data "nutanix_recovery_plans" "list_recovery_plans" {
+  depends_on = [nutanix_recovery_plan.recovery_plan_stage_list, nutanix_recovery_plan.recovery_plan_with_network]
+}

--- a/examples/recovery_plan/terraform.tfvars
+++ b/examples/recovery_plan/terraform.tfvars
@@ -1,0 +1,5 @@
+#define values to the variables to be used in terraform file
+nutanix_username = "admin"
+nutanix_password = "password"
+nutanix_endpoint = "10.xx.xx.xx"
+nutanix_port = 9440

--- a/examples/recovery_plan/variables.tf
+++ b/examples/recovery_plan/variables.tf
@@ -1,0 +1,25 @@
+#define the type of variables to be used in terraform file
+variable "nutanix_username" {
+  type = string
+}
+variable "nutanix_password" {
+  type = string
+}
+variable "nutanix_endpoint" {
+  type = string
+}
+variable "nutanix_port" {
+  type = string
+}
+variable "source_cluster_uuid" {
+  type = string
+}
+variable "target_cluster_uuid" {
+  type = string
+}
+variable "source_az_url" {
+  type = string
+}
+variable "target_az_url" {
+  type = string
+}


### PR DESCRIPTION
This PR adds Terraform usage examples for the following Nutanix resources (version 3):

- Protection Rule

- Categories

- Recovery Plan

These examples help illustrate usage patterns and provide guidance for users working with the v3 API. Examples for v4 of these resources already exist, so this PR focuses on filling the gap for v3.

