### PR TITLE
fix(clustersv2): Prevent expand cluster failure caused by sending default boolean flags in request payload

### DIFF
--- a/nutanix/services/clustersv2/resource_nutanix_cluster_entity_add_node_v2_test.go
+++ b/nutanix/services/clustersv2/resource_nutanix_cluster_entity_add_node_v2_test.go
@@ -157,6 +157,34 @@ resource "nutanix_cluster_v2" "cluster-3nodes" {
     }
   }
 
+  network {
+		external_address {
+			ipv4 {
+				value = local.clusters.network.virtual_ip
+			}
+		}
+		ntp_server_ip_list {
+			fqdn {
+				value = local.clusters.network.ntp_servers[0]
+			}
+		}
+		ntp_server_ip_list {
+			fqdn {
+				value = local.clusters.network.ntp_servers[1]
+			}
+		}
+		ntp_server_ip_list {
+			fqdn {
+				value = local.clusters.network.ntp_servers[2]
+			}
+		}
+		ntp_server_ip_list {
+			fqdn {
+				value = local.clusters.network.ntp_servers[3]
+			}
+		}
+	}
+
   provisioner "local-exec" {
     command = "ssh-keygen -f ~/.ssh/known_hosts -R ${local.clusters.nodes[1].cvm_ip};   sshpass -p '${local.clusters.pe_password}' ssh -o StrictHostKeyChecking=no ${local.clusters.pe_username}@${local.clusters.nodes[1].cvm_ip} '/home/nutanix/prism/cli/ncli user reset-password user-name=${local.clusters.nodes[1].username} password=${local.clusters.nodes[1].password}'"
 
@@ -258,7 +286,8 @@ resource "nutanix_cluster_add_node_v2" "test" {
   should_skip_pre_expand_checks = false
 
   node_params {
-    should_skip_host_networking = false
+    ## remove this because the expand cluster satrt failing from IRIS
+    #should_skip_host_networking = false
     hypervisor_isos {
       type = nutanix_clusters_discover_unconfigured_nodes_v2.cluster-node.unconfigured_nodes[0].hypervisor_type
     }

--- a/nutanix/services/clustersv2/resource_nutanix_cluster_entity_v2_test.go
+++ b/nutanix/services/clustersv2/resource_nutanix_cluster_entity_v2_test.go
@@ -985,6 +985,34 @@ resource "nutanix_cluster_v2" "cluster-3nodes" {
     }
   }
 
+  network {
+		external_address {
+			ipv4 {
+				value = local.clusters.network.virtual_ip
+			}
+		}
+		ntp_server_ip_list {
+			fqdn {
+				value = local.clusters.network.ntp_servers[0]
+			}
+		}
+		ntp_server_ip_list {
+			fqdn {
+				value = local.clusters.network.ntp_servers[1]
+			}
+		}
+		ntp_server_ip_list {
+			fqdn {
+				value = local.clusters.network.ntp_servers[2]
+			}
+		}
+		ntp_server_ip_list {
+			fqdn {
+				value = local.clusters.network.ntp_servers[3]
+			}
+		}
+	}
+
   provisioner "local-exec" {
     command = "ssh-keygen -f ~/.ssh/known_hosts -R ${local.clusters.nodes[1].cvm_ip};   sshpass -p '${local.clusters.pe_password}' ssh -o StrictHostKeyChecking=no ${local.clusters.pe_username}@${local.clusters.nodes[1].cvm_ip} '/home/nutanix/prism/cli/ncli user reset-password user-name=${local.clusters.nodes[1].username} password=${local.clusters.nodes[1].password}'"
 
@@ -1112,8 +1140,17 @@ resource "nutanix_cluster_v2" "cluster-3nodes" {
           value = local.clusters.nodes[3].cvm_ip
         }
       }
-      should_skip_host_networking   = false
-      should_skip_pre_expand_checks = true
+			should_skip_imaging = true
+			should_skip_discovery = false
+			should_validate_rack_awareness = false
+			is_nos_compatible = false
+			is_compute_only = false
+			is_never_scheduleable = false
+			is_light_compute = false
+			hypervisor_hostname = "test-hypervisor"
+			## remove this because the expand cluster satrt failing from IRIS
+      # should_skip_host_networking   = false
+      should_skip_pre_expand_checks = false
     }
   }
   config {
@@ -1123,6 +1160,34 @@ resource "nutanix_cluster_v2" "cluster-3nodes" {
       domain_awareness_level          = "NODE"
     }
   }
