### PR TITLE
Add V1 to V2 Migration Guide Documentation changes, Change Log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 **Fixed Bugs:**
 - Add a clear documentation for cluster delete [\#977](https://github.com/nutanix/terraform-provider-nutanix/issues/977)
 - Show warning if cluster is not registered to the PC [\#974](https://github.com/nutanix/terraform-provider-nutanix/issues/974)
-- nutanix_clusters_v2 not returning associated categories [\#907](https://github.com/nutanix/terraform-provider-nutanix/issues/907)
 - Resource: nutanix_users_v2: Password exposed in state file, Show Warning in case of delete, Documentation changes for using users_v2 resource [\#949](https://github.com/nutanix/terraform-provider-nutanix/issues/949)
 - Resource: nutanix_users_v2: Can't change local user password [\#897](https://github.com/nutanix/terraform-provider-nutanix/issues/897)
 - Empty id attributes returned for Auth Policy, Roles [\#989](https://github.com/nutanix/terraform-provider-nutanix/issues/989)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 2.3. (July 17, 2025)
+[Full Changelog](https://github.com/nutanix/terraform-provider-nutanix/compare/v2.3.1...v2.3.2)
+
+**New Features:**
+- Ovas [\#852](https://github.com/nutanix/terraform-provider-nutanix/issues/852)
+- Password Manager [\#873](https://github.com/nutanix/terraform-provider-nutanix/issues/873)
+
+
+**Enhancements:**
+- Support of import for all V2 resources [\#988](https://github.com/nutanix/terraform-provider-nutanix/issues/988)
+- Project Association with VM for V2 resource [\#807](https://github.com/nutanix/terraform-provider-nutanix/issues/807)
+- Cluster Expansion using clusters_v2 resource [\#976](https://github.com/nutanix/terraform-provider-nutanix/issues/976)
+- Automatic Cluster Selection Support [\#903](https://github.com/nutanix/terraform-provider-nutanix/issues/903)
+- Support for object lite source in Images [\#990](https://github.com/nutanix/terraform-provider-nutanix/issues/990)
+
+
+**Fixed Bugs:**
+- Add a clear documentation for cluster delete [\#977](https://github.com/nutanix/terraform-provider-nutanix/issues/977)
+- Show warning if cluster is not registered to the PC [\#974](https://github.com/nutanix/terraform-provider-nutanix/issues/974)
+- nutanix_clusters_v2 not returning associated categories [\#907](https://github.com/nutanix/terraform-provider-nutanix/issues/907)
+- Resource: nutanix_users_v2: Password exposed in state file, Show Warning in case of delete, Documentation changes for using users_v2 resource [\#949](https://github.com/nutanix/terraform-provider-nutanix/issues/949)
+- Resource: nutanix_users_v2: Can't change local user password [\#897](https://github.com/nutanix/terraform-provider-nutanix/issues/897)
+- Empty id attributes returned for Auth Policy, Roles [\#989](https://github.com/nutanix/terraform-provider-nutanix/issues/989)
+- nutanix_user_groups_v2 empty ext_id in state file [\#899](https://github.com/nutanix/terraform-provider-nutanix/issues/899)
+
+
 ## 2.3.0 (July 17, 2025)
 [Full Changelog](https://github.com/nutanix/terraform-provider-nutanix/compare/v2.2.1...v2.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
-## 2.3. (July 17, 2025)
+## 2.3.2 (November 3, 2025)
 [Full Changelog](https://github.com/nutanix/terraform-provider-nutanix/compare/v2.3.1...v2.3.2)
 
 **New Features:**
 - Ovas [\#852](https://github.com/nutanix/terraform-provider-nutanix/issues/852)
 - Password Manager [\#873](https://github.com/nutanix/terraform-provider-nutanix/issues/873)
-
 
 **Enhancements:**
 - Support of import for all V2 resources [\#988](https://github.com/nutanix/terraform-provider-nutanix/issues/988)
@@ -12,7 +11,6 @@
 - Cluster Expansion using clusters_v2 resource [\#976](https://github.com/nutanix/terraform-provider-nutanix/issues/976)
 - Automatic Cluster Selection Support [\#903](https://github.com/nutanix/terraform-provider-nutanix/issues/903)
 - Support for object lite source in Images [\#990](https://github.com/nutanix/terraform-provider-nutanix/issues/990)
-
 
 **Fixed Bugs:**
 - Add a clear documentation for cluster delete [\#977](https://github.com/nutanix/terraform-provider-nutanix/issues/977)
@@ -22,6 +20,10 @@
 - Resource: nutanix_users_v2: Can't change local user password [\#897](https://github.com/nutanix/terraform-provider-nutanix/issues/897)
 - Empty id attributes returned for Auth Policy, Roles [\#989](https://github.com/nutanix/terraform-provider-nutanix/issues/989)
 - nutanix_user_groups_v2 empty ext_id in state file [\#899](https://github.com/nutanix/terraform-provider-nutanix/issues/899)
+- Resource: nutanix_user_key_v2: User should be able to create User Key of OBJECT KEY type [\#996](https://github.com/nutanix/terraform-provider-nutanix/issues/996)
+- Creation of a floating IP fails when specifying the desired IP address. Ok if not specify the desired IP [\#939](https://github.com/nutanix/terraform-provider-nutanix/issues/939)
+- nutanix_network_security_policy_v2 error: The terraform-provider-nutanix_v2.3.1 plugin crashed! [\#935](https://github.com/nutanix/terraform-provider-nutanix/issues/935)
+- nutanix_volume_group_disk_v2 encounters panic when updating disk_size_bytes [\#866](https://github.com/nutanix/terraform-provider-nutanix/issues/886)
 
 
 ## 2.3.0 (July 17, 2025)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Terraform provider plugin to integrate with Nutanix Cloud Platform.
 
-NOTE: The latest version of the Nutanix provider is [v2.3.0](https://github.com/nutanix/terraform-provider-nutanix/releases/tag/v2.3.0).
+NOTE: The latest version of the Nutanix provider is [v2.3.2](https://github.com/nutanix/terraform-provider-nutanix/releases/tag/v2.3.2).
 
 Modules based on Terraform Nutanix Provider can be found here : [Modules](https://github.com/nutanix/terraform-provider-nutanix/tree/master/modules)
 
@@ -22,18 +22,34 @@ Modules based on Terraform Nutanix Provider can be found here : [Modules](https:
 * [Go](https://golang.org/doc/install) 1.17+ (to build the provider plugin)
 * This provider uses [SDKv2](https://www.terraform.io/plugin/sdkv2/sdkv2-intro) from release 1.3.0
 
-## Introducing Nutanix Terraform Provider Version v2.3.0
+## Introducing Nutanix Terraform Provider Version v2.3.2
 
 We're excited to announce the release of Nutanix Terraform Provider Version 2.3.0! This major update brings new features for automating your Nutanix infrastructure.
 
-### What's New in v2.3.0
+### What's New in v2.3.2
 
 - **Built on v4.1 APIs/SDKs**  
   This release is built on the latest Nutanix v4 APIs and SDKs, providing improved performance, stability, and alignment with the newest platform capabilities.
 
 - **New Resource Support**
-  - **Objects**: Automate Nutanix Objects (S3-compatible storage) management for scalable storage use cases.
-  - **Service Accounts**: Manage service accounts directly through Terraform.
+  - **Password Manager**: Provides the ability to manage system user passwords
+  - **OVAs**: Enables the creation and management of OVAs.
+  - **Project Association with VM for V2 resource**: Associate Project with Virtual Machine V2 resource.
+  - **Automatic Cluster Selection**: Automatic cluster selection support.
+  - **Support for object lite source**: Support for lite source in terraform for images and object store modules.
+
+- **Enhancements**
+  - **Project Association with VM for V2 resource**: Associate Project with Virtual Machine V2 resource.
+  - **Automatic Cluster Selection**: Automatic cluster selection support.
+  - **Support for object lite source**: Support for lite source in terraform for images and object store modules.
+  - **the nutanix_cluster_v2 resource now fully supports cluster expansion operations**, including adding and removing nodes. This enhancement eliminates the need for a separate nutanix_cluster_add_node_v2 resource.
+  - **Import support is now available for V2 resources**, This enhancement allows users to seamlessly bring existing Nutanix entities under Terraform management, **without recreating them**. List of resources we support the import for,
+        - **nutanix_vpc_v2**
+        - **nutanix_routes_v2**
+        - **nutanix_roles_v2**
+        - **nutanix_authorization_policy_v2**
+        - **nutanix_category_v2**
+        - **nutanix_subnets_v2**
 
 ---
 
@@ -45,12 +61,13 @@ The provider is used to interact with the many resources and data sources suppor
 - Self Service version: 4.2.0 (Required only for running Self Service based resource and data source)
 - AOS Version: 7.3 or later
 - Prism Central Version: pc 7.3 or later
-- Nutanix Terraform Provider Version: 2.3.0
+- Nutanix Terraform Provider Version: 2.3.2
 
 
 ## Compatibility Matrix
 | Terraform Version |  AOS Version | PC version  | Other software versions | Supported |
 |  :--- |  :--- | :--- | :--- | :--- |
+| 2.3.2 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.0 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.2.1 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
 | 2.2.0 | | | Self Service v4.1.0 | yes | 

--- a/README.md
+++ b/README.md
@@ -39,15 +39,8 @@ We're excited to announce the release of Nutanix Terraform Provider Version 2.3.
   - **Project Association with VM for V2 resource**: Associate Project with Virtual Machine V2 resource.
   - **Automatic Cluster Selection**: Automatic cluster selection support.
   - **Support for object lite source**: Support for lite source in terraform for images and object store modules.
-  - **the nutanix_cluster_v2 resource now fully supports cluster expansion operations**, including adding and removing nodes. This enhancement eliminates the need for a separate nutanix_cluster_add_node_v2 resource.
-  - **Import support is now available for V2 resources**, This enhancement allows users to seamlessly bring existing Nutanix entities under Terraform management, **without recreating them**. List of resources we support the import for,
-        - **nutanix_vpc_v2**
-        - **nutanix_routes_v2**
-        - **nutanix_roles_v2**
-        - **nutanix_authorization_policy_v2**
-        - **nutanix_category_v2**
-        - **nutanix_subnet_v2**
-
+  - **nutanix_cluster_v2 resource now fully supports cluster expansion operations**, including adding and removing nodes. This enhancement eliminates the need for a separate nutanix_cluster_add_node_v2 resource.
+  - **Import support is now available for V2 resources**, This enhancement allows users to seamlessly bring existing Nutanix entities under Terraform management(using V2 resources which uses V4 API SDK's), **without recreating them**.
 ---
 
 Upgrade now to take advantage of these powerful features and streamline your Nutanix automation workflows!
@@ -66,6 +59,8 @@ The provider is used to interact with the many resources and data sources suppor
 |  :--- |  :--- | :--- | :--- | :--- |
 | 2.3.2 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.0 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
+| 2.2.3 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
+| 2.2.2 (⚠️ Deprecated/Invalid) | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
 | 2.2.1 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
 | 2.2.0 | | | Self Service v4.1.0 | yes | 
 | 2.1.1 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The provider is used to interact with the many resources and data sources suppor
 | Terraform Version |  AOS Version | PC version  | Other software versions | Supported |
 |  :--- |  :--- | :--- | :--- | :--- |
 | 2.3.2 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
+| 2.3.1 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.0 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.2.3 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
 | 2.2.2 (⚠️ Deprecated/Invalid) | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ We're excited to announce the release of Nutanix Terraform Provider Version 2.3.
   - **Support for object lite source**: Support for lite source in terraform for images and object store modules.
   - **nutanix_cluster_v2 resource now fully supports cluster expansion operations**, including adding and removing nodes. This enhancement eliminates the need for a separate nutanix_cluster_add_node_v2 resource.
   - **Import support is now available for V2 resources**, This enhancement allows users to seamlessly bring existing Nutanix entities under Terraform management(using V2 resources which uses V4 API SDK's), **without recreating them**.
+
+- **Fixed Bugs:**
+  - Add a clear documentation for cluster delete [\#977](https://github.com/nutanix/terraform-provider-nutanix/issues/977)
+  - Show warning if cluster is not registered to the PC [\#974](https://github.com/nutanix/terraform-provider-nutanix/issues/974)
+  - Resource: nutanix_users_v2: Password exposed in state file, Show Warning in case of delete, Documentation changes for using users_v2 resource [\#949](https://github.com/nutanix/terraform-provider-nutanix/issues/949)
+  - Resource: nutanix_users_v2: Can't change local user password [\#897](https://github.com/nutanix/terraform-provider-nutanix/issues/897)
+  - Empty id attributes returned for Auth Policy, Roles [\#989](https://github.com/nutanix/terraform-provider-nutanix/issues/989)
+  - nutanix_user_groups_v2 empty ext_id in state file [\#899](https://github.com/nutanix/terraform-provider-nutanix/issues/899)
+  - Resource: nutanix_user_key_v2: User should be able to create User Key of OBJECT KEY type [\#996](https://github.com/nutanix/terraform-provider-nutanix/issues/996)
+  - Creation of a floating IP fails when specifying the desired IP address. Ok if not specify the desired IP [\#939](https://github.com/nutanix/terraform-provider-nutanix/issues/939)
+  - nutanix_network_security_policy_v2 error: The terraform-provider-nutanix_v2.3.1 plugin crashed! [\#935](https://github.com/nutanix/terraform-provider-nutanix/issues/935)
+  - nutanix_volume_group_disk_v2 encounters panic when updating disk_size_bytes [\#866](https://github.com/nutanix/terraform-provider-nutanix/issues/886)
 ---
 
 Upgrade now to take advantage of these powerful features and streamline your Nutanix automation workflows!

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Modules based on Terraform Nutanix Provider can be found here : [Modules](https:
 
 ## Introducing Nutanix Terraform Provider Version v2.3.2
 
-We're excited to announce the release of Nutanix Terraform Provider Version 2.3.0! This major update brings new features for automating your Nutanix infrastructure.
+We're excited to announce the release of Nutanix Terraform Provider Version 2.3.2! This major update brings new features for automating your Nutanix infrastructure.
 
 ### What's New in v2.3.2
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We're excited to announce the release of Nutanix Terraform Provider Version 2.3.
 
 ### What's New in v2.3.2
 
-- **Built on v4.1 APIs/SDKs**  
+- **Built on v4.1 APIs/SDKs**
   This release is built on the latest Nutanix v4 APIs and SDKs, providing improved performance, stability, and alignment with the newest platform capabilities.
 
 - **New Resource Support**
@@ -67,7 +67,7 @@ The provider is used to interact with the many resources and data sources suppor
 | 2.3.2 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.0 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.2.1 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
-| 2.2.0 | | | Self Service v4.1.0 | yes | 
+| 2.2.0 | | | Self Service v4.1.0 | yes |
 | 2.1.1 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
 | 2.1.0 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
 | 2.0.0 | 7.0 | pc2024.3 or later  | ndb v2.7, nke v2.8, foundation v5.7 | Yes |
@@ -188,6 +188,9 @@ From foundation getting released in 1.5.0-beta, provider configuration will acco
 | nutanix_image |nutanix_images_v2 |
 | - | nutanix_image_placement_policy_v2 |
 | nutanix_virtual_machine | nutanix_virtual_machine_v2 |
+| - | nutanix_ova_v2 |
+| - | nutanix_ova_vm_deploy_v2 |
+| - | nutanix_ova_download_v2 |
 | - | nutanix_vm_clone_v2 |
 | - | nutanix_vm_cdrom_insert_eject_v2 |
 | - | nutanix_vm_shutdown_action_v2 |
@@ -268,6 +271,7 @@ From foundation getting released in 1.5.0-beta, provider configuration will acco
 | - | nutanix_user_key_revoke_v2 |
 | - | nutanix_object_store_v2 |
 | - | nutanix_object_store_certificate_v2 |
+| - | nutanix_password_change_request_v2 |
 
 
 
@@ -313,6 +317,8 @@ From foundation getting released in 1.5.0-beta, provider configuration will acco
 | - | nutanix_images_v2 |
 | nutanix_virtual_machine | nutanix_virtual_machine_v2 |
 | - | nutanix_virtual_machines_v2 |
+| - | nutanix_ova_v2 |
+| - | nutanix_ovas_v2 |
 | - | nutanix_template_v2 |
 | - | nutanix_templates_v2 |
 | - | nutanix_ngt_configuration_v2 |
@@ -404,10 +410,11 @@ From foundation getting released in 1.5.0-beta, provider configuration will acco
 | - | nutanix_object_stores_v2 |
 | - | nutanix_certificate_v2 |
 | - | nutanix_certificates_v2 |
+| - | nutanix_system_user_passwords_v2 |
 
 
 
-## Developing the provider 
+## Developing the provider
 
 The Nutanix Provider for Terraform is the work of many contributors. We appreciate your help!
 
@@ -419,7 +426,7 @@ The Nutanix Provider for Terraform is the work of many contributors. We apprecia
 
 -> **Note:** We now have a brand new developer-centric Support Program designed for organizations that require a deeper level of developer support to manage their Nutanix environment and build applications quickly and efficiently. As part of this new Advanced API/SDK Support Program, you will get access to trusted technical advisors who specialize in developer tools including Nutanix Terraform Provider and receive support for your unique development needs and custom integration queries. Visit our Support Portal - [Premium Add-On Support Programs](https://www.nutanix.com/support-services/product-support/premium-support-programs) to learn more about this program.
 
-Customers not taking advantage of the  Advanced API/SDK Support Program will continue to receive the support through our standard, community-supported model. This community model also provides support for contributions to the open-sourceNutanix Terraform Provider repository .Visit https://portal.nutanix.com/kb/13424   for more details. 
+Customers not taking advantage of the  Advanced API/SDK Support Program will continue to receive the support through our standard, community-supported model. This community model also provides support for contributions to the open-sourceNutanix Terraform Provider repository .Visit https://portal.nutanix.com/kb/13424   for more details.
 
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ We're excited to announce the release of Nutanix Terraform Provider Version 2.3.
 - **New Resource Support**
   - **Password Manager**: Provides the ability to manage system user passwords
   - **OVAs**: Enables the creation and management of OVAs.
-  - **Project Association with VM for V2 resource**: Associate Project with Virtual Machine V2 resource.
-  - **Automatic Cluster Selection**: Automatic cluster selection support.
-  - **Support for object lite source**: Support for lite source in terraform for images and object store modules.
 
 - **Enhancements**
   - **Project Association with VM for V2 resource**: Associate Project with Virtual Machine V2 resource.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ We're excited to announce the release of Nutanix Terraform Provider Version 2.3.
         - **nutanix_roles_v2**
         - **nutanix_authorization_policy_v2**
         - **nutanix_category_v2**
-        - **nutanix_subnets_v2**
+        - **nutanix_subnet_v2**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ We're excited to announce the release of Nutanix Terraform Provider Version 2.3.
   This release is built on the latest Nutanix v4 APIs and SDKs, providing improved performance, stability, and alignment with the newest platform capabilities.
 
 - **New Resource Support**
-  - **Password Manager**: Provides the ability to manage system user passwords
   - **OVAs**: Enables the creation and management of OVAs.
+  - **Password Manager**: Provides the ability to manage system user passwords
 
 - **Enhancements**
   - **Project Association with VM for V2 resource**: Associate Project with Virtual Machine V2 resource.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -25,7 +25,6 @@ We're excited to announce the release of Nutanix Terraform Provider Version 2.3.
 - **New Resource Support**
   - **OVAs**: Enables the creation and management of OVAs.
   - **Password Manager**: Provides the ability to manage system user passwords
-  
 
 - **Enhancements**
   - **Project Association with VM for V2 resource**: Associate Project with Virtual Machine V2 resource.
@@ -33,6 +32,18 @@ We're excited to announce the release of Nutanix Terraform Provider Version 2.3.
   - **Support for object lite source**: Support for lite source in terraform for images and object store modules.
   - **nutanix_cluster_v2 resource now fully supports cluster expansion operations**, including adding and removing nodes. This enhancement eliminates the need for a separate nutanix_cluster_add_node_v2 resource.
   - **Import support is now available for V2 resources**, This enhancement allows users to seamlessly bring existing Nutanix entities under Terraform management(using V2 resources which uses V4 API SDK's), **without recreating them**.
+
+- **Fixed Bugs:**
+  - Add a clear documentation for cluster delete [\#977](https://github.com/nutanix/terraform-provider-nutanix/issues/977)
+  - Show warning if cluster is not registered to the PC [\#974](https://github.com/nutanix/terraform-provider-nutanix/issues/974)
+  - Resource: nutanix_users_v2: Password exposed in state file, Show Warning in case of delete, Documentation changes for using users_v2 resource [\#949](https://github.com/nutanix/terraform-provider-nutanix/issues/949)
+  - Resource: nutanix_users_v2: Can't change local user password [\#897](https://github.com/nutanix/terraform-provider-nutanix/issues/897)
+  - Empty id attributes returned for Auth Policy, Roles [\#989](https://github.com/nutanix/terraform-provider-nutanix/issues/989)
+  - nutanix_user_groups_v2 empty ext_id in state file [\#899](https://github.com/nutanix/terraform-provider-nutanix/issues/899)
+  - Resource: nutanix_user_key_v2: User should be able to create User Key of OBJECT KEY type [\#996](https://github.com/nutanix/terraform-provider-nutanix/issues/996)
+  - Creation of a floating IP fails when specifying the desired IP address. Ok if not specify the desired IP [\#939](https://github.com/nutanix/terraform-provider-nutanix/issues/939)
+  - nutanix_network_security_policy_v2 error: The terraform-provider-nutanix_v2.3.1 plugin crashed! [\#935](https://github.com/nutanix/terraform-provider-nutanix/issues/935)
+  - nutanix_volume_group_disk_v2 encounters panic when updating disk_size_bytes [\#866](https://github.com/nutanix/terraform-provider-nutanix/issues/886)
 
 
 ~> **Important Notice:** Upcoming Deprecation of Legacy Nutanix Terraform Provider Resources. Starting with the Nutanix Terraform Provider release planned for Q4-CY2026, legacy resources which are based on v0.8,v1,v2 and v3 APIs will be deprecated and no longer supported. For more information, visit [Legacy API Deprecation Announcement](https://portal.nutanix.com/page/documents/eol/list?type=announcement) [Legacy API Deprecation - FAQs](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA0VO0000005rgP0AQ). Nutanix strongly encourages you to migrate your scripts and applications to the latest v2 version of the Nutanix Terraform Provider resources, which are built on our v4 APIs/SDKs. By adopting the latest v2 version based on v4 APIs and SDKs, our users can leverage the enhanced capabilities and latest innovations from Nutanix. We understand that this transition may require some effort, and we are committed to supporting you throughout the process. Please refer to our documentation and support channels for guidance and assistance.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -23,8 +23,9 @@ We're excited to announce the release of Nutanix Terraform Provider Version 2.3.
   This release is built on the latest Nutanix v4 APIs and SDKs, providing improved performance, stability, and alignment with the newest platform capabilities.
 
 - **New Resource Support**
-  - **Password Manager**: Provides the ability to manage system user passwords
   - **OVAs**: Enables the creation and management of OVAs.
+  - **Password Manager**: Provides the ability to manage system user passwords
+  
 
 - **Enhancements**
   - **Project Association with VM for V2 resource**: Associate Project with Virtual Machine V2 resource.
@@ -32,6 +33,7 @@ We're excited to announce the release of Nutanix Terraform Provider Version 2.3.
   - **Support for object lite source**: Support for lite source in terraform for images and object store modules.
   - **nutanix_cluster_v2 resource now fully supports cluster expansion operations**, including adding and removing nodes. This enhancement eliminates the need for a separate nutanix_cluster_add_node_v2 resource.
   - **Import support is now available for V2 resources**, This enhancement allows users to seamlessly bring existing Nutanix entities under Terraform management(using V2 resources which uses V4 API SDK's), **without recreating them**.
+
 
 ~> **Important Notice:** Upcoming Deprecation of Legacy Nutanix Terraform Provider Resources. Starting with the Nutanix Terraform Provider release planned for Q4-CY2026, legacy resources which are based on v0.8,v1,v2 and v3 APIs will be deprecated and no longer supported. For more information, visit [Legacy API Deprecation Announcement](https://portal.nutanix.com/page/documents/eol/list?type=announcement) [Legacy API Deprecation - FAQs](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA0VO0000005rgP0AQ). Nutanix strongly encourages you to migrate your scripts and applications to the latest v2 version of the Nutanix Terraform Provider resources, which are built on our v4 APIs/SDKs. By adopting the latest v2 version based on v4 APIs and SDKs, our users can leverage the enhanced capabilities and latest innovations from Nutanix. We understand that this transition may require some effort, and we are committed to supporting you throughout the process. Please refer to our documentation and support channels for guidance and assistance.
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -37,7 +37,7 @@ We're excited to announce the release of Nutanix Terraform Provider Version 2.3.
         - **nutanix_roles_v2**
         - **nutanix_authorization_policy_v2**
         - **nutanix_category_v2**
-        - **nutanix_subnets_v2**
+        - **nutanix_subnet_v2**
 
 ~> **Important Notice:** Upcoming Deprecation of Legacy Nutanix Terraform Provider Resources. Starting with the Nutanix Terraform Provider release planned for Q4-CY2026, legacy resources which are based on v0.8,v1,v2 and v3 APIs will be deprecated and no longer supported. For more information, visit [Legacy API Deprecation Announcement](https://portal.nutanix.com/page/documents/eol/list?type=announcement) [Legacy API Deprecation - FAQs](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA0VO0000005rgP0AQ). Nutanix strongly encourages you to migrate your scripts and applications to the latest v2 version of the Nutanix Terraform Provider resources, which are built on our v4 APIs/SDKs. By adopting the latest v2 version based on v4 APIs and SDKs, our users can leverage the enhanced capabilities and latest innovations from Nutanix. We understand that this transition may require some effort, and we are committed to supporting you throughout the process. Please refer to our documentation and support channels for guidance and assistance.
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -13,19 +13,31 @@ The provider is used to interact with the many resources and data sources suppor
 Use the navigation on the left to read about the available resources and data sources this provider can use.
 
 
-## Introducing Nutanix Terraform Provider Version v2.3.0
+## Introducing Nutanix Terraform Provider Version v2.3.2
 
 We're excited to announce the release of Nutanix Terraform Provider Version 2.3.0! This major update brings new features for automating your Nutanix infrastructure.
 
-### What's New in v2.3.0
+### What's New in v2.3.2
 
 - **Built on v4.1 APIs/SDKs**  
   This release is built on the latest Nutanix v4 APIs and SDKs, providing improved performance, stability, and alignment with the newest platform capabilities.
 
 - **New Resource Support**
-  - **Objects**: Automate Nutanix Objects (S3-compatible storage) management for scalable storage use cases.
-  - **Service Accounts**: Manage service accounts directly through Terraform.
+  - **Password Manager**: Provides the ability to manage system user passwords
+  - **OVAs**: Enables the creation and management of OVAs.
 
+- **Enhancements**
+  - **Project Association with VM for V2 resource**: Associate Project with Virtual Machine V2 resource.
+  - **Automatic Cluster Selection**: Automatic cluster selection support.
+  - **Support for object lite source**: Support for lite source in terraform for images and object store modules.
+  - **the nutanix_cluster_v2 resource now fully supports cluster expansion operations**, including adding and removing nodes. This enhancement eliminates the need for a separate nutanix_cluster_add_node_v2 resource.
+  - **Import support is now available for V2 resources**, This enhancement allows users to seamlessly bring existing Nutanix entities under Terraform management, **without recreating them**. List of resources we support the import for,
+        - **nutanix_vpc_v2**
+        - **nutanix_routes_v2**
+        - **nutanix_roles_v2**
+        - **nutanix_authorization_policy_v2**
+        - **nutanix_category_v2**
+        - **nutanix_subnets_v2**
 
 ~> **Important Notice:** Upcoming Deprecation of Legacy Nutanix Terraform Provider Resources. Starting with the Nutanix Terraform Provider release planned for Q4-CY2026, legacy resources which are based on v0.8,v1,v2 and v3 APIs will be deprecated and no longer supported. For more information, visit [Legacy API Deprecation Announcement](https://portal.nutanix.com/page/documents/eol/list?type=announcement) [Legacy API Deprecation - FAQs](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA0VO0000005rgP0AQ). Nutanix strongly encourages you to migrate your scripts and applications to the latest v2 version of the Nutanix Terraform Provider resources, which are built on our v4 APIs/SDKs. By adopting the latest v2 version based on v4 APIs and SDKs, our users can leverage the enhanced capabilities and latest innovations from Nutanix. We understand that this transition may require some effort, and we are committed to supporting you throughout the process. Please refer to our documentation and support channels for guidance and assistance.
 
@@ -38,6 +50,7 @@ Customers not taking advantage of the  Advanced API/SDK Support Program will con
 ## Compatibility Matrix
 | Terraform Version |  AOS Version | PC version  | Other software versions | Supported |
 |  :--- |  :--- | :--- | :--- | :--- |
+| 2.3.2 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.0 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.2.1 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
 | 2.2.0 | | | Self Service  v4.1.0 | yes | 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -30,14 +30,8 @@ We're excited to announce the release of Nutanix Terraform Provider Version 2.3.
   - **Project Association with VM for V2 resource**: Associate Project with Virtual Machine V2 resource.
   - **Automatic Cluster Selection**: Automatic cluster selection support.
   - **Support for object lite source**: Support for lite source in terraform for images and object store modules.
-  - **the nutanix_cluster_v2 resource now fully supports cluster expansion operations**, including adding and removing nodes. This enhancement eliminates the need for a separate nutanix_cluster_add_node_v2 resource.
-  - **Import support is now available for V2 resources**, This enhancement allows users to seamlessly bring existing Nutanix entities under Terraform management, **without recreating them**. List of resources we support the import for,
-        - **nutanix_vpc_v2**
-        - **nutanix_routes_v2**
-        - **nutanix_roles_v2**
-        - **nutanix_authorization_policy_v2**
-        - **nutanix_category_v2**
-        - **nutanix_subnet_v2**
+  - **nutanix_cluster_v2 resource now fully supports cluster expansion operations**, including adding and removing nodes. This enhancement eliminates the need for a separate nutanix_cluster_add_node_v2 resource.
+  - **Import support is now available for V2 resources**, This enhancement allows users to seamlessly bring existing Nutanix entities under Terraform management(using V2 resources which uses V4 API SDK's), **without recreating them**.
 
 ~> **Important Notice:** Upcoming Deprecation of Legacy Nutanix Terraform Provider Resources. Starting with the Nutanix Terraform Provider release planned for Q4-CY2026, legacy resources which are based on v0.8,v1,v2 and v3 APIs will be deprecated and no longer supported. For more information, visit [Legacy API Deprecation Announcement](https://portal.nutanix.com/page/documents/eol/list?type=announcement) [Legacy API Deprecation - FAQs](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA0VO0000005rgP0AQ). Nutanix strongly encourages you to migrate your scripts and applications to the latest v2 version of the Nutanix Terraform Provider resources, which are built on our v4 APIs/SDKs. By adopting the latest v2 version based on v4 APIs and SDKs, our users can leverage the enhanced capabilities and latest innovations from Nutanix. We understand that this transition may require some effort, and we are committed to supporting you throughout the process. Please refer to our documentation and support channels for guidance and assistance.
 
@@ -52,6 +46,8 @@ Customers not taking advantage of the  Advanced API/SDK Support Program will con
 |  :--- |  :--- | :--- | :--- | :--- |
 | 2.3.2 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.0 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
+| 2.2.3 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
+| 2.2.2 (⚠️ Deprecated/Invalid) | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
 | 2.2.1 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
 | 2.2.0 | | | Self Service  v4.1.0 | yes | 
 | 2.1.1 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -15,7 +15,7 @@ Use the navigation on the left to read about the available resources and data so
 
 ## Introducing Nutanix Terraform Provider Version v2.3.2
 
-We're excited to announce the release of Nutanix Terraform Provider Version 2.3.0! This major update brings new features for automating your Nutanix infrastructure.
+We're excited to announce the release of Nutanix Terraform Provider Version 2.3.2! This major update brings new features for automating your Nutanix infrastructure.
 
 ### What's New in v2.3.2
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -45,6 +45,7 @@ Customers not taking advantage of the  Advanced API/SDK Support Program will con
 | Terraform Version |  AOS Version | PC version  | Other software versions | Supported |
 |  :--- |  :--- | :--- | :--- | :--- |
 | 2.3.2 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
+| 2.3.1 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.0 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.2.3 | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
 | 2.2.2 (⚠️ Deprecated/Invalid) | 7.0.1, 7.0 | pc2024.3, pc2024.3.1 or later | | yes |
@@ -92,6 +93,9 @@ Customers not taking advantage of the  Advanced API/SDK Support Program will con
 | nutanix_image |nutanix_images_v2 |
 | - | nutanix_image_placement_policy_v2 |
 | nutanix_virtual_machine | nutanix_virtual_machine_v2 |
+| - | nutanix_ova_v2 |
+| - | nutanix_ova_vm_deploy_v2 |
+| - | nutanix_ova_download_v2 |
 | - | nutanix_vm_clone_v2 |
 | - | nutanix_vm_cdrom_insert_eject_v2 |
 | - | nutanix_vm_shutdown_action_v2 |
@@ -172,7 +176,7 @@ Customers not taking advantage of the  Advanced API/SDK Support Program will con
 | - | nutanix_user_key_revoke_v2 |
 | - | nutanix_object_store_v2 |
 | - | nutanix_object_store_certificate_v2 |
-
+| - | nutanix_password_change_request_v2 |
 
 ## Data Sources
 
@@ -216,6 +220,8 @@ Customers not taking advantage of the  Advanced API/SDK Support Program will con
 | - | nutanix_images_v2 |
 | nutanix_virtual_machine | nutanix_virtual_machine_v2 |
 | - | nutanix_virtual_machines_v2 |
+| - | nutanix_ova_v2 |
+| - | nutanix_ovas_v2 |
 | - | nutanix_template_v2 |
 | - | nutanix_templates_v2 |
 | - | nutanix_ngt_configuration_v2 |
@@ -307,6 +313,7 @@ Customers not taking advantage of the  Advanced API/SDK Support Program will con
 | - | nutanix_object_stores_v2 |
 | - | nutanix_certificate_v2 |
 | - | nutanix_certificates_v2 |
+| - | nutanix_system_user_passwords_v2 |
 
 ## Example Usage
 

--- a/website/docs/r/Guides/v1_to_v2_migration_guide.html.markdown
+++ b/website/docs/r/Guides/v1_to_v2_migration_guide.html.markdown
@@ -43,10 +43,7 @@ resource "nutanix_virtual_machine" "dev_vm" {
 Add a corresponding v2 resource configuration to your Terraform file:
 
 ```hcl
-resource "nutanix_virtual_machine_v2" "import_dev_vm" {
-  # Configuration will be imported from existing resource
-  # You can add minimal required attributes if needed
-}
+resource "nutanix_virtual_machine_v2" "import_dev_vm" {}
 ```
 
 ~> **Note:** At this stage, you only need to declare the resource block.
@@ -105,6 +102,7 @@ Once you've verified the import is successful, remove the v1 resource configurat
 2. **Remove the v1 resource from Terraform state:**
    
    ```bash
+   # terraform state rm <RESOURCE_TYPE>.<RESOURCE_NAME> <UUID_OF_ENTITY>
    terraform state rm nutanix_virtual_machine.dev_vm
    ```
 
@@ -232,6 +230,7 @@ Once you've verified that all imports are successful, remove the v1 resource con
    Remove v1 resource managed by the module from Terraform state:
    
    ```bash
+   # terraform import <MODULE_INSTANCE_NAME>.<RESOURCE_TYPE>.<RESOURCE_NAME> <UUID_OF_ENTITY>
    terraform state rm module.vm_module.nutanix_virtual_machine.vm
    ```
 ~> **Important:** Ensure all v2 resource imports were successful (verified in Step 6) before removing the v1 module resources from state. Once removed, the v1 resources will no longer be managed by Terraform.

--- a/website/docs/r/Guides/v1_to_v2_migration_guide.html.markdown
+++ b/website/docs/r/Guides/v1_to_v2_migration_guide.html.markdown
@@ -1,0 +1,302 @@
+---
+layout: "nutanix"
+page_title: "Migration Guide: V1 to V2 Resources"
+sidebar_current: "docs-nutanix-migration-v1-to-v2"
+description: |-
+  This guide provides step-by-step instructions for migrating from Nutanix Terraform Provider v1 resources to v2 resources, which are built on v4 APIs/SDKs.
+---
+
+# Migration Guide: V1 to V2 Resources
+
+This guide walks you through the process of migrating your existing Terraform-managed infrastructure from Nutanix Provider v1 resources to v2 resources. The v2 resources are built on Nutanix v4 APIs/SDKs and provide enhanced capabilities and improved performance.
+
+~> **Important Notice:** Nutanix strongly encourages migrating to v2 resources built on v4 APIs/SDKs.
+
+## Overview
+
+The migration process involves:
+1. Adding v2 resource configurations alongside existing v1 resources.
+2. Importing existing infrastructure into v2 resource state using entity UUID.
+3. Removing v1 resource configurations.
+4. Managing resources using v2 modules going forward.
+
+This process allows you to migrate without recreating or disrupting your existing infrastructure.
+
+This guide covers migration for:
+- **Resources:** Individual Terraform resources
+- **Modules:** Terraform modules that use v1 resources internally
+
+## Resource Migration
+
+### Step 1: Identify Your V1 Resources
+
+First, identify the v1 resources you want to migrate. For example, if you have a virtual machine created using the v1 module:
+
+```hcl
+resource "nutanix_virtual_machine" "dev_vm" {
+  name = "dev_vm"
+  # ... other configuration
+}
+```
+
+### Step 2: Add V2 Resource Configuration
+
+Add a corresponding v2 resource configuration to your Terraform file:
+
+```hcl
+resource "nutanix_virtual_machine_v2" "import_dev_vm" {
+  # Configuration will be imported from existing resource
+  # You can add minimal required attributes if needed
+}
+```
+
+~> **Note:** At this stage, you only need to declare the resource block.
+
+### Step 3: Get the UUID of the Existing Resource
+
+Retrieve the UUID of the resource created with the v1 module using Terraform state:
+
+```bash
+terraform state show nutanix_virtual_machine.dev_vm
+```
+
+Look for the `id` or `uuid` field in the output.
+
+### Step 4: Import the Resource into V2 State
+
+Execute the terraform import command to import the existing resource into the v2 resource state:
+
+```bash
+terraform import nutanix_virtual_machine_v2.import_dev_vm <UUID_OF_ENTITY>
+```
+
+~> **Note:** Replace `UUID_OF_ENTITY` with the actual UUID obtained from Step 3.
+
+### Step 5: Verify Import is Successful
+
+Verify that the resource has been imported successfully by listing all resources in the Terraform state:
+
+```bash
+terraform state list
+```
+You should now see both the v1 and v2 resources in the state:
+```
+nutanix_virtual_machine.dev_vm
+nutanix_virtual_machine_v2.import_dev_vm
+```
+This confirms that the import was successful and both resources are now tracked in your Terraform state.
+
+
+### Step 6: Remove the V1 Resource Config and Remove it from State
+
+Once you've verified the import is successful, remove the v1 resource configuration and state:
+
+1. **Remove the v1 resource from your Terraform configuration file:**
+   
+   Delete or comment out the v1 resource block:
+   
+   ```hcl
+   # resource "nutanix_virtual_machine" "dev_vm" {
+   #   name = "dev_vm"
+   #   # ... other configuration
+   # }
+   ```
+
+2. **Remove the v1 resource from Terraform state:**
+   
+   ```bash
+   terraform state rm nutanix_virtual_machine.dev_vm
+   ```
+
+~> **Important:** Ensure the v2 resource import was successful (verified in Step 5) before removing the v1 resource from state. Once removed, the v1 resource will no longer be managed by Terraform.
+
+### Step 7: Use V2 Resources from Now On
+
+Congratulations! Your migration is complete. From now on, you can manage the imported resource using the v2 module:
+
+```hcl
+resource "nutanix_virtual_machine_v2" "import_dev_vm" {
+  name = "dev_vm"
+  # All v2 resource attributes can now be managed here
+  # ... other v2 configuration
+}
+```
+
+You can now:
+- Update the resource configuration using v2 attributes
+- Apply changes using `terraform apply`
+- Manage the resource lifecycle with v2 resources
+- Benefit from the enhanced capabilities of v4 APIs/SDKs
+
+
+## Module Migration
+
+If you're using Terraform modules that reference v1 resources internally, you'll need to migrate those as well. The process is similar to resource migration, but involves identifying and migrating all resources managed by the module.
+
+### Step 1: Identify Modules Using V1 Resources
+
+First, identify modules in your configuration that use v1 resources. For example, in your main configuration file:
+
+``hcl
+module "vm_module" {
+  source = "./modules/vm-module"
+  
+  vm_name = "dev_vm"
+  # ... other module inputs
+}
+```
+Then, check the module source code to see if it uses v1 resources. Inside the module directory (e.g., `./modules/vm-module/main.tf`), you might see:
+
+```hcl
+# modules/vm-module/main.tf
+
+variable "vm_name" {
+  description = "Name of the virtual machine"
+  type        = string
+}
+
+resource "nutanix_virtual_machine" "vm" {
+  name = var.vm_name
+  # ... other v1 resource configuration
+}
+```
+If the module source code uses v1 resources like `nutanix_virtual_machine`, it needs migration.
+
+### Step 2: List Resources Created by the Module
+
+Identify all resources created by the module using Terraform state:
+
+```bash
+terraform state list | grep module.vm_module
+```
+This will show all resources managed by the module
+```
+module.vm_module.nutanix_virtual_machine.vm
+# ... other resources created by the module.
+```
+### Step 3: Add V2 Resource Configuration in Module Source
+Update your module source code to include v2 resource configurations. Add v2 resources alongside v1 resources in the module source.
+
+Edit your module source file (e.g., `modules/vm-module/main.tf`) to add v2 resources:
+
+```hcl
+# modules/vm-module/main.tf
+
+variable "vm_name" {
+  description = "Name of the virtual machine"
+  type        = string
+}
+
+# Existing v1 resources (will be removed after import)
+resource "nutanix_virtual_machine" "vm" {
+  name = var.vm_name
+  # ... other v1 resource configuration
+}
+
+# Add v2 resource configuration for import
+resource "nutanix_virtual_machine_v2" "vm_v2" {
+  # Configuration will be imported from existing resource
+  # You can add minimal required attributes if needed
+}
+```
+~> **Note:** At this stage, you only need to declare the v2 resource blocks. The actual configuration will be imported in the further step.
+
+### Step 4: Get the UUID of the Existing Resource
+For resource in the module, retrieve its UUID using Terraform state:
+
+```bash
+terraform state show module.vm_module.nutanix_virtual_machine.vm
+```
+Look for the `id` or `uuid` field in the output for resource.
+
+### Step 5: Import Module Resources into V2 State
+Execute the terraform import command to import each resource managed by the module into v2 resource state. Use the UUIDs obtained from Step 4:
+```bash
+terraform import module.vm_module.nutanix_virtual_machine_v2.vm_v2 <UUID_OF_ENTITY>
+```
+
+### Step 6: Verify Import is Successful
+Verify that all module resources have been imported successfully by listing all resources in the Terraform state:
+
+```bash
+terraform state list
+```
+
+You should now see both the v1 module resources and v2 resources in the state:
+```
+module.vm_module.nutanix_virtual_machine.vm
+module.vm_module.nutanix_virtual_machine_v2.vm_v2
+```
+
+### Step 7: Remove the V1 Resource Config and Remove it from State
+Once you've verified that all imports are successful, remove the v1 resource configurations and state:
+
+1. **Remove the v1 resources from your module source code:**
+
+   remove or comment out the v1 resource blocks in your module file (e.g., `modules/vm-module/main.tf`):
+   
+   ```hcl
+   # modules/vm-module/main.tf
+   
+   # Existing v1 resources (removed after migration)
+   # resource "nutanix_virtual_machine" "vm" {
+   #   name = var.vm_name
+   #   # ... other v1 resource configuration
+   # }
+   ```
+2. **Remove v1 module resources from Terraform state:**
+
+   Remove v1 resource managed by the module from Terraform state:
+   
+   ```bash
+   terraform state rm module.vm_module.nutanix_virtual_machine.vm
+   ```
+~> **Important:** Ensure all v2 resource imports were successful (verified in Step 6) before removing the v1 module resources from state. Once removed, the v1 resources will no longer be managed by Terraform.
+
+### Step 8: Continue to Use Modules Which Internally Use V2 Resources
+Congratulations! Your module migration is complete. From now on, you can manage the resources using modules that internally use v2 resources.
+
+Your module source now uses v2 resources (e.g., `modules/vm-module/main.tf`):
+```hcl
+# modules/vm-module/main.tf
+
+variable "vm_name" {
+  description = "Name of the virtual machine"
+  type        = string
+}
+
+# Using v2 resources
+resource "nutanix_virtual_machine_v2" "vm_v2" {
+  name = var.vm_name
+  # All v2 resource attributes can now be managed here
+  # ... other v2 configuration
+}
+```
+
+You can now:
+- Continue using your module with v2 resources going forward
+- Update the resource configuration using v2 attributes
+- Apply changes using `terraform apply`
+- Manage the resource lifecycle with v2 resources
+- Benefit from the enhanced capabilities of v4 APIs/SDKs
+
+## Important Considerations
+
+- **No Downtime:** The migration process does not recreate resources, so there's no service interruption
+- **Gradual Migration:** You can migrate resources one at a time - you don't need to migrate everything at once
+- **Dependencies:** Pay attention to resource dependencies and migrate them in the correct order
+
+### Configuration Mismatches
+After import, if `terraform plan` shows changes:
+- Review the differences carefully
+- Some attribute changes are expected due to API differences
+- Update your configuration to match the actual resource state
+
+
+## Troubleshooting
+
+### Import Fails
+If the import fails, verify:
+- The UUID is correct
+- The resource still exists in Nutanix
+- You have proper permissions to access the resource

--- a/website/docs/r/Guides/v1_to_v2_migration_guide.html.markdown
+++ b/website/docs/r/Guides/v1_to_v2_migration_guide.html.markdown
@@ -284,7 +284,6 @@ You can now:
 
 - **No Downtime:** The migration process does not recreate resources, so there's no service interruption
 - **Gradual Migration:** You can migrate resources one at a time - you don't need to migrate everything at once
-- **Dependencies:** Pay attention to resource dependencies and migrate them in the correct order
 
 ### Configuration Mismatches
 After import, if `terraform plan` shows changes:

--- a/website/docs/r/Guides/v1_to_v2_migration_guide.html.markdown
+++ b/website/docs/r/Guides/v1_to_v2_migration_guide.html.markdown
@@ -129,16 +129,17 @@ If your Terraform modules reference v1 resources, they must be migrated as well.
 
 Locate modules in your configuration that reference v1 resources. For example, in your main configuration file:
 
-``hcl
+- Example Main Configuration
+```hcl
 module "vm_module" {
-  source = "./modules/vm-module"
+  source  = "./modules/vm-module"
   
   vm_name = "dev_vm"
   # ... other module inputs
 }
 ```
-Within the module directory (e.g., ./modules/vm-module/main.tf), you may find code like:
 
+- Within the module directory (e.g., ./modules/vm-module/main.tf), you may find code like:
 ```hcl
 # modules/vm-module/main.tf
 


### PR DESCRIPTION
### Summary
This PR adds comprehensive migration guide documentation to help users migrate from Nutanix Terraform Provider v1 resources to v2 resources, which are built on v4 APIs/SDKs. This also includes README updates.

### Changes

#### New Documentation
- **New File:** `website/docs/r/Guides/v1_to_v2_migration_guide.html.markdown`
  - Comprehensive step-by-step migration guide for both resources and modules
  - Covers Resource Migration (7 steps)
  - Covers Module Migration (7 steps)
  - Includes troubleshooting section and important considerations
  
  #### Resource Migration
The guide provides detailed steps for migrating individual Terraform resources:
1. Identifying v1 resources
2. Adding v2 resource configurations
3. Getting UUIDs of existing resources
4. Importing resources into v2 state
5. Verifying import success
6. Removing v1 resource configurations and state
7. Using v2 resources going forward

#### Module Migration
The guide also covers migrating Terraform modules that use v1 resources internally:
1. Identifying modules using v1 resources
2. Listing resources created by modules
3. Getting UUIDs for module resources
4. Adding v2 resource configurations in module source
5. Importing module resources into v2 state
6. Verifying import success
7. Removing v1 module configurations
8. Continuing to use modules with v2 resources

### Documentation Structure
The guide is organized under:
- `website/docs/r/Guides/v1_to_v2_migration_guide.html.markdown`