### PR TITLE
Fix issue 939: The creation of a floating IP fails when specifying the desired IP address. Ok if not specify the desired IP.

### DIFF
--- a/nutanix/services/networkingv2/resource_nutanix_address_groups_V2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_address_groups_V2.go
@@ -284,7 +284,7 @@ func expandIPv4AddressList(pr []interface{}) []config.IPv4Address {
 					ip.PrefixLength = utils.IntPtr(n)
 				}
 			}
-			
+
 			ipv4s[k] = ip
 		}
 		return ipv4s

--- a/nutanix/services/networkingv2/resource_nutanix_address_groups_V2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_address_groups_V2.go
@@ -273,13 +273,18 @@ func expandIPv4AddressList(pr []interface{}) []config.IPv4Address {
 			val := v.(map[string]interface{})
 			ip := config.IPv4Address{}
 
-			if vals, ok := val["value"]; ok {
-				ip.Value = utils.StringPtr(vals.(string))
+			if v, ok := val["value"]; ok {
+				if s, ok2 := v.(string); ok2 && len(s) > 0 {
+					ip.Value = utils.StringPtr(s)
+				}
 			}
 
-			if prefix, ok := val["prefix_length"]; ok {
-				ip.PrefixLength = utils.IntPtr(prefix.(int))
+			if p, ok := val["prefix_length"]; ok {
+				if n, ok2 := p.(int); ok2 {
+					ip.PrefixLength = utils.IntPtr(n)
+				}
 			}
+			
 			ipv4s[k] = ip
 		}
 		return ipv4s
@@ -307,48 +312,3 @@ func expandIPv4Range(pr []interface{}) []import1.IPv4Range {
 	}
 	return nil
 }
-
-// func taskStateRefreshPrismTaskGroupFunc(ctx context.Context, client *prism.Client, taskUUID string) resource.StateRefreshFunc {
-//	return func() (interface{}, string, error) {
-//		vresp, err := client.TaskRefAPI.GetTaskById(utils.StringPtr(taskUUID))
-//
-//		if err != nil {
-//			return "", "", (fmt.Errorf("error while polling prism task: %v", err))
-//		}
-//
-//		// get the group results
-//
-//		v := vresp.Data.GetValue().(import2.Task)
-//
-//		if getTaskStatusMicroSeg(v.Status) == "CANCELED" || getTaskStatusMicroSeg(v.Status) == "FAILED" {
-//			return v, getTaskStatusMicroSeg(v.Status),
-//				fmt.Errorf("error_detail: %s, progress_message: %d", utils.StringValue(v.ErrorMessages[0].Message), utils.IntValue(v.ProgressPercentage))
-//		}
-//		return v, getTaskStatusMicroSeg(v.Status), nil
-//	}
-//}
-//
-//func getTaskStatusMicroSeg(pr *import2.TaskStatus) string {
-//	if pr != nil {
-//		const two, three, four, five, six, seven = 2, 3, 4, 5, 6, 7
-//		if *pr == import2.TaskStatus(two) {
-//			return "QUEUED"
-//		}
-//		if *pr == import2.TaskStatus(three) {
-//			return "RUNNING"
-//		}
-//		if *pr == import2.TaskStatus(four) {
-//			return "CANCELING"
-//		}
-//		if *pr == import2.TaskStatus(five) {
-//			return "SUCCEEDED"
-//		}
-//		if *pr == import2.TaskStatus(six) {
-//			return "FAILED"
-//		}
-//		if *pr == import2.TaskStatus(seven) {
-//			return "CANCELED"
-//		}
-//	}
-//	return "UNKNOWN"
-//}

--- a/nutanix/services/networkingv2/resource_nutanix_floating_ip_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_floating_ip_v2.go
@@ -510,7 +510,7 @@ func expandFloatingIPv6Address(pr interface{}) *import1.FloatingIPv6Address {
 			ipv6.PrefixLength = utils.IntPtr(n)
 		}
 	}
-	
+
 	return ipv6
 }
 

