### PR TITLE
Fix issue 949: Improve `nutanix_users_v2` resource: add delete warning, update docs, and enhance example clarity

### DIFF
--- a/examples/users_v2/main.tf
+++ b/examples/users_v2/main.tf
@@ -7,7 +7,7 @@ terraform {
   }
 }
 
-#defining nutanix configuration
+# Defining Nutanix provider configuration
 provider "nutanix" {
   username = var.nutanix_username
   password = var.nutanix_password
@@ -16,8 +16,9 @@ provider "nutanix" {
   insecure = true
 }
 
-# Add a User group to the system.
-
+# -------------------------------------------------
+# Create an ACTIVE local user in the system
+# -------------------------------------------------
 resource "nutanix_users_v2" "active-user" {
   username             = "example_user"
   first_name           = "first-name"
@@ -33,6 +34,9 @@ resource "nutanix_users_v2" "active-user" {
   force_reset_password = true
 }
 
+# -------------------------------------------------
+# Create an INACTIVE local user in the system
+# -------------------------------------------------
 resource "nutanix_users_v2" "inactive-user" {
   username             = "inactive_user"
   first_name           = "first-name"
@@ -48,47 +52,74 @@ resource "nutanix_users_v2" "inactive-user" {
   force_reset_password = true
 }
 
+# -------------------------------------------------
+# Create an LDAP user in the system
+# -------------------------------------------------
+# This resource creates a user that is authenticated via an LDAP Identity Provider (IdP).
+# You must provide the IdP UUID (idp_id) associated with your LDAP configuration.
 resource "nutanix_users_v2" "ldap-user" {
   username  = "ldap_user"
   user_type = "LDAP"
-  idp_id    = "ba250e3e-1db1-4950-917f-a9e2ea35b8e3"
+  idp_id    = var.ldap_idp_id
 }
 
+# -------------------------------------------------
+# Create a SAML user in the system
+# -------------------------------------------------
+# This resource creates a user that is authenticated via a SAML Identity Provider (IdP).
+# You must provide the IdP UUID (idp_id) associated with your SAML configuration.
 resource "nutanix_users_v2" "saml-user" {
   username  = "saml_user"
   user_type = "SAML"
-  idp_id    = "a8fe48c4-f0d3-49c7-a017-efc30dd8fb2b"
+  idp_id    = var.sam_idp_id
 }
 
-# List all the users in the system.
+# -------------------------------------------------
+# Retrieve a list of all users in the system
+# -------------------------------------------------
 data "nutanix_users_v2" "list-users" {
-  depends_on = [nutanix_users_v2.active-user, nutanix_users_v2.inactive-user, nutanix_users_v2.ldap-user, nutanix_users_v2.saml-user]
+  depends_on = [
+    nutanix_users_v2.active-user,
+    nutanix_users_v2.inactive-user,
+    nutanix_users_v2.ldap-user,
+    nutanix_users_v2.saml-user
+  ]
 }
 
-# List all the users with a filter.
+# -------------------------------------------------
+# Retrieve a filtered list of users based on username
+# -------------------------------------------------
 data "nutanix_users_v2" "test" {
   filter = "username eq '${nutanix_users_v2.active-user.username}'"
 }
 
-# Get the details of a user.
+# -------------------------------------------------
+# Retrieve details of a specific user using ext_id
+# -------------------------------------------------
 data "nutanix_user_v2" "get-user" {
   ext_id = nutanix_users_v2.active-user.id
 }
 
-# Create Service Account
+# -------------------------------------------------
+# Create a Service Account user
+# -------------------------------------------------
 resource "nutanix_users_v2" "service_account" {
-  username = "service_account_terraform_example"
+  username    = "service_account_terraform_example"
   description = "service account tf"
-  email_id = "terraform_plugin@domain.com"
-  user_type = "SERVICE_ACCOUNT"
+  email_id    = "terraform_plugin@domain.com"
+  user_type   = "SERVICE_ACCOUNT"
 }
 
-# Get Service Account using the ext_id
+# -------------------------------------------------
+# Retrieve Service Account details using ext_id
+# -------------------------------------------------
 data "nutanix_user_v2" "get_service_account" {
-	ext_id = nutanix_users_v2.service_account.id
+  ext_id = nutanix_users_v2.service_account.id
 }
 
-# Get list of Service Accounts with Filter
+# -------------------------------------------------
+# Retrieve list of Service Accounts using a filter
+# -------------------------------------------------
 data "nutanix_users_v2" "list_service_account" {
-	filter = "userType eq Schema.Enums.UserType'SERVICE_ACCOUNT' and username contains '${nutanix_users_v2.service_account.username}'"
+  filter = "userType eq Schema.Enums.UserType'SERVICE_ACCOUNT' and username contains '${nutanix_users_v2.service_account.username}'"
 }

--- a/examples/users_v2/variables.tf
+++ b/examples/users_v2/variables.tf
@@ -11,3 +11,9 @@ variable "nutanix_endpoint" {
 variable "nutanix_port" {
   type = string
 }
+variable "ldap_idp_id" {
+  type = string
+}
+variable "sam_idp_id" {
+  type = string
+}

--- a/nutanix/services/iamv2/resource_nutanix_users_v2.go
+++ b/nutanix/services/iamv2/resource_nutanix_users_v2.go
@@ -101,9 +101,10 @@ func ResourceNutanixUserV2() *schema.Resource {
 				Computed: true,
 			},
 			"password": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:      schema.TypeString,
+				Optional:  true,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"force_reset_password": {
 				Type:     schema.TypeBool,
@@ -180,23 +181,19 @@ func ResourceNutanixUserV2() *schema.Resource {
 				},
 			},
 			"last_login_time": {
-				Type: schema.TypeString,
-				// Optional: true,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"created_time": {
-				Type: schema.TypeString,
-				// Optional: true,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"last_updated_time": {
-				Type: schema.TypeString,
-				// Optional: true,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"created_by": {
-				Type: schema.TypeString,
-				// Optional: true,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
@@ -397,7 +394,7 @@ func resourceNutanixUserV2Update(ctx context.Context, d *schema.ResourceData, me
 	updateSpec = &getUserResp
 
 	// validation on update spec
-	// Note: user read response has "" as default value for  middleInitial, emailId,
+	// Note: user read response has "" as default value for  middleInitial, emailId, displayName.
 	if updateSpec.MiddleInitial != nil && utils.StringValue(updateSpec.MiddleInitial) == "" {
 		updateSpec.MiddleInitial = nil
 	}
@@ -508,7 +505,14 @@ func resourceNutanixUserV2Update(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceNutanixUserV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return nil
+	log.Printf("[DEBUG] ResourceNutanixUserV2Delete : Delete not supported yet")
+	return diag.Diagnostics{
+		{
+			Severity: diag.Warning,
+			Summary:  "Delete operation not supported",
+			Detail:   "Deleting users via Terraform is not supported yet. Please delete the user manually from the Prism Central UI if required.",
+		},
+	}
 }
 
 func expandKVPair(pr []interface{}) []config.KVPair {

--- a/nutanix/services/iamv2/resource_nutanix_users_v2.go
+++ b/nutanix/services/iamv2/resource_nutanix_users_v2.go
@@ -510,7 +510,7 @@ func resourceNutanixUserV2Delete(ctx context.Context, d *schema.ResourceData, me
 		{
 			Severity: diag.Warning,
 			Summary:  "Delete operation not supported",
-			Detail:   "Deleting users via Terraform is not supported yet. Please delete the user manually from the Prism Central UI if required.",
+			Detail:   "Deleting users via Terraform is not supported yet. Please delete the user manually from the Prism Central UI if required, or use v3 resource for now",
 		},
 	}
 }

--- a/website/docs/r/users_v2.html.markdown
+++ b/website/docs/r/users_v2.html.markdown
@@ -20,7 +20,7 @@ resource "nutanix_users_v2" "user"{
   locale = "<locale>"
   region = "<region>"
   force_reset_password = <force_reset_password>
-  status = "<status>"  
+  status = "<status>"
 }
 
 # user_type of SERVICE_ACCOUNT
@@ -129,4 +129,16 @@ resource "nutanix_users_v2" "import_user" {}
 terraform import nutanix_users_v2.import_user <UUID>
 ```
 
+## Delete Behavior
+
+Deleting users via Terraform is **not currently supported** in `nutanix_users_v2`.
+If you attempt to delete a resource, Terraform will issue a **warning** and continue without removing the actual user in Prism Central.
+
+To delete a user, you must remove it manually via the **Prism Central UI**, or as a workaround, you can:
+
+1. **Import the user into the `nutanix_user` resource** (v3 API).
+2. Use Terraform to delete the user, as delete operations are supported in the v3 API.
+
+
+## References
 See detailed information in [Nutanix Users v4](https://developers.nutanix.com/api-reference?namespace=iam&version=v4.0#tag/Users/operation/createUser).


### PR DESCRIPTION
This PR enhances the `nutanix_users_v2` Terraform resource implementation and documentation to improve user experience and maintain consistency with API capabilities.

### Key Changes

- Delete Operation:

    -   Added a soft warning when attempting to delete a user, indicating that delete operations are not supported in the v4 API.
    -   Added corresponding documentation to clarify the delete behavior and provide a workaround using the `nutanix_user` (v3 API) resource.

- Documentation Improvements:
  - Updated nutanix_users_v2 docs to include a “Delete Behavior” section describing current limitations and available workarounds.
  - Added detailed docstrings to Terraform examples for LDAP and SAML users, explaining their purpose and required parameters.
  - Improved structure and readability of resource examples.

### Notes: 

- These updates are non-breaking and primarily focus on documentation and user experience.
- The delete warning provides clear guidance until delete support is available in the v4 API.