+
+	network {
+		external_address {
+			ipv4 {
+				value = local.clusters.network.virtual_ip
+			}
+		}
+		ntp_server_ip_list {
+			fqdn {
+				value = local.clusters.network.ntp_servers[0]
+			}
+		}
+		ntp_server_ip_list {
+			fqdn {
+				value = local.clusters.network.ntp_servers[1]
+			}
+		}
+		ntp_server_ip_list {
+			fqdn {
+				value = local.clusters.network.ntp_servers[2]
+			}
+		}
+		ntp_server_ip_list {
+			fqdn {
+				value = local.clusters.network.ntp_servers[3]
+			}
+		}
+	}
 
   provisioner "local-exec" {
     command = "ssh-keygen -f ~/.ssh/known_hosts -R ${local.clusters.nodes[1].cvm_ip};   sshpass -p '${local.clusters.pe_password}' ssh -o StrictHostKeyChecking=no ${local.clusters.pe_username}@${local.clusters.nodes[1].cvm_ip} '/home/nutanix/prism/cli/ncli user reset-password user-name=${local.clusters.nodes[1].username} password=${local.clusters.nodes[1].password}'"
@@ -1211,8 +1276,16 @@ resource "nutanix_cluster_v2" "cluster-3nodes" {
           value = local.clusters.nodes[3].cvm_ip
         }
       }
-      should_skip_host_networking   = false
-      should_skip_pre_expand_checks = true
+			should_skip_imaging = true
+			should_skip_discovery = false
+			should_validate_rack_awareness = false
+			is_nos_compatible = false
+			is_compute_only = false
+			is_never_scheduleable = false
+			is_light_compute = false
+			hypervisor_hostname = "test-hypervisor"
+      # should_skip_host_networking   = false
+      should_skip_pre_expand_checks = false
     }
   }
   config {
@@ -1222,6 +1295,34 @@ resource "nutanix_cluster_v2" "cluster-3nodes" {
       domain_awareness_level          = "NODE"
     }
   }
+
+	network {
+		external_address {
+			ipv4 {
+				value = local.clusters.network.virtual_ip
+			}
+		}
+		ntp_server_ip_list {
+			fqdn {
+				value = local.clusters.network.ntp_servers[0]
+			}
+		}
+		ntp_server_ip_list {
+			fqdn {
+				value = local.clusters.network.ntp_servers[1]
+			}
+		}
+		ntp_server_ip_list {
+			fqdn {
+				value = local.clusters.network.ntp_servers[2]
+			}
+		}
+		ntp_server_ip_list {
+			fqdn {
+				value = local.clusters.network.ntp_servers[3]
+			}
+		}
+	}
 
   provisioner "local-exec" {
     command = "ssh-keygen -f ~/.ssh/known_hosts -R ${local.clusters.nodes[1].cvm_ip};   sshpass -p '${local.clusters.pe_password}' ssh -o StrictHostKeyChecking=no ${local.clusters.pe_username}@${local.clusters.nodes[1].cvm_ip} '/home/nutanix/prism/cli/ncli user reset-password user-name=${local.clusters.nodes[1].username} password=${local.clusters.nodes[1].password}'"


### PR DESCRIPTION
## Problem

The expand cluster operation was failing because the boolean flag `shouldSkipHostNetworking` was always being sent in the API request payload with a value of `false`, even when not explicitly configured by the user.

This issue started occurring from **AOS 7.5**. Prior to AOS 7.5, the expand cluster operation worked even when sending `shouldSkipHostNetworking = false` in the payload.

The failure occurred because sending the `shouldSkipHostNetworking` boolean field set to `false` resulted in:

{
  "shouldSkipHostNetworking": false,
  ...
}The API now expects this optional field to be omitted from the request when not explicitly configured, allowing it to use its own defaults.

## Root Cause

The extraction logic used `d.Get()` which returns the computed/default value (`false` for booleans), making it impossible to distinguish between:
- User explicitly set the field to `false`
- User did not set the field (TF defaulted to `false`)

## Fix

1. **Added `isFieldSetInRawConfig` helper** - Checks Terraform's raw config (`d.GetRawConfig()`) to determine if a field was explicitly set by the user

2. **Changed `ShouldSkipHostNetworking` to pointer type** - Using `*bool` allows the field to be `nil` when not set

3. **Updated extraction logic** - Only sets flag values when explicitly configured in the TF config

4. **Updated API request construction** - Only includes the field in the payload when the pointer is not `nil`

### Before (Broken)

// Always sent in payload, even when not configured
nodeParam.ShouldSkipHostNetworking = utils.BoolPtr(flags.ShouldSkipHostNetworking)### After (Fixed)

// Only sent in payload when explicitly configured
if flags.ShouldSkipHostNetworking != nil {
    nodeParam.ShouldSkipHostNetworking = flags.ShouldSkipHostNetworking
}## Affected Fields

Add  expand cluster boolean flags[missed from the schema]:
- `should_skip_host_networking`
- `should_skip_pre_expand_checks`
- `should_skip_discovery`
- `should_skip_imaging`
- `should_validate_rack_awareness`
- `is_nos_compatible`
- `is_compute_only`
- `is_never_scheduleable`
- `is_light_compute`
- `hypervisor_hostname`

## Testing

- [x] Verified expand cluster succeeds on AOS 7.5+ without setting optional flags
- [x] Verified optional flags are omitted from request payload when not configured
- [x] Verified explicitly set flags are correctly included in request payload