### PR TITLE
Add guides under docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.3.3 (November 4, 2025)
+[Full Changelog](https://github.com/nutanix/terraform-provider-nutanix/compare/v2.3.2...v2.3.3)
+
+**Fixed Bugs:**
+- Documentation fix to show guides in Terraform provider docs [#1002](https://github.com/nutanix/terraform-provider-nutanix/issues/1002)
+
+
 ## 2.3.2 (November 3, 2025)
 [Full Changelog](https://github.com/nutanix/terraform-provider-nutanix/compare/v2.3.1...v2.3.2)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Terraform provider plugin to integrate with Nutanix Cloud Platform.
 
-NOTE: The latest version of the Nutanix provider is [v2.3.2](https://github.com/nutanix/terraform-provider-nutanix/releases/tag/v2.3.2).
+NOTE: The latest version of the Nutanix provider is [v2.3.3](https://github.com/nutanix/terraform-provider-nutanix/releases/tag/v2.3.3).
 
 Modules based on Terraform Nutanix Provider can be found here : [Modules](https://github.com/nutanix/terraform-provider-nutanix/tree/master/modules)
 
@@ -22,40 +22,13 @@ Modules based on Terraform Nutanix Provider can be found here : [Modules](https:
 * [Go](https://golang.org/doc/install) 1.17+ (to build the provider plugin)
 * This provider uses [SDKv2](https://www.terraform.io/plugin/sdkv2/sdkv2-intro) from release 1.3.0
 
-## Introducing Nutanix Terraform Provider Version v2.3.2
+## Introducing Nutanix Terraform Provider Version v2.3.3
 
-We're excited to announce the release of Nutanix Terraform Provider Version 2.3.2! This major update brings new features for automating your Nutanix infrastructure.
+We're excited to announce the release of Nutanix Terraform Provider Version 2.3.3!
 
-### What's New in v2.3.2
+### What's New in v2.3.3
 
-- **Built on v4.1 APIs/SDKs**
-  This release is built on the latest Nutanix v4 APIs and SDKs, providing improved performance, stability, and alignment with the newest platform capabilities.
-
-- **New Resource Support**
-  - **OVAs**: Enables the creation and management of OVAs, deployment of VM's through OVA.
-  - **Password Manager**: Provides the ability to manage system user passwords
-
-- **Enhancements**
-  - **Project Association with VM for V2 resource**: Associate Project with Virtual Machine V2 resource.
-  - **Automatic Cluster Selection**: Automatic cluster selection support.
-  - **Support for object lite source**: Support for object lite source in terraform for images.
-  - **nutanix_cluster_v2 resource now fully supports cluster expansion operations**, including adding and removing nodes. This enhancement eliminates the need for a separate nutanix_cluster_add_node_v2 resource.
-  - **Import support is now available for V2 resources**, This enhancement allows users to seamlessly bring existing Nutanix entities under Terraform management(using V2 resources which uses V4 API SDK's), **without recreating them**.
-
-- **Fixed Bugs:**
-  - Add a clear documentation for cluster delete [\#977](https://github.com/nutanix/terraform-provider-nutanix/issues/977)
-  - Show warning if cluster is not registered to the PC [\#974](https://github.com/nutanix/terraform-provider-nutanix/issues/974)
-  - Resource: nutanix_users_v2: Password exposed in state file, Show Warning in case of delete, Documentation changes for using users_v2 resource [\#949](https://github.com/nutanix/terraform-provider-nutanix/issues/949)
-  - Resource: nutanix_users_v2: Can't change local user password [\#897](https://github.com/nutanix/terraform-provider-nutanix/issues/897)
-  - Empty id attributes returned for Auth Policy, Roles [\#989](https://github.com/nutanix/terraform-provider-nutanix/issues/989)
-  - nutanix_user_groups_v2 empty ext_id in state file [\#899](https://github.com/nutanix/terraform-provider-nutanix/issues/899)
-  - Resource: nutanix_user_key_v2: User should be able to create User Key of OBJECT KEY type [\#996](https://github.com/nutanix/terraform-provider-nutanix/issues/996)
-  - Creation of a floating IP fails when specifying the desired IP address. Ok if not specify the desired IP [\#939](https://github.com/nutanix/terraform-provider-nutanix/issues/939)
-  - nutanix_network_security_policy_v2 error: The terraform-provider-nutanix_v2.3.1 plugin crashed! [\#935](https://github.com/nutanix/terraform-provider-nutanix/issues/935)
-  - nutanix_volume_group_disk_v2 encounters panic when updating disk_size_bytes [\#866](https://github.com/nutanix/terraform-provider-nutanix/issues/886)
----
-
-Upgrade now to take advantage of these powerful features and streamline your Nutanix automation workflows!
+- This release includes one documentation fix to show guides in Terraform provider docs [#1002](https://github.com/nutanix/terraform-provider-nutanix/issues/1002), functionally this release is equivalent to v2.3.2
 
 
 ### Software Requirements
@@ -69,6 +42,7 @@ The provider is used to interact with the many resources and data sources suppor
 ## Compatibility Matrix
 | Terraform Version |  AOS Version | PC version  | Other software versions | Supported |
 |  :--- |  :--- | :--- | :--- | :--- |
+| 2.3.3 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.2 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.1 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.0 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |

--- a/website/docs/guides/v1_to_v2_migration_guide.html.markdown
+++ b/website/docs/guides/v1_to_v2_migration_guide.html.markdown
@@ -1,7 +1,8 @@
 ---
 layout: "nutanix"
 page_title: "Migration Guide: V1 to V2 Resources"
-sidebar_current: "docs-nutanix-migration-v1-to-v2"
+subcategory: "Guides"
+sidebar_current: "docs-nutanix-guides-v1-to-v2-migration-guide"
 description: |-
   This guide provides step-by-step instructions for migrating from Nutanix Terraform Provider v1 resources to v2 resources, which are built on v4 APIs/SDKs.
 ---

--- a/website/docs/guides/v1_to_v2_migration_guide.html.markdown
+++ b/website/docs/guides/v1_to_v2_migration_guide.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "nutanix"
 page_title: "Migration Guide: V1 to V2 Resources"
-subcategory: "Guides"
 sidebar_current: "docs-nutanix-guides-v1-to-v2-migration-guide"
 description: |-
   This guide provides step-by-step instructions for migrating from Nutanix Terraform Provider v1 resources to v2 resources, which are built on v4 APIs/SDKs.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -13,37 +13,13 @@ The provider is used to interact with the many resources and data sources suppor
 Use the navigation on the left to read about the available resources and data sources this provider can use.
 
 
-## Introducing Nutanix Terraform Provider Version v2.3.2
+## Introducing Nutanix Terraform Provider Version v2.3.3
 
-We're excited to announce the release of Nutanix Terraform Provider Version 2.3.2! This major update brings new features for automating your Nutanix infrastructure.
+We're excited to announce the release of Nutanix Terraform Provider Version 2.3.3!
 
-### What's New in v2.3.2
+### What's New in v2.3.3
 
-- **Built on v4.1 APIs/SDKs**  
-  This release is built on the latest Nutanix v4 APIs and SDKs, providing improved performance, stability, and alignment with the newest platform capabilities.
-
-- **New Resource Support**
-  - **OVAs**: Enables the creation and management of OVAs, deployment of VM's through OVA.
-  - **Password Manager**: Provides the ability to manage system user passwords
-
-- **Enhancements**
-  - **Project Association with VM for V2 resource**: Associate Project with Virtual Machine V2 resource.
-  - **Automatic Cluster Selection**: Automatic cluster selection support.
-  - **Support for object lite source**: Support for object lite source in terraform for images.
-  - **nutanix_cluster_v2 resource now fully supports cluster expansion operations**, including adding and removing nodes. This enhancement eliminates the need for a separate nutanix_cluster_add_node_v2 resource.
-  - **Import support is now available for V2 resources**, This enhancement allows users to seamlessly bring existing Nutanix entities under Terraform management(using V2 resources which uses V4 API SDK's), **without recreating them**.
-
-- **Fixed Bugs:**
-  - Add a clear documentation for cluster delete [\#977](https://github.com/nutanix/terraform-provider-nutanix/issues/977)
-  - Show warning if cluster is not registered to the PC [\#974](https://github.com/nutanix/terraform-provider-nutanix/issues/974)
-  - Resource: nutanix_users_v2: Password exposed in state file, Show Warning in case of delete, Documentation changes for using users_v2 resource [\#949](https://github.com/nutanix/terraform-provider-nutanix/issues/949)
-  - Resource: nutanix_users_v2: Can't change local user password [\#897](https://github.com/nutanix/terraform-provider-nutanix/issues/897)
-  - Empty id attributes returned for Auth Policy, Roles [\#989](https://github.com/nutanix/terraform-provider-nutanix/issues/989)
-  - nutanix_user_groups_v2 empty ext_id in state file [\#899](https://github.com/nutanix/terraform-provider-nutanix/issues/899)
-  - Resource: nutanix_user_key_v2: User should be able to create User Key of OBJECT KEY type [\#996](https://github.com/nutanix/terraform-provider-nutanix/issues/996)
-  - Creation of a floating IP fails when specifying the desired IP address. Ok if not specify the desired IP [\#939](https://github.com/nutanix/terraform-provider-nutanix/issues/939)
-  - nutanix_network_security_policy_v2 error: The terraform-provider-nutanix_v2.3.1 plugin crashed! [\#935](https://github.com/nutanix/terraform-provider-nutanix/issues/935)
-  - nutanix_volume_group_disk_v2 encounters panic when updating disk_size_bytes [\#866](https://github.com/nutanix/terraform-provider-nutanix/issues/886)
+- This release includes one documentation fix to show guides in Terraform provider docs [#1002](https://github.com/nutanix/terraform-provider-nutanix/issues/1002), functionally this release is equivalent to v2.3.2
 
 
 ~> **Important Notice:** Upcoming Deprecation of Legacy Nutanix Terraform Provider Resources. Starting with the Nutanix Terraform Provider release planned for Q4-CY2026, legacy resources which are based on v0.8,v1,v2 and v3 APIs will be deprecated and no longer supported. For more information, visit [Legacy API Deprecation Announcement](https://portal.nutanix.com/page/documents/eol/list?type=announcement) [Legacy API Deprecation - FAQs](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA0VO0000005rgP0AQ). Nutanix strongly encourages you to migrate your scripts and applications to the latest v2 version of the Nutanix Terraform Provider resources, which are built on our v4 APIs/SDKs. By adopting the latest v2 version based on v4 APIs and SDKs, our users can leverage the enhanced capabilities and latest innovations from Nutanix. We understand that this transition may require some effort, and we are committed to supporting you throughout the process. Please refer to our documentation and support channels for guidance and assistance.
@@ -57,6 +33,7 @@ Customers not taking advantage of the  Advanced API/SDK Support Program will con
 ## Compatibility Matrix
 | Terraform Version |  AOS Version | PC version  | Other software versions | Supported |
 |  :--- |  :--- | :--- | :--- | :--- |
+| 2.3.3 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.2 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.1 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.0 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |

--- a/website/nutanix.erb
+++ b/website/nutanix.erb
@@ -9,7 +9,14 @@
         <li<%= sidebar_current("docs-nutanix-index") %>>
             <a href="/docs/providers/nutanix/index.html">Nutanix Provider</a>
         </li>
-
+        <li<%= sidebar_current("docs-nutanix-guides") %>>
+            <a href="#">Guides</a>
+            <ul class="nav nav-visible">
+                <li<%= sidebar_current("docs-nutanix-guides-v1-to-v2-migration-guide") %>>
+                    <a href="/docs/providers/nutanix/guides/v1_to_v2_migration_guide.html">Migration Guide: V1 to V2 Resources</a>
+                </li>
+            </ul>
+        </li>
         <li<%= sidebar_current("docs-nutanix-datasource") %>>
             <a href="#">Data Sources</a>
             <ul class="nav nav-visible">


### PR DESCRIPTION
Add guides under docs, It shouldn't be under resources.

Issue: Added Guides under `r` folder which made the migration guide unavailable in Terraform registry Provider Docs.