--- a/nutanix/services/networkingv2/resource_nutanix_floating_ip_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_floating_ip_v2.go
@@ -445,37 +445,73 @@ func expandFloatingIPAddress(pr interface{}) *import1.FloatingIPAddress {
 }
 
 func expandFloatingIPv4Address(pr interface{}) *import1.FloatingIPv4Address {
-	if pr != nil {
-		ipv4 := &import1.FloatingIPv4Address{}
-		prI := pr.([]interface{})
-		val := prI[0].(map[string]interface{})
-
-		if value, ok := val["value"]; ok {
-			ipv4.Value = utils.StringPtr(value.(string))
-		}
-		if prefix, ok := val["prefix_length"]; ok {
-			ipv4.PrefixLength = utils.IntPtr(prefix.(int))
-		}
-		return ipv4
+	// nil check
+	if pr == nil {
+		return nil
 	}
-	return nil
+
+	// safe type assert for expected slice
+	prSlice, ok := pr.([]interface{})
+	if !ok || len(prSlice) == 0 {
+		return nil
+	}
+
+	// safe type assert for first element being a map
+	valMap, ok := prSlice[0].(map[string]interface{})
+	if !ok || len(valMap) == 0 {
+		return nil
+	}
+
+	ipv4 := &import1.FloatingIPv4Address{}
+
+	if v, ok := valMap["value"]; ok {
+		if s, ok2 := v.(string); ok2 {
+			ipv4.Value = utils.StringPtr(s)
+		}
+	}
+
+	if p, ok := valMap["prefix_length"]; ok {
+		if n, ok2 := p.(int); ok2 {
+			ipv4.PrefixLength = utils.IntPtr(n)
+		}
+	}
+
+	return ipv4
 }
 
 func expandFloatingIPv6Address(pr interface{}) *import1.FloatingIPv6Address {
-	if pr != nil {
-		ipv6 := &import1.FloatingIPv6Address{}
-		prI := pr.([]interface{})
-		val := prI[0].(map[string]interface{})
-
-		if value, ok := val["value"]; ok {
-			ipv6.Value = utils.StringPtr(value.(string))
-		}
-		if prefix, ok := val["prefix_length"]; ok {
-			ipv6.PrefixLength = utils.IntPtr(prefix.(int))
-		}
-		return ipv6
+	// nil check
+	if pr == nil {
+		return nil
 	}
-	return nil
+
+	// safe type assert for expected slice
+	prSlice, ok := pr.([]interface{})
+	if !ok || len(prSlice) == 0 {
+		return nil
+	}
+
+	// safe type assert for first element being a map
+	valMap, ok := prSlice[0].(map[string]interface{})
+	if !ok || len(valMap) == 0 {
+		return nil
+	}
+
+	ipv6 := &import1.FloatingIPv6Address{}
+
+	if v, ok := valMap["value"]; ok {
+		if s, ok2 := v.(string); ok2 {
+			ipv6.Value = utils.StringPtr(s)
+		}
+	}
+
+	if p, ok := valMap["prefix_length"]; ok {
+		if n, ok2 := p.(int); ok2 {
+			ipv6.PrefixLength = utils.IntPtr(n)
+		}
+	}
+	
+	return ipv6
 }
 
 func expandSubnet(pr interface{}) *import1.Subnet {

--- a/nutanix/services/networkingv2/resource_nutanix_floating_ip_v2_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_floating_ip_v2_test.go
@@ -164,6 +164,11 @@ func testFloatingIPv2ConfigWithVMNic(name, desc string) string {
 			name = "%[1]s"
 			description = "%[2]s"
 			external_subnet_reference = data.nutanix_subnets_v2.test.subnets.0.ext_id
+			floating_ip {
+				ipv4 {
+					value = "10.44.3.205"
+				}
+			}
 			association{
 				vm_nic_association{
 					vm_nic_reference = data.nutanix_virtual_machines_v2.test.vms.0.nics.0.ext_id

--- a/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go
@@ -976,20 +976,35 @@ func expandIsolationGroup(isolationGroup []interface{}) []import1.IsolationGroup
 }
 
 func expandIPv4AddressMicroseg(pr interface{}) *config.IPv4Address {
-	if pr != nil {
-		ipv4 := &config.IPv4Address{}
-		prI := pr.([]interface{})
-		val := prI[0].(map[string]interface{})
-
-		if value, ok := val["value"]; ok {
-			ipv4.Value = utils.StringPtr(value.(string))
-		}
-		if prefix, ok := val["prefix_length"]; ok {
-			ipv4.PrefixLength = utils.IntPtr(prefix.(int))
-		}
-		return ipv4
+	if pr == nil {
+		return nil
 	}
-	return nil
+
+	prSlice, ok := pr.([]interface{})
+	if !ok || len(prSlice) == 0 {
+		return nil
+	}
+
+	valMap, ok := prSlice[0].(map[string]interface{})
+	if !ok || len(valMap) == 0 {
+		return nil
+	}
+
+	ipv4 := &config.IPv4Address{}
+
+	if v, ok := valMap["value"]; ok {
+		if s, ok2 := v.(string); ok2 {
+			ipv4.Value = utils.StringPtr(s)
+		}
+	}
+
+	if p, ok := valMap["prefix_length"]; ok {
+		if n, ok2 := p.(int); ok2 {
+			ipv4.PrefixLength = utils.IntPtr(n)
+		}
+	}
+
+	return ipv4
 }
 
 func indexOf(slice []string, target string) int {

--- a/nutanix/services/networkingv2/resource_nutanix_subnets_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_subnets_v2.go
@@ -945,7 +945,6 @@ func expandIPv6Address(pr interface{}) *config.IPv6Address {
 	return ipv6
 }
 
-
 func expandVirtualSwitch(pr interface{}) *import1.VirtualSwitch {
 	if pr != nil {
 		vSwitch := &import1.VirtualSwitch{}
@@ -1102,7 +1101,6 @@ func expandIPv6Subnet(pr interface{}) *import1.IPv6Subnet {
 
 	return ipv6Subs
 }
-
 
 func expandVpc(pr interface{}) *import1.Vpc {
 	if pr != nil {
@@ -1288,7 +1286,6 @@ func expandIPv6AddressMap(pr interface{}) *config.IPv6Address {
 
 	return ipv6Add
 }
-
 
 func expandIPSubnet(pr []interface{}) []import1.IPSubnet {
 	if len(pr) > 0 {

--- a/nutanix/services/networkingv2/resource_nutanix_subnets_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_subnets_v2.go
@@ -882,38 +882,69 @@ func expandIPAddress(pr []interface{}) []config.IPAddress {
 }
 
 func expandIPv4Address(pr interface{}) *config.IPv4Address {
-	if pr != nil {
-		ipv4 := &config.IPv4Address{}
-		prI := pr.([]interface{})
-		val := prI[0].(map[string]interface{})
-
-		if value, ok := val["value"]; ok && len(value.(string)) > 0 {
-			ipv4.Value = utils.StringPtr(value.(string))
-		}
-		if prefix, ok := val["prefix_length"]; ok {
-			ipv4.PrefixLength = utils.IntPtr(prefix.(int))
-		}
-		return ipv4
+	if pr == nil {
+		return nil
 	}
-	return nil
+
+	prSlice, ok := pr.([]interface{})
+	if !ok || len(prSlice) == 0 {
+		return nil
+	}
+
+	valMap, ok := prSlice[0].(map[string]interface{})
+	if !ok || len(valMap) == 0 {
+		return nil
+	}
+
+	ipv4 := &config.IPv4Address{}
+
+	if v, ok := valMap["value"]; ok {
+		if s, ok2 := v.(string); ok2 && len(s) > 0 {
+			ipv4.Value = utils.StringPtr(s)
+		}
+	}
+
+	if p, ok := valMap["prefix_length"]; ok {
+		if n, ok2 := p.(int); ok2 {
+			ipv4.PrefixLength = utils.IntPtr(n)
+		}
+	}
+
+	return ipv4
 }
 
 func expandIPv6Address(pr interface{}) *config.IPv6Address {
-	if pr != nil {
-		ipv6 := &config.IPv6Address{}
-		prI := pr.([]interface{})
-		val := prI[0].(map[string]interface{})
-
-		if value, ok := val["value"]; ok && len(value.(string)) > 0 {
-			ipv6.Value = utils.StringPtr(value.(string))
-		}
-		if prefix, ok := val["prefix_length"]; ok {
-			ipv6.PrefixLength = utils.IntPtr(prefix.(int))
-		}
-		return ipv6
+	if pr == nil {
+		return nil
 	}
-	return nil
+
+	prSlice, ok := pr.([]interface{})
+	if !ok || len(prSlice) == 0 {
+		return nil
+	}
+
+	valMap, ok := prSlice[0].(map[string]interface{})
+	if !ok || len(valMap) == 0 {
+		return nil
+	}
+
+	ipv6 := &config.IPv6Address{}
+
+	if v, ok := valMap["value"]; ok {
+		if s, ok2 := v.(string); ok2 && len(s) > 0 {
+			ipv6.Value = utils.StringPtr(s)
+		}
+	}
+
+	if p, ok := valMap["prefix_length"]; ok {
+		if n, ok2 := p.(int); ok2 {
+			ipv6.PrefixLength = utils.IntPtr(n)
+		}
+	}
+
+	return ipv6
 }
+
 
 func expandVirtualSwitch(pr interface{}) *import1.VirtualSwitch {
 	if pr != nil {
@@ -1013,40 +1044,65 @@ func expandHost(pr []interface{}) []import1.Host {
 }
 
 func expandIPv4Subnet(pr interface{}) *import1.IPv4Subnet {
-	if pr != nil {
-		ipv4Subs := &import1.IPv4Subnet{}
-		prI := pr.([]interface{})
-		val := prI[0].(map[string]interface{})
-
-		if ip, ok := val["ip"]; ok {
-			ipv4Subs.Ip = expandIPv4Address(ip)
-		}
-		if prefix, ok := val["prefix_length"]; ok {
-			ipv4Subs.PrefixLength = utils.IntPtr(prefix.(int))
-		}
-
-		return ipv4Subs
+	if pr == nil {
+		return nil
 	}
-	return nil
+
+	prSlice, ok := pr.([]interface{})
+	if !ok || len(prSlice) == 0 {
+		return nil
+	}
+
+	valMap, ok := prSlice[0].(map[string]interface{})
+	if !ok || len(valMap) == 0 {
+		return nil
+	}
+
+	ipv4Subs := &import1.IPv4Subnet{}
+
+	if ip, ok := valMap["ip"]; ok {
+		ipv4Subs.Ip = expandIPv4Address(ip)
+	}
+
+	if prefix, ok := valMap["prefix_length"]; ok {
+		if n, ok2 := prefix.(int); ok2 {
+			ipv4Subs.PrefixLength = utils.IntPtr(n)
+		}
+	}
+
+	return ipv4Subs
 }
 
 func expandIPv6Subnet(pr interface{}) *import1.IPv6Subnet {
-	if pr != nil {
-		ipv6Subs := &import1.IPv6Subnet{}
-		prI := pr.([]interface{})
-		val := prI[0].(map[string]interface{})
-
-		if ip, ok := val["ip"]; ok {
-			ipv6Subs.Ip = expandIPv6Address(ip)
-		}
-		if prefix, ok := val["prefix_length"]; ok {
-			ipv6Subs.PrefixLength = utils.IntPtr(prefix.(int))
-		}
-
-		return ipv6Subs
+	if pr == nil {
+		return nil
 	}
-	return nil
+
+	prSlice, ok := pr.([]interface{})
+	if !ok || len(prSlice) == 0 {
+		return nil
+	}
+
+	valMap, ok := prSlice[0].(map[string]interface{})
+	if !ok || len(valMap) == 0 {
+		return nil
+	}
+
+	ipv6Subs := &import1.IPv6Subnet{}
+
+	if ip, ok := valMap["ip"]; ok {
+		ipv6Subs.Ip = expandIPv6Address(ip)
+	}
+
+	if prefix, ok := valMap["prefix_length"]; ok {
+		if n, ok2 := prefix.(int); ok2 {
+			ipv6Subs.PrefixLength = utils.IntPtr(n)
+		}
+	}
+
+	return ipv6Subs
 }
+
 
 func expandVpc(pr interface{}) *import1.Vpc {
 	if pr != nil {
@@ -1170,40 +1226,69 @@ func expandIPAddressMap(pr interface{}) *config.IPAddress {
 }
 
 func expandIPv4AddressMap(pr interface{}) *config.IPv4Address {
-	if pr != nil {
-		prI := pr.([]interface{})
-		val := prI[0].(map[string]interface{})
-
-		ipv4Add := &config.IPv4Address{}
-
-		if value, ok := val["value"]; ok {
-			ipv4Add.Value = utils.StringPtr(value.(string))
-		}
-		if prefix, ok := val["prefix_length"]; ok {
-			ipv4Add.PrefixLength = utils.IntPtr(prefix.(int))
-		}
-		return ipv4Add
+	if pr == nil {
+		return nil
 	}
-	return nil
+
+	prSlice, ok := pr.([]interface{})
+	if !ok || len(prSlice) == 0 {
+		return nil
+	}
+
+	valMap, ok := prSlice[0].(map[string]interface{})
+	if !ok || len(valMap) == 0 {
+		return nil
+	}
+
+	ipv4Add := &config.IPv4Address{}
+
+	if v, ok := valMap["value"]; ok {
+		if s, ok2 := v.(string); ok2 {
+			ipv4Add.Value = utils.StringPtr(s)
+		}
+	}
+
+	if p, ok := valMap["prefix_length"]; ok {
+		if n, ok2 := p.(int); ok2 {
+			ipv4Add.PrefixLength = utils.IntPtr(n)
+		}
+	}
+
+	return ipv4Add
 }
 
 func expandIPv6AddressMap(pr interface{}) *config.IPv6Address {
-	if pr != nil {
-		prI := pr.([]interface{})
-		val := prI[0].(map[string]interface{})
-
-		ipv6Add := &config.IPv6Address{}
-
-		if value, ok := val["value"]; ok {
-			ipv6Add.Value = utils.StringPtr(value.(string))
-		}
-		if prefix, ok := val["prefix_length"]; ok {
-			ipv6Add.PrefixLength = utils.IntPtr(prefix.(int))
-		}
-		return ipv6Add
+	if pr == nil {
+		return nil
 	}
-	return nil
+
+	prSlice, ok := pr.([]interface{})
+	if !ok || len(prSlice) == 0 {
+		return nil
+	}
+
+	valMap, ok := prSlice[0].(map[string]interface{})
+	if !ok || len(valMap) == 0 {
+		return nil
+	}
+
+	ipv6Add := &config.IPv6Address{}
+
+	if v, ok := valMap["value"]; ok {
+		if s, ok2 := v.(string); ok2 {
+			ipv6Add.Value = utils.StringPtr(s)
+		}
+	}
+
+	if p, ok := valMap["prefix_length"]; ok {
+		if n, ok2 := p.(int); ok2 {
+			ipv6Add.PrefixLength = utils.IntPtr(n)
+		}
+	}
+
+	return ipv6Add
 }
+
 
 func expandIPSubnet(pr []interface{}) []import1.IPSubnet {
 	if len(pr) > 0 {


### PR DESCRIPTION
fix issue 939, when creating a floating IP with a desired IP value caused failures (works when no desired IP is specified). PR updates expanders for IPv4/IPv6 and related files, and upgrades tests.