### PR TITLE
add ext_id to be shown in state file for a resource

### DIFF
--- a/nutanix/services/iamv2/resource_nutanix_roles_v2.go
+++ b/nutanix/services/iamv2/resource_nutanix_roles_v2.go
@@ -210,6 +210,9 @@ func ResourceNutanixRolesV4Read(ctx context.Context, d *schema.ResourceData, met
 	if err := d.Set("links", flattenLinks(getResp.Links)); err != nil {
 		return diag.FromErr(err)
 	}
+	if err := d.Set("ext_id", getResp.ExtId); err != nil {
+		return diag.FromErr(err)
+	}
 	if err := d.Set("display_name", getResp.DisplayName); err != nil {
 		return diag.FromErr(err)
 	}

--- a/nutanix/services/iamv2/resource_nutanix_roles_v2_test.go
+++ b/nutanix/services/iamv2/resource_nutanix_roles_v2_test.go
@@ -22,6 +22,7 @@ func TestAccV2NutanixRolesResource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceNameRoles, "client_name"),
 					resource.TestCheckResourceAttr(resourceNameRoles, "display_name", testVars.Iam.Roles.DisplayName),
 					resource.TestCheckResourceAttr(resourceNameRoles, "description", testVars.Iam.Roles.Description),
+					resource.TestCheckResourceAttrSet(resourceNameRoles, "ext_id"),
 				),
 			},
 			// update role


### PR DESCRIPTION
Currently when we create a role we are not setting the ext_id in state file, this PR fixes the discrepancy. As part of ticket https://github.com/nutanix/terraform-provider-nutanix/issues/951 we have added this change.