### PR TITLE
Move the go version to latest

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.25'
           check-latest: true  # Ensures the latest patch of Go 1.20 is installed
           cache: true  # Enables module caching
 

--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.25'
-          check-latest: true  # Ensures the latest patch of Go 1.20 is installed
+          check-latest: true  # Ensures the latest patch of Go 1.25 is installed
           cache: true  # Enables module caching
 
       - name: Verify Go Installation


### PR DESCRIPTION
```
0s
##[group***Run go mod tidy
go mod tidy**m
go mod vendor**m
shell: /usr/bin/bash -e ***
env:
  GOPATH: /home/ubuntu/go
  PATH: /home/ubuntu/go/bin:/home/ubuntu/go/bin:/home/ubuntu/actions-runner/_work/_tool/go/1.2***.14/x64/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
##[endgroup***
go: go.mod file indicates go 1.25, but maximum version supported by tidy is 1.2***
##[error***Process completed with exit code 1.
```