### PR TITLE
do not depend on task api response for fetching the entities affected

### DIFF
--- a/nutanix/services/clustersv2/resource_nutanix_cluster_entity_add_node_v2.go
+++ b/nutanix/services/clustersv2/resource_nutanix_cluster_entity_add_node_v2.go
@@ -541,10 +541,11 @@ func ResourceNutanixClusterAddNodeV2Create(ctx context.Context, d *schema.Resour
 	aJSON, _ = json.Marshal(resourceUUID)
 	log.Printf("[DEBUG] Add Node Response: %s", string(aJSON))
 
-	rUUID := resourceUUID.Data.GetValue().(import2.Task)
-
-	uuid := rUUID.EntitiesAffected[0].ExtId
-	d.SetId(*uuid)
+	// rUUID := resourceUUID.Data.GetValue().(import2.Task)
+	// Entities affected is always the cluster uuid
+	//uuid := rUUID.EntitiesAffected[0].ExtId
+	uuid := clusterExtID.(string)
+	d.SetId(uuid)
 	return nil
 }
 

--- a/nutanix/services/clustersv2/resource_nutanix_cluster_entity_add_node_v2.go
+++ b/nutanix/services/clustersv2/resource_nutanix_cluster_entity_add_node_v2.go
@@ -541,9 +541,6 @@ func ResourceNutanixClusterAddNodeV2Create(ctx context.Context, d *schema.Resour
 	aJSON, _ = json.Marshal(resourceUUID)
 	log.Printf("[DEBUG] Add Node Response: %s", string(aJSON))
 
-	// rUUID := resourceUUID.Data.GetValue().(import2.Task)
-	// Entities affected is always the cluster uuid
-	//uuid := rUUID.EntitiesAffected[0].ExtId
 	uuid := clusterExtID.(string)
 	d.SetId(uuid)
 	return nil


### PR DESCRIPTION
Currently for setting the resource id we are relying on task response to get the entities affected. Instead of fetching the entities affected uuid from task response, use the uuid which has been sent in payload sent by the user.