### PR TITLE
Add support for Cisco Intersight managed nodes onboarding and imaging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/hcl/v2 v2.8.2 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
+	github.com/jinzhu/copier v0.4.0
 	github.com/mitchellh/gox v1.0.1
 	github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4 v4.1.1
 	github.com/nutanix/ntnx-api-golang-clients/datapolicies-go-client/v4 v4.1.1

--- a/go.sum
+++ b/go.sum
@@ -359,6 +359,8 @@ github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZ
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a h1:GmsqmapfzSJkm28dhRoHz2tLRbJmqhU86IPgBtN3mmk=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a/go.mod h1:xRskid8CManxVta/ALEhJha/pweKBaVG6fWgc0yH25s=
+github.com/jinzhu/copier v0.4.0 h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8=
+github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jirfag/go-printf-func-name v0.0.0-20191110105641-45db9963cdd3 h1:jNYPNLe3d8smommaoQlK7LOA5ESyUJJ+Wf79ZtA7Vp4=
 github.com/jirfag/go-printf-func-name v0.0.0-20191110105641-45db9963cdd3/go.mod h1:HEWGJkRDzjJY2sqdDwxccsGicWEf9BQOZsq2tV+xzM0=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -342,6 +342,7 @@ func Provider() *schema.Provider {
 			"nutanix_foundation_image":                        foundation.ResourceNutanixFoundationImage(),
 			"nutanix_foundation_central_image_cluster":        foundationCentral.ResourceNutanixFCImageCluster(),
 			"nutanix_foundation_central_api_keys":             foundationCentral.ResourceNutanixFCAPIKeys(),
+			"nutanix_foundation_central_onboard_nodes":        foundationCentral.ResourceNutanixFCOnboardNodes(),
 			"nutanix_vpc":                                     networking.ResourceNutanixVPC(),
 			"nutanix_pbr":                                     networking.ResourceNutanixPbr(),
 			"nutanix_floating_ip":                             networking.ResourceNutanixFloatingIP(),

--- a/nutanix/sdks/v3/fc/fc_service.go
+++ b/nutanix/sdks/v3/fc/fc_service.go
@@ -25,6 +25,10 @@ type Service interface {
 	CreateAPIKey(context.Context, *CreateAPIKeysInput) (*CreateAPIKeysResponse, error)
 	GetAPIKey(context.Context, string) (*CreateAPIKeysResponse, error)
 	ListAPIKeys(context.Context, *ListMetadataInput) (*ListAPIKeysResponse, error)
+	ListHardwareManagers(context.Context) (*ListHardwareManagersResponse, error)
+	ListHardwareManagerNodes(context.Context, string) (*ListHardwareManagerNodesResponse, error)
+	CreateOnboardNode(context.Context, *CreateOnboardNodeInput) (*CreateOnboardNodeResponse, error)
+	DeleteOnboardNode(context.Context, string) error
 }
 
 /*GetImagedNode Get the details of an imaged node
@@ -211,4 +215,51 @@ func (op Operations) ListAPIKeys(ctx context.Context, body *ListMetadataInput) (
 
 	listAPIKeysResponse := new(ListAPIKeysResponse)
 	return listAPIKeysResponse, op.client.Do(ctx, req, listAPIKeysResponse)
+}
+
+func (op Operations) ListHardwareManagers(ctx context.Context) (*ListHardwareManagersResponse, error) {
+	path := "/hardware_managers/list"
+
+	req, err := op.client.NewRequest(ctx, http.MethodPost, path, &map[string]interface{}{})
+	if err != nil {
+		return nil, err
+	}
+
+	listHardwareManagersResponse := new(ListHardwareManagersResponse)
+	return listHardwareManagersResponse, op.client.Do(ctx, req, listHardwareManagersResponse)
+}
+
+func (op Operations) ListHardwareManagerNodes(ctx context.Context, hardwareManagerUUID string) (*ListHardwareManagerNodesResponse, error) {
+	path := fmt.Sprintf("/hardware_managers/%s/nodes/list", hardwareManagerUUID)
+
+	req, err := op.client.NewRequest(ctx, http.MethodPost, path, &map[string]interface{}{})
+	if err != nil {
+		return nil, err
+	}
+
+	listHardwareManagersResponse := new(ListHardwareManagerNodesResponse)
+	return listHardwareManagersResponse, op.client.Do(ctx, req, listHardwareManagersResponse)
+}
+
+func (op Operations) CreateOnboardNode(ctx context.Context, input *CreateOnboardNodeInput) (*CreateOnboardNodeResponse, error) {
+	path := "/imaged_nodes/onboard"
+
+	req, err := op.client.NewRequest(ctx, http.MethodPost, path, input)
+	if err != nil {
+		return nil, err
+	}
+
+	createAPIResponse := new(CreateOnboardNodeResponse)
+	return createAPIResponse, op.client.Do(ctx, req, createAPIResponse)
+}
+
+func (op Operations) DeleteOnboardNode(ctx context.Context, nodeUUID string) error {
+	path := fmt.Sprintf("/imaged_nodes/%s", nodeUUID)
+
+	req, err := op.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+
+	return op.client.Do(ctx, req, nil)
 }

--- a/nutanix/sdks/v3/fc/fc_structs.go
+++ b/nutanix/sdks/v3/fc/fc_structs.go
@@ -213,6 +213,7 @@ type Node struct {
 	IpmiIP                     *string                `json:"ipmi_ip,omitempty"`
 	HypervisorGateway          *string                `json:"hypervisor_gateway,omitempty"`
 	HardwareAttributesOverride map[string]interface{} `json:"hardware_attributes_override,omitempty"`
+	ServerConfigurationData    map[string]interface{} `json:"server_configuration_data,omitempty"`
 	CvmRAMGb                   *int                   `json:"cvm_ram_gb,omitempty"`
 	CvmIP                      *string                `json:"cvm_ip,omitempty"`
 	HypervisorIP               *string                `json:"hypervisor_ip,omitempty"`
@@ -222,19 +223,21 @@ type Node struct {
 
 // Input to Create a cluster
 type CreateClusterInput struct {
-	ClusterExternalIP     *string                 `json:"cluster_external_ip,omitempty"`
-	CommonNetworkSettings *CommonNetworkSettings  `json:"common_network_settings,omitempty"`
-	HypervisorIsoDetails  *HypervisorIsoDetails   `json:"hypervisor_iso_details,omitempty"`
-	HypervisorIsos        *[]HypervisorIsoDetails `json:"hypervisor_isos,omitempty"`
-	StorageNodeCount      *int                    `json:"storage_node_count,omitempty"`
-	RedundancyFactor      *int                    `json:"redundancy_factor,omitempty"`
-	ClusterName           *string                 `json:"cluster_name,omitempty"`
-	AosPackageURL         *string                 `json:"aos_package_url,omitempty"`
-	ClusterSize           *int                    `json:"cluster_size,omitempty"`
-	AosPackageSha256sum   *string                 `json:"aos_package_sha256sum,omitempty"`
-	Timezone              *string                 `json:"timezone,omitempty"`
-	NodesList             []*Node                 `json:"nodes_list,omitempty"`
-	SkipClusterCreation   bool                    `json:"skip_cluster_creation,omitempty"`
+	ClusterExternalIP       *string                 `json:"cluster_external_ip,omitempty"`
+	CommonNetworkSettings   *CommonNetworkSettings  `json:"common_network_settings,omitempty"`
+	HypervisorIsoDetails    *HypervisorIsoDetails   `json:"hypervisor_iso_details,omitempty"`
+	HypervisorIsos          *[]HypervisorIsoDetails `json:"hypervisor_isos,omitempty"`
+	StorageNodeCount        *int                    `json:"storage_node_count,omitempty"`
+	RedundancyFactor        *int                    `json:"redundancy_factor,omitempty"`
+	ClusterName             *string                 `json:"cluster_name,omitempty"`
+	AosPackageURL           *string                 `json:"aos_package_url,omitempty"`
+	ClusterSize             *int                    `json:"cluster_size,omitempty"`
+	AosPackageSha256sum     *string                 `json:"aos_package_sha256sum,omitempty"`
+	Timezone                *string                 `json:"timezone,omitempty"`
+	NodesList               []*Node                 `json:"nodes_list,omitempty"`
+	SkipClusterCreation     bool                    `json:"skip_cluster_creation,omitempty"`
+	ServerConfigurationData map[string]interface{}  `json:"server_configuration_data,omitempty"`
+	FcMetadata              *FcMetadata             `json:"fc_metadata,omitempty"`
 }
 
 // Response of cluster creation
@@ -336,4 +339,52 @@ type Clusters struct {
 // input of Imaged node details
 type ImagedNodeDetailsInput struct {
 	ImagedNodeUUID string `json:"imaged_node_uuid"`
+}
+
+type FcMetadata struct {
+	APIKeyUUID *string `json:"api_key_uuid,omitempty"`
+}
+
+type CreateOnboardNodeInput struct {
+	HardwareManagerNodeResponse
+	EntityID   *string `json:"entity_id,omitempty"`
+	EntityType *string `json:"entity_type,omitempty"`
+}
+
+type CreateOnboardNodeResponse struct {
+	ImagedNodeDetails
+	EntityID   *string `json:"entityId,omitempty"`
+	EntityType *string `json:"entity_type,omitempty"`
+}
+
+type ListHardwareManagersResponse struct {
+	Metadata         *ListMetadataOutput
+	HardwareManagers []*HardwareManager `json:"hardware_managers,omitempty"`
+}
+
+type HardwareManager struct {
+	DeploymentType      *string                `json:"deployment_type,omitempty"`
+	HardwareManagerUUID *string                `json:"hardware_manager_uuid,omitempty"`
+	Name                *string                `json:"name,omitempty"`
+	ObjectVersion       *int                   `json:"object_version,omitempty"`
+	Region              *string                `json:"region,omitempty"`
+	Type                *string                `json:"type,omitempty"`
+	ConnectionDetails   map[string]interface{} `json:"connection_details,omitempty"`
+}
+
+type ListHardwareManagerNodesResponse struct {
+	Metadata *ListMetadataOutput
+	Nodes    []*HardwareManagerNodeResponse `json:"nodes,omitempty"`
+}
+
+type HardwareManagerNodeResponse struct {
+	BlockSerial         *string                `json:"block_serial,omitempty"`
+	CPUCoreCount        *int                   `json:"cpu_core_count,omitempty"`
+	CPUVendor           *string                `json:"cpu_vendor,omitempty"`
+	HardwareManagerData map[string]interface{} `json:"hardware_manager_data,omitempty"`
+	HardwareManagerType *string                `json:"hardware_manager_type,omitempty"`
+	HardwareManagerUUID *string                `json:"hardware_manager_uuid,omitempty"`
+	MemoryGb            *int                   `json:"memory_gb,omitempty"`
+	Model               *string                `json:"model,omitempty"`
+	NodeSerial          *string                `json:"node_serial,omitempty"`
 }

--- a/nutanix/services/foundationCentral/main_test.go
+++ b/nutanix/services/foundationCentral/main_test.go
@@ -52,6 +52,9 @@ type FoundationVars struct {
 			HypervisorNtpServers []string `json:"hypervisor_ntp_servers"`
 		} `json:"common_network_settings"`
 	} `json:"blocks"`
+	OnboardNodes []struct {
+		NodeSerial string `json:"node_serial"`
+	} `json:"onboard_nodes"`
 }
 
 var foundationVars FoundationVars

--- a/nutanix/services/foundationCentral/resource_nutanix_foundation_central_image_nodes.go
+++ b/nutanix/services/foundationCentral/resource_nutanix_foundation_central_image_nodes.go
@@ -816,7 +816,7 @@ func expandNodesList(d *schema.ResourceData) []*fc.Node {
 				// Convert json string to map[string]interface{}
 				var mapData map[string]interface{}
 				if err := json.Unmarshal([]byte(serverConfigurationData), &mapData); err != nil {
-					fmt.Println(err)
+					log.Printf("Error unmarshalling server_configuration_data: %v", err)
 				}
 				node.ServerConfigurationData = mapData
 			}
@@ -903,7 +903,7 @@ func resourceNutanixFCImageClusterCreate(ctx context.Context, d *schema.Resource
 			// Convert json string to map[string]interface{}
 			var mapData map[string]interface{}
 			if err := json.Unmarshal([]byte(serverConfigurationData), &mapData); err != nil {
-				fmt.Println(err)
+				log.Printf("Error unmarshalling server_configuration_data: %v", err)
 			}
 			req.ServerConfigurationData = mapData
 		}

--- a/nutanix/services/foundationCentral/resource_nutanix_foundation_central_image_nodes.go
+++ b/nutanix/services/foundationCentral/resource_nutanix_foundation_central_image_nodes.go
@@ -265,6 +265,10 @@ func ResourceNutanixFCImageCluster() *schema.Resource {
 							Optional: true,
 							Default:  false,
 						},
+						"server_configuration_data": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -498,6 +502,14 @@ func ResourceNutanixFCImageCluster() *schema.Resource {
 						},
 					},
 				},
+			},
+			"fc_api_key_uuid": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"server_configuration_data": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"cluster_status": {
 				Type:     schema.TypeList,
@@ -798,6 +810,17 @@ func expandNodesList(d *schema.ResourceData) []*fc.Node {
 			}
 			node.HardwareAttributesOverride = mapData
 		}
+
+		if serverConfigurationData, ok := nodeSettings["server_configuration_data"]; ok {
+			if serverConfigurationData, ok := serverConfigurationData.(string); ok {
+				// Convert json string to map[string]interface{}
+				var mapData map[string]interface{}
+				if err := json.Unmarshal([]byte(serverConfigurationData), &mapData); err != nil {
+					fmt.Println(err)
+				}
+				node.ServerConfigurationData = mapData
+			}
+		}
 		nodeList = append(nodeList, &node)
 	}
 
@@ -875,6 +898,23 @@ func resourceNutanixFCImageClusterCreate(ctx context.Context, d *schema.Resource
 		}
 	}
 
+	if serverConfigurationData, ok := d.GetOk("server_configuration_data"); ok {
+		if serverConfigurationData, ok := serverConfigurationData.(string); ok {
+			// Convert json string to map[string]interface{}
+			var mapData map[string]interface{}
+			if err := json.Unmarshal([]byte(serverConfigurationData), &mapData); err != nil {
+				fmt.Println(err)
+			}
+			req.ServerConfigurationData = mapData
+		}
+	}
+
+	if fcAPIKeyUUID, ok := d.GetOk("fc_api_key_uuid"); ok {
+		req.FcMetadata = &fc.FcMetadata{
+			APIKeyUUID: utils.StringPtr(fcAPIKeyUUID.(string)),
+		}
+	}
+
 	req.CommonNetworkSettings = expandCommonNetworkSettings(d)
 	req.NodesList = expandNodesList(d)
 
@@ -882,7 +922,7 @@ func resourceNutanixFCImageClusterCreate(ctx context.Context, d *schema.Resource
 	for _, vv := range req.NodesList {
 		stateConfig := &resource.StateChangeConf{
 			Pending: []string{"STATE_DISCOVERING", "STATE_UNAVAILABLE"},
-			Target:  []string{"STATE_AVAILABLE", "STATE_IMAGING"},
+			Target:  []string{"STATE_AVAILABLE", "STATE_IMAGING", "STATE_ONBOARDED"},
 			Refresh: foundationCentralPollingNode(ctx, conn, *vv.ImagedNodeUUID),
 			Timeout: NodePollTimeout,
 			Delay:   DelayTimeNodeAvailability,
@@ -892,7 +932,7 @@ func resourceNutanixFCImageClusterCreate(ctx context.Context, d *schema.Resource
 			return diag.Errorf("error waiting for node (%s) to be available: %v", *vv.CvmIP, err)
 		}
 		if progress, ok := infos.(*fc.ImagedNodeDetails); ok {
-			if !(*progress.Available) {
+			if !(*progress.Available) && *progress.NodeState != "STATE_ONBOARDED" {
 				return diag.Errorf("Current Node Available Status: (%s). Node is not available to image or already be a part of cluster", *progress.NodeState)
 			}
 		}

--- a/nutanix/services/foundationCentral/resource_nutanix_foundation_central_onboard_nodes.go
+++ b/nutanix/services/foundationCentral/resource_nutanix_foundation_central_onboard_nodes.go
@@ -105,7 +105,7 @@ func resourceNutanixFCOnboardNodesCreate(ctx context.Context, d *schema.Resource
 		for _, node := range hwManagerNodes.Nodes {
 			if *node.NodeSerial == serial {
 				var req fc.CreateOnboardNodeInput
-				err := copier.Copy(&req, &node) //nolint:scopelint
+				err := copier.Copy(&req, node)
 				if err != nil {
 					return diag.FromErr(err)
 				}

--- a/nutanix/services/foundationCentral/resource_nutanix_foundation_central_onboard_nodes.go
+++ b/nutanix/services/foundationCentral/resource_nutanix_foundation_central_onboard_nodes.go
@@ -26,8 +26,6 @@ func ResourceNutanixFCOnboardNodes() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"node_serial": {
 				Type:     schema.TypeString,
-				Computed: false,
-				Optional: false,
 				Required: true,
 			},
 			"block_serial": {
@@ -85,7 +83,6 @@ func resourceNutanixFCOnboardNodesRead(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	d.SetId(*resp.ImagedNodeUUID)
 	return nil
 }
 

--- a/nutanix/services/foundationCentral/resource_nutanix_foundation_central_onboard_nodes.go
+++ b/nutanix/services/foundationCentral/resource_nutanix_foundation_central_onboard_nodes.go
@@ -1,0 +1,152 @@
+package fc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jinzhu/copier"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	fc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v3/fc"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func ResourceNutanixFCOnboardNodes() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNutanixFCOnboardNodesCreate,
+		ReadContext:   resourceNutanixFCOnboardNodesRead,
+		UpdateContext: resourceNutanixFCOnboardNodesUpdate,
+		DeleteContext: resourceNutanixFCOnboardNodesDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(ImageMiniTimeout),
+		},
+		Schema: map[string]*schema.Schema{
+			"node_serial": {
+				Type:     schema.TypeString,
+				Computed: false,
+				Optional: false,
+				Required: true,
+			},
+			"block_serial": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"imaged_node_uuid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"model": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"node_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"node_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceNutanixFCOnboardNodesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).FoundationCentral
+	resp, err := conn.Service.GetImagedNode(ctx, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if resp == nil || resp.ImagedNodeUUID == nil {
+		d.SetId("")
+		return nil
+	}
+
+	if err := d.Set("node_serial", resp.NodeSerial); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("block_serial", resp.BlockSerial); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("imaged_node_uuid", resp.ImagedNodeUUID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("model", resp.Model); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("node_state", resp.NodeState); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("node_type", resp.NodeType); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(*resp.ImagedNodeUUID)
+	return nil
+}
+
+func resourceNutanixFCOnboardNodesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	serial := d.Get("node_serial")
+
+	// Get client connection
+	conn := meta.(*conns.Client).FoundationCentral
+	hwManagers, err := conn.Service.ListHardwareManagers(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	for _, hwManager := range hwManagers.HardwareManagers {
+		hwManagerNodes, err := conn.Service.ListHardwareManagerNodes(ctx, *hwManager.HardwareManagerUUID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		for _, node := range hwManagerNodes.Nodes {
+			if *node.NodeSerial == serial {
+				var req fc.CreateOnboardNodeInput
+				err := copier.Copy(&req, &node) //nolint:scopelint
+				if err != nil {
+					return diag.FromErr(err)
+				}
+				req.EntityID = node.NodeSerial
+				req.EntityType = utils.StringPtr("intersight_nodes_to_be_onboarded")
+
+				resp, err := conn.Service.CreateOnboardNode(ctx, &req)
+				if err != nil {
+					return diag.FromErr(err)
+				}
+				if resp.ImagedNodeUUID == nil {
+					return diag.Errorf("returned node uuid is empty")
+				}
+
+				d.SetId(*resp.ImagedNodeUUID)
+				return resourceNutanixFCOnboardNodesRead(ctx, d, meta)
+			}
+		}
+	}
+
+	return diag.Errorf("Node not found with serial %s", serial)
+}
+
+func resourceNutanixFCOnboardNodesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceNutanixFCOnboardNodesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).FoundationCentral
+	log.Printf("[DEBUG] Deleting onboarded node: %s, %s", d.Get("node_serial").(string), d.Id())
+	err := conn.Service.DeleteOnboardNode(ctx, d.Id())
+	if err != nil {
+		if strings.Contains(fmt.Sprint(err), "ENTITY_NOT_FOUND") {
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("error while Deleting Onboarded Node: UUID(%s): %s", d.Id(), err)
+	}
+	d.SetId("")
+	return nil
+}

--- a/nutanix/services/foundationCentral/resource_nutanix_foundation_central_onboard_nodes_test.go
+++ b/nutanix/services/foundationCentral/resource_nutanix_foundation_central_onboard_nodes_test.go
@@ -1,6 +1,7 @@
 package fc_test
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -12,27 +13,30 @@ func TestAccFCOnboardNodesResource(t *testing.T) {
 	// Since the acceptance test environment most likely doesn't have any Intersight managed nodes
 	// to onboard, we test that an onboarding config has a non-empty plan and correctly produces
 	// a Node not found error
+
+	nodeSerial := foundationVars.OnboardNodes[0].NodeSerial
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:             testFCOnboardNodesResource(),
+				Config:             testFCOnboardNodesResource(nodeSerial),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config:      testFCOnboardNodesResource(),
-				ExpectError: regexp.MustCompile(`Node not found with serial ABC12345D6E`),
+				Config:      testFCOnboardNodesResource(nodeSerial),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(`Node not found with serial %[1]s`, nodeSerial)),
 			},
 		},
 	})
 }
 
-func testFCOnboardNodesResource() string {
-	return `
+func testFCOnboardNodesResource(nodeSerial string) string {
+	return fmt.Sprintf(`
 		resource "nutanix_foundation_central_onboard_nodes" "node" {
-			node_serial = "ABC12345D6E"
+			node_serial = "%[1]s"
 		}
-  `
+  `, nodeSerial)
 }

--- a/nutanix/services/foundationCentral/resource_nutanix_foundation_central_onboard_nodes_test.go
+++ b/nutanix/services/foundationCentral/resource_nutanix_foundation_central_onboard_nodes_test.go
@@ -1,0 +1,38 @@
+package fc_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+func TestAccFCOnboardNodesResource(t *testing.T) {
+	// Since the acceptance test environment most likely doesn't have any Intersight managed nodes
+	// to onboard, we test that an onboarding config has a non-empty plan and correctly produces
+	// a Node not found error
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:             testFCOnboardNodesResource(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config:      testFCOnboardNodesResource(),
+				ExpectError: regexp.MustCompile(`Node not found with serial ABC12345D6E`),
+			},
+		},
+	})
+}
+
+func testFCOnboardNodesResource() string {
+	return `
+		resource "nutanix_foundation_central_onboard_nodes" "node" {
+			node_serial = "ABC12345D6E"
+		}
+  `
+}

--- a/test_foundation_config.json
+++ b/test_foundation_config.json
@@ -1,136 +1,142 @@
 {
-	"ipv6_addresses" : ["",""],
+	"ipv6_addresses": [
+		"",
+		""
+	],
 	"ipmi_config": {
-		"ipmi_netmask":"",
-		"ipmi_gateway":"",
-		"ipmi_user":"",
-		"ipmi_password":"",
-		"ipmi_mac":"",
-		"ipmi_ip":""
+		"ipmi_netmask": "",
+		"ipmi_gateway": "",
+		"ipmi_user": "",
+		"ipmi_password": "",
+		"ipmi_mac": "",
+		"ipmi_ip": ""
 	},
-	"blocks":[
+	"blocks": [
 		{
 			"cvm_gateway": "",
-			"hypervisor_gateway":"",
-			"cvm_netmask":"",
-			"hypervisor_netmask":"",
+			"hypervisor_gateway": "",
+			"cvm_netmask": "",
+			"hypervisor_netmask": "",
 			"ipmi_user": "",
 			"nodes": [
 				{
-					"ipmi_ip":"",
-					"ipmi_user":"",
-					"ipmi_password":"",
-					"ipmi_netmask":"",
-					"ipmi_gateway":"",
-					"cvm_ip":"",
-					"hypervisor":"",
-					"hypervisor_hostname":"",
-					"hypervisor_ip":"",
-					"node_position":"",
-					"ipv6_address":"",
-					"current_network_interface":""
+					"ipmi_ip": "",
+					"ipmi_user": "",
+					"ipmi_password": "",
+					"ipmi_netmask": "",
+					"ipmi_gateway": "",
+					"cvm_ip": "",
+					"hypervisor": "",
+					"hypervisor_hostname": "",
+					"hypervisor_ip": "",
+					"node_position": "",
+					"ipv6_address": "",
+					"current_network_interface": ""
 				},
 				{
-					"ipmi_ip":"",
-					"ipmi_user":"",
-					"ipmi_password":"",
-					"ipmi_netmask":"",
-					"ipmi_gateway":"",
-					"cvm_ip":"",
-					"hypervisor":"",
-					"hypervisor_hostname":"",
-					"hypervisor_ip":"",
-					"node_position":"",
-					"ipv6_address":"",
-					"current_network_interface":""
+					"ipmi_ip": "",
+					"ipmi_user": "",
+					"ipmi_password": "",
+					"ipmi_netmask": "",
+					"ipmi_gateway": "",
+					"cvm_ip": "",
+					"hypervisor": "",
+					"hypervisor_hostname": "",
+					"hypervisor_ip": "",
+					"node_position": "",
+					"ipv6_address": "",
+					"current_network_interface": ""
 				},
 				{
-					"ipmi_ip":"",
-					"ipmi_user":"",
-					"ipmi_password":"",
-					"ipmi_netmask":"",
-					"ipmi_gateway":"",
-					"cvm_ip":"",
-					"hypervisor":"",
-					"hypervisor_hostname":"",
-					"hypervisor_ip":"",
-					"node_position":"",
-					"ipv6_address":"",
-					"current_network_interface":""
+					"ipmi_ip": "",
+					"ipmi_user": "",
+					"ipmi_password": "",
+					"ipmi_netmask": "",
+					"ipmi_gateway": "",
+					"cvm_ip": "",
+					"hypervisor": "",
+					"hypervisor_hostname": "",
+					"hypervisor_ip": "",
+					"node_position": "",
+					"ipv6_address": "",
+					"current_network_interface": ""
 				},
 				{
-					"ipmi_ip":"",
-					"ipmi_user":"",
-					"ipmi_password":"",
-					"ipmi_netmask":"",
-					"ipmi_gateway":"",
-					"cvm_ip":"",
-					"hypervisor":"",
-					"hypervisor_hostname":"",
-					"hypervisor_ip":"",
-					"node_position":"",
-					"ipv6_address":"",
-					"current_network_interface":""
+					"ipmi_ip": "",
+					"ipmi_user": "",
+					"ipmi_password": "",
+					"ipmi_netmask": "",
+					"ipmi_gateway": "",
+					"cvm_ip": "",
+					"hypervisor": "",
+					"hypervisor_hostname": "",
+					"hypervisor_ip": "",
+					"node_position": "",
+					"ipv6_address": "",
+					"current_network_interface": ""
 				}
 			],
 			"block_id": ""
 		},
 		{
-			"common_network_settings":{
-			  "cvm_dns_servers":[
-				  ""
-			  ],
-			  "hypervisor_dns_servers":[
-				  ""
-			  ],
-			  "cvm_ntp_servers":[
-				  ""
-			  ],
-			  "hypervisor_ntp_servers":[
-				  ""
-			  ]
+			"common_network_settings": {
+				"cvm_dns_servers": [
+					""
+				],
+				"hypervisor_dns_servers": [
+					""
+				],
+				"cvm_ntp_servers": [
+					""
+				],
+				"hypervisor_ntp_servers": [
+					""
+				]
 			},
-			"cvm_gateway":"",
-			"cvm_netmask":"",
-			"hypervisor_gateway":"",
-			"hypervisor_netmask":"",
-			"use_existing_network_settings":false,
-			"image_now":true,
-			
-			 "nodes": [
+			"cvm_gateway": "",
+			"cvm_netmask": "",
+			"hypervisor_gateway": "",
+			"hypervisor_netmask": "",
+			"use_existing_network_settings": false,
+			"image_now": true,
+			"nodes": [
 				{
-					"cvm_ip":"",
-					"hypervisor_ip":"",
-					"hypervisor_hostname":"",
-					"imaged_node_uuid":"",
-					"ipmi_gateway":"",
-					"ipmi_ip":"",
-					"ipmi_netmask":"",
-					"hypervisor_type":""
+					"cvm_ip": "",
+					"hypervisor_ip": "",
+					"hypervisor_hostname": "",
+					"imaged_node_uuid": "",
+					"ipmi_gateway": "",
+					"ipmi_ip": "",
+					"ipmi_netmask": "",
+					"hypervisor_type": ""
 				},
 				{
-					"cvm_ip":"",
-					"hypervisor_ip":"",
-					"hypervisor_hostname":"",
-					"imaged_node_uuid":"",
-					"ipmi_gateway":"",
-					"ipmi_ip":"",
-					"ipmi_netmask":"",
-					"hypervisor_type":""
+					"cvm_ip": "",
+					"hypervisor_ip": "",
+					"hypervisor_hostname": "",
+					"imaged_node_uuid": "",
+					"ipmi_gateway": "",
+					"ipmi_ip": "",
+					"ipmi_netmask": "",
+					"hypervisor_type": ""
 				},
 				{
-					"cvm_ip":"",
-					"hypervisor_ip":"",
-					"hypervisor_hostname":"",
-					"imaged_node_uuid":"",
-					"ipmi_gateway":"",
-					"ipmi_ip":"",
-					"ipmi_netmask":"",
-					"hypervisor_type":""
+					"cvm_ip": "",
+					"hypervisor_ip": "",
+					"hypervisor_hostname": "",
+					"imaged_node_uuid": "",
+					"ipmi_gateway": "",
+					"ipmi_ip": "",
+					"ipmi_netmask": "",
+					"hypervisor_type": ""
 				}
-				
-			 ],
-			"aos_package_url":""
+			],
+			"aos_package_url": ""
+		}
+	],
+	"onboard_nodes": [
+		{
+			"node_serial": "ABC12345D6E"
 		}
 	]
 }

--- a/website/docs/r/foundation_central_image_cluster.html.markdown
+++ b/website/docs/r/foundation_central_image_cluster.html.markdown
@@ -118,6 +118,15 @@ The following arguments are supported:
 * `aos_package_sha256sum`: Sha256sum of AOS package.
 * `timezone`: Timezone to be set on the cluster.
 * `nodes_list`: List of details of nodes out of which the cluster needs to be created.
+* `fc_api_key_uuid`: UUID of the FC API key to be used in the imaging process. Required only for imaging via a hardware manager like Cisco Intersight managed UCS nodes. 
+* `server_configuration_data`: JSON-encoded server configuration data for cluster. Required only for imaging via a hardware manager like Cisco Intersight managed UCS nodes. Example:
+    ```
+    server_configuration_data = jsonencode({
+      intersight_data = {
+        organization = "default"
+      }
+    })
+    ```
 
 ### common network settings
 * `cvm_dns_servers`: List of dns servers for the cvms in the cluster.
@@ -157,6 +166,24 @@ The following arguments are supported:
 * `hypervisor_ip`: IP address to be set for the hypervisor on the node.
 * `use_existing_network_settings`: Decides whether to use the existing network settings for the node. If True, the existing network settings of the node will be used during cluster creation. If False, then client must provide new network settings. If all nodes are booted in phoenix, this field is, by default, considered to be False.
 * `ipmi_gateway`: Gateway of the ipmi.
+* `server_configuration_data`: JSON-encoded server configuration data for node. Required only for imaging via a hardware manager like Cisco Intersight managed UCS nodes. Example:
+
+    ```
+    server_configuration_data = jsonencode({
+        intersight_data = {
+          uuid_pool_name = ""
+          imc_settings = {
+            out_of_band_settings = {
+              ip_pool_name = "test-vlan-pool"
+            }
+          }
+          vnic_settings = {
+            mac_pool_name = "test-mac-pool"
+            vlans         = "16"
+          }
+        }
+      })
+    ```
 
 
 ## Attributes Reference

--- a/website/docs/r/foundation_central_onboard_nodes.html.markdown
+++ b/website/docs/r/foundation_central_onboard_nodes.html.markdown
@@ -23,7 +23,7 @@ resource "nutanix_foundation_central_onboard_nodes" "node" {
 
 The following arguments are supported:
 
-* `node_serial`: Serial number of the node to onbaord
+* `node_serial`: Serial number of the node to onboard
 
 ## Attributes Reference
 

--- a/website/docs/r/foundation_central_onboard_nodes.html.markdown
+++ b/website/docs/r/foundation_central_onboard_nodes.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_foundation_central_onboard_nodes"
+sidebar_current: "docs-nutanix-resource-foundation-central-onboard-nodes"
+description: |-
+  Onboard nodes from a hardware manager (such as Cisco Intersight) into Foundation Central.
+---
+
+# nutanix_foundation_central_onboard_nodes
+
+Onboard nodes from a hardware manager (such as Cisco Intersight) into Foundation Central.
+
+## Example Usage
+
+```hcl
+resource "nutanix_foundation_central_onboard_nodes" "node" {
+  node_serial = "ABC12345D6E"
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `node_serial`: Serial number of the node to onbaord
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `block_serial`: Block serial number of the node
+* `imaged_node_uuid`: UUID of the imaged_node in FC
+* `model`: Model of the node
+* `node_state`: State of the node (e.g. STATE_ONBOARDED)
+* `node_type`: Type of node (e.g. "on-prem")
+
+
+## Error 
+
+Incase of error (such as node serial not found), an error will be generated. 
+
+## lifecycle
+
+* `Create` : - Resource will trigger onboarding of the node.
+* `delete` : - Node will be removed from FC "imaged nodes" but will still be available in the hardware manager for re-onboarding. 

--- a/website/nutanix.erb
+++ b/website/nutanix.erb
@@ -545,6 +545,9 @@
                 <li<%= sidebar_current("docs-nutanix-resource-foundation-central-image-cluster") %>>
                     <a href="/docs/providers/nutanix/r/foundation_central_image_cluster.html">nutanix_foundation_central_image_cluster</a>
                 </li>
+                <li<%= sidebar_current("docs-nutanix-resource-foundation-central-onboard-nodes") %>>
+                    <a href="/docs/providers/nutanix/r/foundation_central_onboard_nodes.html">nutanix_foundation_central_onboard_nodes</a>
+                </li>
                 <li<%= sidebar_current("docs-nutanix-resource-floating-ip") %>>
                     <a href="/docs/providers/nutanix/r/floating_ip.html">nutanix_floating_ip</a>
                 </li>


### PR DESCRIPTION
This PR is intended to enable Terraform automation of the day 0 provisioning of Cisco UCS nodes managed by Intersight. 

The PR:
- Adds a new resource `nutanix_foundation_central_onboard_nodes` to onboard nodes in Foundation Central from a connected Intersight hardware manager
- Extends the `nutanix_foundation_central_image_cluster` resource with the `.server_configuration_data`, `.fc_api_key_uuid` and `.node_list[].server_configuration_data` attributes required for imaging clusters on Intersight managed nodes

