### PR TITLE
Changes for release 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.2 (September 1, 2025)
+[Full Changelog](https://github.com/nutanix/terraform-provider-nutanix/compare/v2.2.1...v2.2.2)
+
+**Fixed bugs:**
+- nutanix_clusters_v2 not returning associated categories [\#907](https://github.com/nutanix/terraform-provider-nutanix/issues/907)
+
+
 ## 2.2.1 (June 30, 2025)
 [Full Changelog](https://github.com/nutanix/terraform-provider-nutanix/compare/v2.2.0...v2.2.1)
 
@@ -61,7 +68,7 @@
 ## 2.1.0 (April 07, 2025)
 [Full Changelog](https://github.com/nutanix/terraform-provider-nutanix/compare/v2.0.0...v2.1.0)
 
-All new features are v4 SDKs based. 
+All new features are v4 SDKs based.
 
 **New Feature:**
 - Prism [\#815](https://github.com/nutanix/terraform-provider-nutanix/issues/815)
@@ -109,7 +116,7 @@ All new features are v4 SDKs based.
 ## 2.0.0 (January 07, 2025)
 [Full Changelog](https://github.com/nutanix/terraform-provider-nutanix/compare/v1.9.5...v2.0.0)
 
-All new features are v4 SDKs based. 
+All new features are v4 SDKs based.
 
 **New Feature:**
 - Cluster Management [\#704](https://github.com/nutanix/terraform-provider-nutanix/issues/704)
@@ -260,7 +267,7 @@ All new features are v4 SDKs based.
 
 **New Feature:**
 - Add support for new Karbon features. [\#290](https://github.com/nutanix/terraform-provider-nutanix/issues/290)
-    
+
     New Resource :
     - nutanix_karbon_worker_nodepool
 
@@ -305,7 +312,7 @@ All new features are v4 SDKs based.
 - lcm_config should be Set without plugin crash in clone resource. [\#583](https://github.com/nutanix/terraform-provider-nutanix/issues/583)
 
 **Closed issues:**
-- NDB datasource for network available ips. [\#569](https://github.com/nutanix/terraform-provider-nutanix/issues/569) 
+- NDB datasource for network available ips. [\#569](https://github.com/nutanix/terraform-provider-nutanix/issues/569)
 - Support for adding import on ndb day2 actions. [\#582](https://github.com/nutanix/terraform-provider-nutanix/issues/582)
 - How to configure IP address for Nutanix Packer images. [\#576](https://github.com/nutanix/terraform-provider-nutanix/issues/576)
 
@@ -337,7 +344,7 @@ All new features are v4 SDKs based.
     - nutanix_ndb_networks
     - nutanix_ndb_dbserver
     - nutanix_ndb_dbservers
-    
+
 
 ## 1.8.0-beta-2 (Jan 20, 2023)
 [Full Changelog](https://github.com/nutanix/terraform-provider-nutanix/compare/v1.8.0-beta.1...v1.8.0-beta.2)
@@ -373,7 +380,7 @@ All new features are v4 SDKs based.
  - Support for HA instance in nutanix_ndb_database resource. [\#518](https://github.com/nutanix/terraform-provider-nutanix/pull/518)
  - Improving the error when server is unreachable. [\#530](https://github.com/nutanix/terraform-provider-nutanix/pull/530)
  - Fetching of database based on database_type filter [\#513](https://github.com/nutanix/terraform-provider-nutanix/pull/513)
- - Support of Tags and Maintainence Window in provisioning [\#528](https://github.com/nutanix/terraform-provider-nutanix/pull/528) 
+ - Support of Tags and Maintainence Window in provisioning [\#528](https://github.com/nutanix/terraform-provider-nutanix/pull/528)
 
 
 ## 1.8.0-beta.1 (Oct 12, 2022)
@@ -432,7 +439,7 @@ All new features are v4 SDKs based.
 
 **Fixed bugs:**
 
-- Terraform provider crashes when using guest_customization_sysprep_custom_key_values [\#441] (https://github.com/nutanix/terraform-provider-nutanix/issues/441) 
+- Terraform provider crashes when using guest_customization_sysprep_custom_key_values [\#441] (https://github.com/nutanix/terraform-provider-nutanix/issues/441)
 - Nutanix terraform- Karbon clusters, the storage_class_config is not been displayed. [\#417] (https://github.com/nutanix/terraform-provider-nutanix/issues/417)
 - Checksum is not considered while uploading image from local using nutanix_image resource. [\#469] (https://github.com/nutanix/terraform-provider-nutanix/issues/469)
 - Not able to update image_type of PC image [\#454] (https://github.com/nutanix/terraform-provider-nutanix/issues/454)
@@ -441,7 +448,7 @@ All new features are v4 SDKs based.
 **Closed issues:**
 
 - Support for User Groups [\#475] (https://github.com/nutanix/terraform-provider-nutanix/issues/475)
-- Resizing disk identified in plan, but not actually done during apply [\#463] (https://github.com/nutanix/terraform-provider-nutanix/issues/463) 
+- Resizing disk identified in plan, but not actually done during apply [\#463] (https://github.com/nutanix/terraform-provider-nutanix/issues/463)
 - uuid of address_groups are not available [\#461] (https://github.com/nutanix/terraform-provider-nutanix/issues/461)
 - ntx provider have ENTITY_READ_ERROR when try to recreate a VM deleted manually [\#451] (https://github.com/nutanix/terraform-provider-nutanix/issues/451)
 - Allow project definiation by name and not just ID [\#406] (https://github.com/nutanix/terraform-provider-nutanix/issues/406)
@@ -499,7 +506,7 @@ All new features are v4 SDKs based.
 - Foundation Acceptance tests and minor fixes [\#436](https://github.com/nutanix/terraform-provider-nutanix/pull/436) ([bhatipradeep](https://github.com/bhatipradeep))
 - Foundation Central unit tests and acceptance tests [\#439](https://github.com/nutanix/terraform-provider-nutanix/pull/439) ([abhimutant](https://github.com/abhimutant))
 - Optimize Image upload to avoid buffering. Add cluster related fields in image upload resource & data source for PC [\#432](https://github.com/nutanix/terraform-provider-nutanix/pull/432) ([bhatipradeep](https://github.com/bhatipradeep))
-- fixing karbon docs at registry [\#434](https://github.com/nutanix/terraform-provider-nutanix/pull/434)([abhimutant](https://github.com/abhimutant)) 
+- fixing karbon docs at registry [\#434](https://github.com/nutanix/terraform-provider-nutanix/pull/434)([abhimutant](https://github.com/abhimutant))
 - Example for using config downloaded from install.nutanix.com to image nodes[\#444](https://github.com/nutanix/terraform-provider-nutanix/pull/444) ([bhatipradeep](https://github.com/bhatipradeep))
 - Add example to pull secrets from hashicorp vault to use them in node imaging [\#431](https://github.com/nutanix/terraform-provider-nutanix/pull/431) ([bhatipradeep](https://github.com/bhatipradeep))
 
@@ -536,12 +543,12 @@ All new features are v4 SDKs based.
     -   nutanix_foundation_central_cluster_details
     -   nutanix_foundation_central_imaged_node_details
 
-    
+
     New Resources :
     -   nutanix_foundation_central_image_cluster
     -   nutanix_foundation_central_api_keys
 
-    New Modules : 
+    New Modules :
     -   aos-based-node-imaging/node-serials-filter
     -   manual-mode-imaging
 
@@ -559,13 +566,13 @@ All new features are v4 SDKs based.
     -   nutanix_foundation_hypervisor_isos
     -   nutanix_foundation_discover_nodes
     -   nutanix_foundation_node_network_details
-    
+
     New Resources :
     -   nutanix_foundation_image_nodes
     -   nutanix_foundation_ipmi_config
     -   nutanix_foundation_image
 
-    New Modules : 
+    New Modules :
     -   aos-based-node-imaging/node-serials-filter
     -   discover-nodes-network-details/node-serials-filter
     -   manual-mode-imaging

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Terraform provider plugin to integrate with Nutanix Cloud Platform.
 
-NOTE: The latest version of the Nutanix provider is [v2.2.1](https://github.com/nutanix/terraform-provider-nutanix/releases/tag/v2.2.1).
+NOTE: The latest version of the Nutanix provider is [v2.2.2](https://github.com/nutanix/terraform-provider-nutanix/releases/tag/v2.2.2).
 
 Modules based on Terraform Nutanix Provider can be found here : [Modules](https://github.com/nutanix/terraform-provider-nutanix/tree/master/modules)
 
@@ -22,19 +22,24 @@ Modules based on Terraform Nutanix Provider can be found here : [Modules](https:
 * [Go](https://golang.org/doc/install) 1.17+ (to build the provider plugin)
 * This provider uses [SDKv2](https://www.terraform.io/plugin/sdkv2/sdkv2-intro) from release 1.3.0
 
+### Introducing Nutanix Terraform Provider Version 2.2.2
+We're excited to announce the release of Nutanix Terraform Provider Version 2.2.2! This update brings significant enhancements and bug fixes to your infrastructure management experience:
+
+- This is a minor release that includes enhancements and bug fixes, aimed at improving stability and reliability.
+
 ### Introducing Nutanix Terraform Provider Version 2.2.1
 We're excited to announce the release of Nutanix Terraform Provider Version 2.2.1! This update brings significant enhancements and bug fixes to your infrastructure management experience:
- 
+
 - This is a minor release that includes enhancements and bug fixes, aimed at improving stability and reliability.
 
 ### Introducing Nutanix Terraform Provider Version 2.2.0
 We're excited to announce the release of Nutanix Terraform Provider Version 2.2.0! This major update brings significant improvements to your infrastructure management experience:
- 
+
 - It will allow you to interact with Self Service API. With this new plugin support you will be able to launch a Single VM Blueprint to create an Application in Self Service and perform some Day 2 actions like updating application, creating snapshot/restore etc.
 
 ### Introducing Nutanix Terraform Provider Version 2.1.0
 We're excited to announce the release of Nutanix Terraform Provider Version 2.1.0! This major update brings significant improvements to your infrastructure management experience:
- 
+
 - Built on the latest v4 APIs/SDKs: Leveraging the power of Nutanix v4 APIs/SDKs, this version offers enhanced functionality and better integration with the latest Nutanix features.
 - Expanded Resource Coverage:  Discover new resources and data sources, enabling you to model and manage a broader spectrum of Nutanix infrastructure components within your Terraform configurations.
 - <b>Version Suffix: Modules built based on v4 PC/PE GA sdks are marked with the *_v2 suffix.</b>
@@ -44,14 +49,15 @@ The provider is used to interact with the many resources and data sources suppor
 - Self Service version: 4.1.0 (Required only for running Self Service based resource and data source)
 - AOS Version: 7.0.1, 7.0 or later
 - Prism Central Version: pc2024.3, pc2024.3.1 or later
-- Nutanix Terraform Provider Version: 2.2.0
+- Nutanix Terraform Provider Version: 2.2.2
 
 
 ## Compatibility Matrix
 | Terraform Version |  AOS Version | PC version  | Other software versions | Supported |
 |  :--- |  :--- | :--- | :--- | :--- |
+| 2.2.2 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
 | 2.2.1 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
-| 2.2.0 | | | Self Service v4.1.0 | yes | 
+| 2.2.0 | | | Self Service v4.1.0 | yes |
 | 2.1.1 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
 | 2.1.0 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
 | 2.0.0 | 7.0 | pc2024.3 or later  | ndb v2.7, nke v2.8, foundation v5.7 | Yes |
@@ -380,7 +386,7 @@ From foundation getting released in 1.5.0-beta, provider configuration will acco
 
 
 
-## Developing the provider 
+## Developing the provider
 
 The Nutanix Provider for Terraform is the work of many contributors. We appreciate your help!
 
@@ -392,7 +398,7 @@ The Nutanix Provider for Terraform is the work of many contributors. We apprecia
 
 -> **Note:** We now have a brand new developer-centric Support Program designed for organizations that require a deeper level of developer support to manage their Nutanix environment and build applications quickly and efficiently. As part of this new Advanced API/SDK Support Program, you will get access to trusted technical advisors who specialize in developer tools including Nutanix Terraform Provider and receive support for your unique development needs and custom integration queries. Visit our Support Portal - [Premium Add-On Support Programs](https://www.nutanix.com/support-services/product-support/premium-support-programs) to learn more about this program.
 
-Customers not taking advantage of the  Advanced API/SDK Support Program will continue to receive the support through our standard, community-supported model. This community model also provides support for contributions to the open-sourceNutanix Terraform Provider repository .Visit https://portal.nutanix.com/kb/13424   for more details. 
+Customers not taking advantage of the  Advanced API/SDK Support Program will continue to receive the support through our standard, community-supported model. This community model also provides support for contributions to the open-sourceNutanix Terraform Provider repository .Visit https://portal.nutanix.com/kb/13424   for more details.
 
 
 ## Community

--- a/nutanix/services/clustersv2/data_source_nutanix_cluster_entities_v2.go
+++ b/nutanix/services/clustersv2/data_source_nutanix_cluster_entities_v2.go
@@ -141,6 +141,9 @@ func flattenClusterEntities(pr []import1.Cluster) []interface{} {
 			cls["vm_count"] = v.VmCount
 			cls["inefficient_vm_count"] = v.InefficientVmCount
 			cls["container_name"] = v.ContainerName
+			cls["categories"] = v.Categories
+			cls["cluster_profile_ext_id"] = v.ClusterProfileExtId
+			cls["backup_eligibility_score"] = v.BackupEligibilityScore
 
 			clsList[k] = cls
 		}

--- a/nutanix/services/clustersv2/helper_test.go
+++ b/nutanix/services/clustersv2/helper_test.go
@@ -1,0 +1,189 @@
+package clustersv2_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/config"
+	clusterPrism "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/prism/v4/config"
+	prismConfig "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/prism/v4/config"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+const timeout = 3 * time.Minute
+
+func associateCategoryToCluster() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		log.Println("Associating category with cluster")
+		conn := acc.TestAccProvider.Meta().(*conns.Client)
+		client := conn.ClusterAPI.ClusterEntityAPI
+
+		clusterExtID := ""
+		categoryExtID := ""
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "nutanix_cluster_v2" {
+				clusterExtID = rs.Primary.ID
+			}
+			if rs.Type == "nutanix_category_v2" {
+				categoryExtID = rs.Primary.ID
+			}
+		}
+
+		if clusterExtID == "" || categoryExtID == "" {
+			return fmt.Errorf("cluster or category not found in state")
+		}
+
+		log.Printf("[DEBUG] Associating category: %s to cluster: %s", categoryExtID, clusterExtID)
+
+		body := config.NewCategoryEntityReferences()
+
+		body.Categories = append(body.Categories, categoryExtID)
+
+		aJSON, _ := json.MarshalIndent(body, "", "  ")
+		log.Printf("[DEBUG] Category body: %s", aJSON)
+
+		resp, err := client.AssociateCategoriesToCluster(utils.StringPtr(clusterExtID), body)
+		if err != nil {
+			return fmt.Errorf("error associating category to cluster: %v", err)
+		}
+
+		TaskRef := resp.Data.GetValue().(clusterPrism.TaskReference)
+		taskUUID := TaskRef.ExtId
+
+		taskconn := conn.PrismAPI
+		// Wait for the backup target to be deleted
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{"PENDING", "RUNNING", "QUEUED"},
+			Target:  []string{"SUCCEEDED"},
+			Refresh: taskStateRefreshPrismTaskGroupFunc(utils.StringValue(taskUUID)),
+			Timeout: timeout,
+		}
+
+		if _, taskErr := stateConf.WaitForState(); taskErr != nil {
+			return fmt.Errorf("error waiting for category association task to complete: %s", taskErr)
+		}
+
+		_, err = taskconn.TaskRefAPI.GetTaskById(taskUUID, nil)
+		if err != nil {
+			return fmt.Errorf("error while fetching Category Association Task Details: %s", err)
+		}
+
+		return nil
+	}
+}
+
+func disassociateCategoryFromCluster() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		log.Println("Disassociating category from cluster")
+		conn := acc.TestAccProvider.Meta().(*conns.Client)
+		client := conn.ClusterAPI.ClusterEntityAPI
+
+		clusterExtID := ""
+		categoryExtID := ""
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "nutanix_cluster_v2" {
+				clusterExtID = rs.Primary.ID
+			}
+			if rs.Type == "nutanix_category_v2" {
+				categoryExtID = rs.Primary.ID
+			}
+		}
+
+		if clusterExtID == "" || categoryExtID == "" {
+			return fmt.Errorf("cluster or category not found in state")
+		}
+
+		log.Printf("[DEBUG] Disassociating category: %s from cluster: %s", categoryExtID, clusterExtID)
+
+		body := config.NewCategoryEntityReferences()
+
+		body.Categories = append(body.Categories, categoryExtID)
+
+		aJSON, _ := json.MarshalIndent(body, "", "  ")
+		log.Printf("[DEBUG] Category body: %s", aJSON)
+
+		resp, err := client.DisassociateCategoriesFromCluster(utils.StringPtr(clusterExtID), body)
+		if err != nil {
+			return fmt.Errorf("error disassociating category from cluster: %v", err)
+		}
+
+		TaskRef := resp.Data.GetValue().(clusterPrism.TaskReference)
+		taskUUID := TaskRef.ExtId
+
+		taskconn := conn.PrismAPI
+		// Wait for the backup target to be deleted
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{"PENDING", "RUNNING", "QUEUED"},
+			Target:  []string{"SUCCEEDED"},
+			Refresh: taskStateRefreshPrismTaskGroupFunc(utils.StringValue(taskUUID)),
+			Timeout: timeout,
+		}
+
+		if _, taskErr := stateConf.WaitForState(); taskErr != nil {
+			return fmt.Errorf("error waiting for category disassociation task to complete: %s", taskErr)
+		}
+
+		_, err = taskconn.TaskRefAPI.GetTaskById(taskUUID, nil)
+		if err != nil {
+			return fmt.Errorf("error while fetching Category Disassociation Task Details: %s", err)
+		}
+
+		return nil
+	}
+}
+
+// helper function to check the delete task
+func taskStateRefreshPrismTaskGroupFunc(taskUUID string) resource.StateRefreshFunc {
+	conn := acc.TestAccProvider.Meta().(*conns.Client)
+
+	return func() (interface{}, string, error) {
+		// data := base64.StdEncoding.EncodeToString([]byte("ergon"))
+		// encodeUUID := data + ":" + taskUUID
+		vresp, err := conn.PrismAPI.TaskRefAPI.GetTaskById(utils.StringPtr(taskUUID), nil)
+
+		if err != nil {
+			return "", "", (fmt.Errorf("error while polling prism task: %v", err))
+		}
+
+		// get the group results
+
+		v := vresp.Data.GetValue().(prismConfig.Task)
+
+		if getTaskStatus(v.Status) == "CANCELED" || getTaskStatus(v.Status) == "FAILED" {
+			return v, getTaskStatus(v.Status),
+				fmt.Errorf("error_detail: %s, progress_message: %d", utils.StringValue(v.ErrorMessages[0].Message), utils.IntValue(v.ProgressPercentage))
+		}
+		return v, getTaskStatus(v.Status), nil
+	}
+}
+
+// helper function to flatten the task status to string
+func getTaskStatus(pr *prismConfig.TaskStatus) string {
+	if pr != nil {
+		const QUEUED, RUNNING, SUCCEEDED, FAILED, CANCELED = 2, 3, 5, 6, 7
+		if *pr == prismConfig.TaskStatus(FAILED) {
+			return "FAILED"
+		}
+		if *pr == prismConfig.TaskStatus(CANCELED) {
+			return "CANCELED"
+		}
+		if *pr == prismConfig.TaskStatus(QUEUED) {
+			return "QUEUED"
+		}
+		if *pr == prismConfig.TaskStatus(RUNNING) {
+			return "RUNNING"
+		}
+		if *pr == prismConfig.TaskStatus(SUCCEEDED) {
+			return "SUCCEEDED"
+		}
+	}
+	return "UNKNOWN"
+}

--- a/nutanix/services/clustersv2/resource_nutanix_cluster_entity_v2.go
+++ b/nutanix/services/clustersv2/resource_nutanix_cluster_entity_v2.go
@@ -18,6 +18,7 @@ import (
 	import1 "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/prism/v4/config"
 	import2 "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/prism/v4/config"
 	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/common"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/clusters"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/prism"
 	"github.com/terraform-providers/terraform-provider-nutanix/utils"
@@ -34,6 +35,9 @@ func ResourceNutanixClusterV2() *schema.Resource {
 		ReadContext:   ResourceNutanixClusterV2Read,
 		UpdateContext: ResourceNutanixClusterV2Update,
 		DeleteContext: ResourceNutanixClusterV2Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 		Schema: map[string]*schema.Schema{
 			"ext_id": {
 				Type:     schema.TypeString,
@@ -778,10 +782,7 @@ func ResourceNutanixClusterV2Create(ctx context.Context, d *schema.ResourceData,
 
 	if categories, ok := d.GetOk("categories"); ok {
 		categoriesList := categories.([]interface{})
-		categoriesListStr := make([]string, len(categoriesList))
-		for i, v := range categoriesList {
-			categoriesListStr[i] = v.(string)
-		}
+		categoriesListStr := common.ExpandListOfString(categoriesList)
 		log.Printf("[DEBUG] categories List : %v", categoriesListStr)
 		body.Categories = categoriesListStr
 	}

--- a/nutanix/services/clustersv2/resource_nutanix_cluster_entity_v2_test.go
+++ b/nutanix/services/clustersv2/resource_nutanix_cluster_entity_v2_test.go
@@ -54,7 +54,7 @@ func TestAccV2NutanixClusterResource_CreateClusterWithAllConfig(t *testing.T) {
 	if testVars.Clusters.Nodes[0].CvmIP == "" {
 		t.Skip("Skipping test as No available node to be used for testing")
 	}
-	r := acctest.RandInt()
+	r := acctest.RandIntRange(1, 10000)
 	name := fmt.Sprintf("tf-test-cluster-%d", r)
 
 	resource.Test(t, resource.TestCase{
@@ -95,6 +95,8 @@ func TestAccV2NutanixClusterResource_CreateClusterWithAllConfig(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceNameClusterRegistration, "pc_ext_id"),
 					resource.TestCheckResourceAttr(resourceNameClusterRegistration, "remote_cluster.0.aos_remote_cluster_spec.0.remote_cluster.0.address.0.ipv4.0.value", testVars.Clusters.Nodes[0].CvmIP),
 					resource.TestCheckResourceAttr(resourceNameClusterRegistration, "remote_cluster.0.aos_remote_cluster_spec.0.remote_cluster.0.credentials.0.authentication.0.username", testVars.Clusters.Nodes[0].Username),
+
+					associateCategoryToCluster(),
 				),
 			},
 			{
@@ -122,6 +124,11 @@ func TestAccV2NutanixClusterResource_CreateClusterWithAllConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameCluster, "network.0.smtp_server.0.server.0.port", strconv.Itoa(testVars.Clusters.Network.SMTPServer.Port)),
 					resource.TestCheckResourceAttr(resourceNameCluster, "network.0.smtp_server.0.server.0.username", testVars.Clusters.Network.SMTPServer.Username),
 					resource.TestCheckResourceAttr(resourceNameCluster, "network.0.smtp_server.0.type", testVars.Clusters.Network.SMTPServer.Type),
+
+					// check on list cluster data source for categories
+					resource.TestCheckResourceAttr(dataSourceNameClusters, "cluster_entities.0.categories.#", "1"),
+					resource.TestCheckResourceAttrPair(dataSourceNameClusters, "cluster_entities.0.categories.0", "nutanix_category_v2.test", "id"),
+					disassociateCategoryFromCluster(),
 				),
 			},
 			// Disable the cluster pulse status
@@ -277,87 +284,104 @@ func testAccClusterResourceAllConfig(name string) string {
 		}
 
 
+		# create a new category
+		resource "nutanix_category_v2" "test" {
+			key         = "%[2]s-key"
+			value       = "%[2]s-value"
+			description = "test-cat-cluster-description"
+			provisioner "local-exec" {
+				command = "sleep 120"
+				when = destroy
+				on_failure = continue
+			}
+		  lifecycle {
+			ignore_changes = [key,  value]
+		  }
+		}
+
 		resource "nutanix_cluster_v2" "test" {
 		  name   = "%[2]s"
 		  dryrun = false
 		  nodes {
-			node_list {
-			  controller_vm_ip {
-				ipv4 {
-				  value = local.clusters.nodes[0].cvm_ip
+				node_list {
+					controller_vm_ip {
+						ipv4 {
+							value = local.clusters.nodes[0].cvm_ip
+						}
+					}
 				}
-			  }
-			}
 		  }
 		  config {
-			cluster_function = local.clusters.config.cluster_functions
-			cluster_arch     = local.clusters.config.cluster_arch
-			fault_tolerance_state {
-			  domain_awareness_level          = local.clusters.config.fault_tolerance_state.domain_awareness_level
-			}
+				cluster_function = local.clusters.config.cluster_functions
+				cluster_arch     = local.clusters.config.cluster_arch
+				fault_tolerance_state {
+					domain_awareness_level          = local.clusters.config.fault_tolerance_state.domain_awareness_level
+				}
 		  }
 		  network {
-			external_address {
-			  ipv4 {
-				value = local.clusters.network.virtual_ip
-			  }
-			}
-			ntp_server_ip_list {
-			  fqdn {
-				value = local.clusters.network.ntp_servers[0]
-			  }
-			}
-			ntp_server_ip_list {
-			  fqdn {
-				value = local.clusters.network.ntp_servers[1]
-			  }
-			}
-			ntp_server_ip_list {
-			  fqdn {
-				value = local.clusters.network.ntp_servers[2]
-			  }
-			}
-			ntp_server_ip_list {
-			  fqdn {
-				value = local.clusters.network.ntp_servers[3]
-			  }
-			}
+				external_address {
+					ipv4 {
+						value = local.clusters.network.virtual_ip
+					}
+				}
+				ntp_server_ip_list {
+					fqdn {
+						value = local.clusters.network.ntp_servers[0]
+					}
+				}
+				ntp_server_ip_list {
+					fqdn {
+						value = local.clusters.network.ntp_servers[1]
+					}
+				}
+				ntp_server_ip_list {
+					fqdn {
+						value = local.clusters.network.ntp_servers[2]
+					}
+				}
+				ntp_server_ip_list {
+					fqdn {
+						value = local.clusters.network.ntp_servers[3]
+					}
+				}
 		  }
 
+
 		  lifecycle {
-			ignore_changes = [network.0.smtp_server.0.server.0.password,  links, categories, config.0.cluster_function]
+				ignore_changes = [network.0.smtp_server.0.server.0.password,  links, categories, config.0.cluster_function]
 		  }
 
 		  provisioner "local-exec" {
-			command = "ssh-keygen -f '~/.ssh/known_hosts' -R '${local.clusters.nodes[0].cvm_ip}'; sshpass -p '${local.clusters.pe_password}' ssh -o StrictHostKeyChecking=no ${local.clusters.pe_username}@${local.clusters.nodes[0].cvm_ip} '/home/nutanix/prism/cli/ncli user reset-password user-name=${local.clusters.nodes[0].username} password=${local.clusters.nodes[0].password}' "
+				command = "ssh-keygen -f '~/.ssh/known_hosts' -R '${local.clusters.nodes[0].cvm_ip}'; sshpass -p '${local.clusters.pe_password}' ssh -o StrictHostKeyChecking=no ${local.clusters.pe_username}@${local.clusters.nodes[0].cvm_ip} '/home/nutanix/prism/cli/ncli user reset-password user-name=${local.clusters.nodes[0].username} password=${local.clusters.nodes[0].password}' "
 
-			on_failure = continue
+				on_failure = continue
 		  }
-		  depends_on = [nutanix_clusters_discover_unconfigured_nodes_v2.test-discover-cluster-node]
+		  depends_on = [nutanix_clusters_discover_unconfigured_nodes_v2.test-discover-cluster-node, nutanix_category_v2.test]
 		}
 
 		# register the cluster to pc
 		resource "nutanix_pc_registration_v2" "node-registration" {
 		  pc_ext_id = local.cluster_ext_id
 		  remote_cluster {
-			aos_remote_cluster_spec {
-			  remote_cluster {
-				address {
-				  ipv4 {
-					value = local.clusters.nodes[0].cvm_ip
-				  }
+				aos_remote_cluster_spec {
+					remote_cluster {
+						address {
+							ipv4 {
+								value = local.clusters.nodes[0].cvm_ip
+							}
+						}
+						credentials {
+							authentication {
+								username = local.clusters.nodes[0].username
+								password = local.clusters.nodes[0].password
+							}
+						}
+					}
 				}
-				credentials {
-				  authentication {
-					username = local.clusters.nodes[0].username
-					password = local.clusters.nodes[0].password
-				  }
-				}
-			  }
-			}
 		  }
 		  depends_on = [nutanix_cluster_v2.test]
 		}
+
 	`, clusterConfig, name)
 }
 
@@ -386,6 +410,20 @@ func testAccClusterResourceUpdateConfig(updatedName, pulseStatus string) string 
 		  }
 		}
 
+		# create a new category
+		resource "nutanix_category_v2" "test" {
+			key         = "%[2]s-key"
+			value       = "%[2]s-value"
+			description = "test-cat-cluster-description"
+			provisioner "local-exec" {
+				command = "sleep 120"
+				when = destroy
+				on_failure = continue
+			}
+		  lifecycle {
+			ignore_changes = [key,  value]
+		  }
+		}
 
 		resource "nutanix_cluster_v2" "test" {
 		  name   = "%[2]s"
@@ -463,11 +501,10 @@ func testAccClusterResourceUpdateConfig(updatedName, pulseStatus string) string 
 		  }
 
 		  provisioner "local-exec" {
-
 			command = "ssh-keygen -f '~/.ssh/known_hosts' -R '${local.clusters.nodes[0].cvm_ip}';  sshpass -p '${local.clusters.pe_password}' ssh -o StrictHostKeyChecking=no ${local.clusters.pe_username}@${local.clusters.nodes[0].cvm_ip} '/home/nutanix/prism/cli/ncli user reset-password user-name=${local.clusters.nodes[0].username} password=${local.clusters.nodes[0].password}' "
 			on_failure = continue
 		  }
-		  depends_on = [nutanix_clusters_discover_unconfigured_nodes_v2.test-discover-cluster-node]
+		  depends_on = [nutanix_clusters_discover_unconfigured_nodes_v2.test-discover-cluster-node, nutanix_category_v2.test]
 		}
 
 		# register the cluster to pc
@@ -493,5 +530,10 @@ func testAccClusterResourceUpdateConfig(updatedName, pulseStatus string) string 
 		  depends_on = [nutanix_cluster_v2.test]
 		}
 
+		# List all cluster to tests categories
+		data "nutanix_clusters_v2" "test" {
+			filter = "name eq '${nutanix_cluster_v2.test.name}'"
+			depends_on = [nutanix_pc_registration_v2.node-registration]
+		}
 `, clusterConfig, updatedName, pulseStatus)
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -319,7 +319,7 @@ terraform {
   required_providers {
     nutanix = {
       source = "nutanix/nutanix"
-      version = "2.0.0"
+      version = "2.2.2"
     }
   }
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -12,19 +12,25 @@ The provider is used to interact with the many resources and data sources suppor
 
 Use the navigation on the left to read about the available resources and data sources this provider can use.
 
+### Introducing Nutanix Terraform Provider Version 2.2.2
+We're excited to announce the release of Nutanix Terraform Provider Version 2.2.2! This update brings significant enhancements and bug fixes to your infrastructure management experience:
+
+- This is a minor release that includes enhancements and bug fixes, aimed at improving stability and reliability.
+
+
 ### Introducing Nutanix Terraform Provider Version 2.2.1
 We're excited to announce the release of Nutanix Terraform Provider Version 2.2.1! This update brings significant enhancements and bug fixes to your infrastructure management experience:
- 
+
 - This is a minor release that includes enhancements and bug fixes, aimed at improving stability and reliability.
 
 ### Introducing Nutanix Terraform Provider Version 2.2.0
 We're excited to announce the release of Nutanix Terraform Provider Version 2.2.0! This major update brings significant improvements to your infrastructure management experience:
- 
+
 - It will allow you to interact with Self Service API. With this new plugin support you will be able to launch a Single VM Blueprint to create an Application in Self Service and perform some Day 2 actions like updating application, creating snapshot/restore etc.
 
 ### Introducing Nutanix Terraform Provider Version 2.1.0
 We're excited to announce the release of Nutanix Terraform Provider Version 2.1.0! This major update brings significant improvements to your infrastructure management experience:
- 
+
 - Built on the latest v4 APIs/SDKs: Leveraging the power of Nutanix v4 APIs/SDKs, this version offers enhanced functionality and better integration with the latest Nutanix features.
 - Expanded Resource Coverage:  Discover new resources and data sources, enabling you to model and manage a broader spectrum of Nutanix infrastructure components within your Terraform configurations.
 - <b>Version Suffix: Modules built based on v4 PC/PE GA sdks are marked with the *_v2 suffix.</b>
@@ -35,13 +41,14 @@ We're excited to announce the release of Nutanix Terraform Provider Version 2.1.
 
 -> **Note:** We now have a brand new developer-centric Support Program designed for organizations that require a deeper level of developer support to manage their Nutanix environment and build applications quickly and efficiently. As part of this new Advanced API/SDK Support Program, you will get access to trusted technical advisors who specialize in developer tools including Nutanix Terraform Provider and receive support for your unique development needs and custom integration queries. Visit our Support Portal - [Premium Add-On Support Programs](https://www.nutanix.com/support-services/product-support/premium-support-programs) to learn more about this program.
 
-Customers not taking advantage of the  Advanced API/SDK Support Program will continue to receive the support through our standard, community-supported model. This community model also provides support for contributions to the open-sourceNutanix Terraform Provider repository .Visit https://portal.nutanix.com/kb/13424   for more details. 
+Customers not taking advantage of the  Advanced API/SDK Support Program will continue to receive the support through our standard, community-supported model. This community model also provides support for contributions to the open-sourceNutanix Terraform Provider repository .Visit https://portal.nutanix.com/kb/13424   for more details.
 
 ## Compatibility Matrix
 | Terraform Version |  AOS Version | PC version  | Other software versions | Supported |
 |  :--- |  :--- | :--- | :--- | :--- |
+| 2.2.2 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
 | 2.2.1 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
-| 2.2.0 | | | Self Service  v4.1.0 | yes | 
+| 2.2.0 | | | Self Service  v4.1.0 | yes |
 | 2.1.1 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
 | 2.1.0 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
 | 2.0.0   |  7.0  | pc2024.3 or later  | ndb v2.7, nke v2.8, foundation v5.7 | Yes |
@@ -417,7 +424,7 @@ provider "nutanix" {
   port                = var.nutanix_port
   insecure            = true
   wait_timeout        = 10
-  ndb_endpoint        = var.ndb_endpoint 
+  ndb_endpoint        = var.ndb_endpoint
   ndb_username        = var.ndb_username
   ndb_password        = var.ndb_password
 }
@@ -427,9 +434,9 @@ NDB based examples : https://github.com/nutanix/terraform-provider-nutanix/blob/
 
 ## Provider configuration required details
 
-Going from 1.8.0-beta release of nutanix provider, fields inside provider configuration would be mandatory as per the usecase : 
+Going from 1.8.0-beta release of nutanix provider, fields inside provider configuration would be mandatory as per the usecase :
 
 * `Prism Central & Karbon` : For prism central and karbon related resources and data sources, `username`, `password` & `endpoint` are manadatory.
 * `Foundation` : For foundation related resources and data sources, `foundation_endpoint` in manadatory.
-* `NDB` : For Nutanix Database Service (NDB) related resources and data sources. 
+* `NDB` : For Nutanix Database Service (NDB) related resources and data sources.
 

--- a/website/docs/r/cluster_v2.html.markdown
+++ b/website/docs/r/cluster_v2.html.markdown
@@ -360,4 +360,14 @@ The ipv6 attribute supports the following:
 * `prefix_length`: - (Optional) The prefix length of the network to which this host IPv4 address belongs.
 * `value`: - (Required) Ip address.
 
+## Import
+
+This helps to manage existing entities which are not created through terraform. Users can be imported using the `UUID`.  eg,
+```hcl
+// create its configuration in the root module. For example:
+resource "nutanix_cluster_v2" "import_cluster" {}
+// execute this cli command
+terraform import nutanix_cluster_v2.import_cluster <UUID>
+```
+
 See detailed information in [Nutanix Create Cluster V4](https://developers.nutanix.com/api-reference?namespace=clustermgmt&version=v4.0#tag/Clusters/operation/createCluster).


### PR DESCRIPTION
# fix(clusters): backport fix for issue #907 — return associated categories in `nutanix_clusters_v2` (release/2.2.2)

## What this PR does
Backports a bugfix to the `release/2.2.2` branch that ensures `nutanix_clusters_v2` returns associated categories. The categories field was missing from the initial V4 implementation, so clusters returned no category metadata,  this change adds the missing behavior.

## Why this is needed
The initial implementation of cluster listing data source did not include category , so users could not read cluster categories via data source `nutanix_clusters_v2`. Many consumers and automation workflows depend on those categories. Adding this fix restores expected functionality for users on the 2.2.x line who rely on V4.0 SDK.


## How it was tested
- Verified that `nutanix_clusters_v2` now returns associated categories for a cluster after assigning categories to it in a test Nutanix environment.

## References
- Original fix branch : [bug/issue-907](https://github.com/nutanix/terraform-provider-nutanix/tree/bug/issue-907).  
- Issue: #907

