### PR TITLE
populate ext_id in nutanix_virtual_machine_v2 resource

### DIFF
--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -1767,6 +1767,9 @@ func ResourceNutanixVirtualMachineV2Read(ctx context.Context, d *schema.Resource
 
 	getResp := resp.Data.GetValue().(config.Vm)
 
+	if err := d.Set("ext_id", getResp.ExtId); err != nil {
+		return diag.FromErr(err)
+	}
 	if err := d.Set("name", getResp.Name); err != nil {
 		return diag.FromErr(err)
 	}

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
@@ -592,6 +592,7 @@ func TestAccV2NutanixVmsResource_WithCategories(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameVms, "num_cores_per_socket", "1"),
 					resource.TestCheckResourceAttr(resourceNameVms, "description", desc),
 					resource.TestCheckResourceAttr(resourceNameVms, "num_sockets", "2"),
+					resource.TestCheckResourceAttrSet(resourceNameVms, "ext_id"),
 					resource.TestCheckResourceAttrSet(resourceNameVms, "create_time"),
 					resource.TestCheckResourceAttrSet(resourceNameVms, "update_time"),
 					resource.TestCheckResourceAttr(resourceNameVms, "protection_type", "UNPROTECTED"),


### PR DESCRIPTION
The `ext_id` attribute was present in the schema of the `nutanix_virtual_machine_v2` resource already, but was never populated.