### PR TITLE
Fix ext_id null issue for resource nutanix_user_groups_v2

### DIFF
--- a/nutanix/services/iamv2/resource_nutanix_user_groups_v2.go
+++ b/nutanix/services/iamv2/resource_nutanix_user_groups_v2.go
@@ -101,7 +101,9 @@ func ResourceNutanixUserGroupsV4Read(ctx context.Context, d *schema.ResourceData
 	}
 
 	getResp := resp.Data.GetValue().(import1.UserGroup)
-
+	if err := d.Set("ext_id", getResp.ExtId); err != nil {
+		return diag.FromErr(err)
+	}
 	if err := d.Set("group_type", flattenGroupType(getResp.GroupType)); err != nil {
 		return diag.FromErr(err)
 	}

--- a/nutanix/services/iamv2/resource_nutanix_user_groups_v2_test.go
+++ b/nutanix/services/iamv2/resource_nutanix_user_groups_v2_test.go
@@ -24,6 +24,7 @@ func TestAccV2NutanixUserGroupsResource_LDAPUserGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameUserGroups, "idp_id", testVars.Iam.Users.DirectoryServiceID),
 					resource.TestCheckResourceAttr(resourceNameUserGroups, "group_type", "LDAP"),
 					resource.TestCheckResourceAttr(resourceNameUserGroups, "distinguished_name", testVars.Iam.UserGroups.DistinguishedName),
+					resource.TestCheckResourceAttrSet(resourceNameUserGroups, "ext_id"),
 				),
 			},
 			{


### PR DESCRIPTION
When a resource for nutanix_user_groups_v2 is created, in state file we are not storing the ext_id as we are storing the uuid of resource in id. As part of ticket https://github.com/nutanix/terraform-provider-nutanix/issues/947 we are adding this changes.