### PR TITLE
Deprecate resource_domain for nutanix_project (unsupported since v2.4.0)

### DIFF
--- a/nutanix/services/prism/data_source_nutanix_project_test.go
+++ b/nutanix/services/prism/data_source_nutanix_project_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/spf13/cast"
 	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
 )
 
@@ -18,15 +17,11 @@ func TestAccNutanixProjectDataSourceByID_basic(t *testing.T) {
 	description := acctest.RandomWithPrefix("test-project-desc-dou")
 	categoryName := "Environment"
 	categoryVal := "Staging"
-	limit := cast.ToString(acctest.RandIntRange(2, 4))
-	rsType := "STORAGE"
 
 	updateName := acctest.RandomWithPrefix("test-project-name-dou")
 	updateDescription := acctest.RandomWithPrefix("test-project-desc-dou")
 	updateCategoryName := "Environment"
 	updateCategoryVal := "Production"
-	updateLimit := cast.ToString(acctest.RandIntRange(4, 8))
-	updateRSType := "MEMORY"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -34,30 +29,21 @@ func TestAccNutanixProjectDataSourceByID_basic(t *testing.T) {
 		CheckDestroy: testAccCheckNutanixProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectDataSourceByIDConfig(subnetName, name, description, categoryName, categoryVal, limit, rsType),
+				Config: testAccProjectDataSourceByIDConfig(subnetName, name, description, categoryName, categoryVal),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNutanixProjectExists(&resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.limit", limit),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.resource_type", rsType),
 					resource.TestCheckResourceAttr(resourceName, "categories.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "api_version", "3.1"),
 				),
 			},
 			{
-				Config: testAccProjectDataSourceByIDConfig(
-					subnetName, updateName, updateDescription, updateCategoryName, updateCategoryVal, updateLimit, updateRSType),
+				Config: testAccProjectDataSourceByIDConfig(subnetName, updateName, updateDescription, updateCategoryName, updateCategoryVal),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNutanixProjectExists(&resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
 					resource.TestCheckResourceAttr(resourceName, "description", updateDescription),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.limit", updateLimit),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.resource_type", updateRSType),
 					resource.TestCheckResourceAttr(resourceName, "categories.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "api_version", "3.1"),
 				),
@@ -74,15 +60,11 @@ func TestAccNutanixProjectDataSourceByName_basic(t *testing.T) {
 	description := acctest.RandomWithPrefix("test-project-desc-dou")
 	categoryName := "Environment"
 	categoryVal := "Staging"
-	limit := cast.ToString(acctest.RandIntRange(2, 4))
-	rsType := "STORAGE"
 
 	updateName := acctest.RandomWithPrefix("test-project-name-dou")
 	updateDescription := acctest.RandomWithPrefix("test-project-desc-dou")
 	updateCategoryName := "Environment"
 	updateCategoryVal := "Production"
-	updateLimit := cast.ToString(acctest.RandIntRange(4, 8))
-	updateRSType := "MEMORY"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -90,30 +72,21 @@ func TestAccNutanixProjectDataSourceByName_basic(t *testing.T) {
 		CheckDestroy: testAccCheckNutanixProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectDataSourceByNameConfig(subnetName, name, description, categoryName, categoryVal, limit, rsType),
+				Config: testAccProjectDataSourceByNameConfig(subnetName, name, description, categoryName, categoryVal),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNutanixProjectExists(&resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.limit", limit),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.resource_type", rsType),
 					resource.TestCheckResourceAttr(resourceName, "categories.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "api_version", "3.1"),
 				),
 			},
 			{
-				Config: testAccProjectDataSourceByNameConfig(
-					subnetName, updateName, updateDescription, updateCategoryName, updateCategoryVal, updateLimit, updateRSType),
+				Config: testAccProjectDataSourceByNameConfig(subnetName, updateName, updateDescription, updateCategoryName, updateCategoryVal),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNutanixProjectExists(&resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
 					resource.TestCheckResourceAttr(resourceName, "description", updateDescription),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.limit", updateLimit),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.resource_type", updateRSType),
 					resource.TestCheckResourceAttr(resourceName, "categories.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "api_version", "3.1"),
 				),
@@ -122,7 +95,7 @@ func TestAccNutanixProjectDataSourceByName_basic(t *testing.T) {
 	})
 }
 
-func testAccProjectDataSourceByIDConfig(subnetName, name, description, categoryName, categoryVal, limit, rsType string) string {
+func testAccProjectDataSourceByIDConfig(subnetName, name, description, categoryName, categoryVal string) string {
 	return fmt.Sprintf(`
 		data "nutanix_clusters" "clusters" {}
 
@@ -160,13 +133,6 @@ func testAccProjectDataSourceByIDConfig(subnetName, name, description, categoryN
 			categories {
 				name  = "%s"
 				value = "%s"
-			}
-
-			resource_domain {
-				resources {
-					limit         = %s
-					resource_type = "%s"
-				}
 			}
 
 			default_subnet_reference {
@@ -183,10 +149,10 @@ func testAccProjectDataSourceByIDConfig(subnetName, name, description, categoryN
 		data "nutanix_project" "test" {
 			project_id = nutanix_project.project_test.id
 		}
-	`, subnetName, name, description, categoryName, categoryVal, limit, rsType)
+	`, subnetName, name, description, categoryName, categoryVal)
 }
 
-func testAccProjectDataSourceByNameConfig(subnetName, name, description, categoryName, categoryVal, limit, rsType string) string {
+func testAccProjectDataSourceByNameConfig(subnetName, name, description, categoryName, categoryVal string) string {
 	return fmt.Sprintf(`
 		data "nutanix_clusters" "clusters" {}
 
@@ -226,13 +192,6 @@ func testAccProjectDataSourceByNameConfig(subnetName, name, description, categor
 				value = "%s"
 			}
 
-			resource_domain {
-				resources {
-					limit         = %s
-					resource_type = "%s"
-				}
-			}
-
 			default_subnet_reference {
 				uuid = nutanix_subnet.subnet.metadata.uuid
 			}
@@ -247,5 +206,5 @@ func testAccProjectDataSourceByNameConfig(subnetName, name, description, categor
 		data "nutanix_project" "test" {
 			project_name = nutanix_project.project_test.name
 		}
-	`, subnetName, name, description, categoryName, categoryVal, limit, rsType)
+	`, subnetName, name, description, categoryName, categoryVal)
 }

--- a/nutanix/services/prism/resource_nutanix_project_test.go
+++ b/nutanix/services/prism/resource_nutanix_project_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/spf13/cast"
 	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
 	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
 )
@@ -22,15 +21,11 @@ func TestAccNutanixProject_basic(t *testing.T) {
 	description := acctest.RandomWithPrefix("test-project-desc-dou")
 	categoryName := "Environment"
 	categoryVal := "Staging"
-	limit := cast.ToString(acctest.RandIntRange(2, 4))
-	rsType := "STORAGE"
 
 	updateName := acctest.RandomWithPrefix("test-project-name-dou")
 	updateDescription := acctest.RandomWithPrefix("test-project-desc-dou")
 	updateCategoryName := "Environment"
 	updateCategoryVal := "Production"
-	updateLimit := cast.ToString(acctest.RandIntRange(4, 8))
-	updateRSType := "MEMORY"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -38,30 +33,21 @@ func TestAccNutanixProject_basic(t *testing.T) {
 		CheckDestroy: testAccCheckNutanixProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNutanixProjectConfig(subnetName, name, description, categoryName, categoryVal, limit, rsType),
+				Config: testAccNutanixProjectConfig(subnetName, name, description, categoryName, categoryVal),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNutanixProjectExists(&resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.limit", limit),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.resource_type", rsType),
 					resource.TestCheckResourceAttr(resourceName, "categories.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "api_version", "3.1"),
 				),
 			},
 			{
-				Config: testAccNutanixProjectConfig(
-					subnetName, updateName, updateDescription, updateCategoryName, updateCategoryVal, updateLimit, updateRSType),
+				Config: testAccNutanixProjectConfig(subnetName, updateName, updateDescription, updateCategoryName, updateCategoryVal),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNutanixProjectExists(&resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
 					resource.TestCheckResourceAttr(resourceName, "description", updateDescription),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.limit", updateLimit),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.resource_type", updateRSType),
 					resource.TestCheckResourceAttr(resourceName, "categories.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "api_version", "3.1"),
 				),
@@ -78,8 +64,6 @@ func TestAccNutanixProject_importBasic(t *testing.T) {
 	description := acctest.RandomWithPrefix("test-project-desc-dou")
 	categoryName := "Environment"
 	categoryVal := "Staging"
-	limit := cast.ToString(acctest.RandIntRange(2, 4))
-	rsType := "STORAGE"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -87,7 +71,7 @@ func TestAccNutanixProject_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckNutanixProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNutanixProjectConfig(subnetName, name, description, categoryName, categoryVal, limit, rsType),
+				Config: testAccNutanixProjectConfig(subnetName, name, description, categoryName, categoryVal),
 			},
 			{
 				ResourceName:      resourceName,
@@ -107,22 +91,16 @@ func TestAccNutanixProject_withInternal(t *testing.T) {
 	description := acctest.RandomWithPrefix("test-project-desc-dou")
 	categoryName := "Environment"
 	categoryVal := "Staging"
-	limit := cast.ToString(acctest.RandIntRange(2, 4))
-	rsType := "STORAGE"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNutanixProjectInternalConfig(subnetName, name, description, categoryName, categoryVal, limit, rsType),
+				Config: testAccNutanixProjectInternalConfig(subnetName, name, description, categoryName, categoryVal),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.limit", limit),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.resource_type", rsType),
 					resource.TestCheckResourceAttr(resourceName, "categories.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "api_version", "3.1"),
 					resource.TestCheckResourceAttr(resourceName, "subnet_reference_list.#", "2"),
@@ -177,22 +155,16 @@ func TestAccNutanixProject_withInternalWithACP(t *testing.T) {
 	description := acctest.RandomWithPrefix("test-project-desc-dou")
 	categoryName := "Environment"
 	categoryVal := "Staging"
-	limit := cast.ToString(acctest.RandIntRange(2, 4))
-	rsType := "STORAGE"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNutanixProjectInternalConfigWithACP(subnetName, name, description, categoryName, categoryVal, limit, rsType),
+				Config: testAccNutanixProjectInternalConfigWithACP(subnetName, name, description, categoryName, categoryVal),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.limit", limit),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.resource_type", rsType),
 					resource.TestCheckResourceAttr(resourceName, "categories.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "api_version", "3.1"),
 					resource.TestCheckResourceAttr(resourceName, "subnet_reference_list.#", "1"),
@@ -211,22 +183,16 @@ func TestAccNutanixProject_withInternalWithACPUserGroup(t *testing.T) {
 	description := acctest.RandomWithPrefix("test-project-desc-dou")
 	categoryName := "Environment"
 	categoryVal := "Staging"
-	limit := cast.ToString(acctest.RandIntRange(2, 4))
-	rsType := "STORAGE"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNutanixProjectInternalConfigWithACPUserGroup(subnetName, name, description, categoryName, categoryVal, limit, rsType),
+				Config: testAccNutanixProjectInternalConfigWithACPUserGroup(subnetName, name, description, categoryName, categoryVal),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.limit", limit),
-					resource.TestCheckResourceAttr(resourceName, "resource_domain.0.resources.0.resource_type", rsType),
 					resource.TestCheckResourceAttr(resourceName, "categories.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "api_version", "3.1"),
 					resource.TestCheckResourceAttr(resourceName, "subnet_reference_list.#", "1"),
@@ -283,7 +249,7 @@ func testAccCheckNutanixProjectDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccNutanixProjectConfig(subnetName, name, description, categoryName, categoryVal, limit, rsType string) string {
+func testAccNutanixProjectConfig(subnetName, name, description, categoryName, categoryVal string) string {
 	return fmt.Sprintf(`
 		data "nutanix_clusters" "clusters" {}
 
@@ -323,13 +289,6 @@ func testAccNutanixProjectConfig(subnetName, name, description, categoryName, ca
 				value = "%s"
 			}
 
-			resource_domain {
-				resources {
-					limit         = %s
-					resource_type = "%s"
-				}
-			}
-
 			default_subnet_reference {
 				uuid = nutanix_subnet.subnet.metadata.uuid
 			}
@@ -339,10 +298,10 @@ func testAccNutanixProjectConfig(subnetName, name, description, categoryName, ca
 
 			api_version = "3.1"
 		}
-	`, subnetName, name, description, categoryName, categoryVal, limit, rsType)
+	`, subnetName, name, description, categoryName, categoryVal)
 }
 
-func testAccNutanixProjectInternalConfig(subnetName, name, description, categoryName, categoryVal, limit, rsType string) string {
+func testAccNutanixProjectInternalConfig(subnetName, name, description, categoryName, categoryVal string) string {
 	return fmt.Sprintf(`
 		data "nutanix_clusters" "clusters" {}
 
@@ -419,13 +378,6 @@ func testAccNutanixProjectInternalConfig(subnetName, name, description, category
 				value = "%s"
 			}
 
-			resource_domain {
-				resources {
-					limit         = %s
-					resource_type = "%s"
-				}
-			}
-
 			default_subnet_reference {
 				uuid = nutanix_subnet.subnet.metadata.uuid
 			}
@@ -453,7 +405,7 @@ func testAccNutanixProjectInternalConfig(subnetName, name, description, category
 				uuid= nutanix_vpc.acctest-managed.id
 			}
 		}
-	`, subnetName, name, description, categoryName, categoryVal, limit, rsType)
+	`, subnetName, name, description, categoryName, categoryVal)
 }
 
 func testAccNutanixProjectInternalConfigUpdate(subnetName, name, description string) string {
@@ -520,7 +472,7 @@ func testAccNutanixProjectInternalConfigUpdate(subnetName, name, description str
 	`, subnetName, name, description)
 }
 
-func testAccNutanixProjectInternalConfigWithACP(subnetName, name, description, categoryName, categoryVal, limit, rsType string) string {
+func testAccNutanixProjectInternalConfigWithACP(subnetName, name, description, categoryName, categoryVal string) string {
 	return fmt.Sprintf(`
 		data "nutanix_clusters" "clusters" {}
 
@@ -556,7 +508,7 @@ func testAccNutanixProjectInternalConfigWithACP(subnetName, name, description, c
 			description = "description role"
 			permission_reference_list {
 				kind = "permission"
-				uuid = "%[8]s"
+				uuid = "%[6]s"
 			}
 		}
 
@@ -567,13 +519,6 @@ func testAccNutanixProjectInternalConfigWithACP(subnetName, name, description, c
 			categories {
 				name  = "%[4]s"
 				value = "%[5]s"
-			}
-
-			resource_domain {
-				resources {
-					limit         = %[6]s
-					resource_type = "%[7]s"
-				}
 			}
 
 			default_subnet_reference {
@@ -611,10 +556,10 @@ func testAccNutanixProjectInternalConfigWithACP(subnetName, name, description, c
 				description= "untitledAcp-54acc50f-ab94-640a-5f06-5c855cc09539"
 			}
 		}
-	`, subnetName, name, description, categoryName, categoryVal, limit, rsType, testVars.Permissions[0].UUID)
+	`, subnetName, name, description, categoryName, categoryVal, testVars.Permissions[0].UUID)
 }
 
-func testAccNutanixProjectInternalConfigWithACPUserGroup(subnetName, name, description, categoryName, categoryVal, limit, rsType string) string {
+func testAccNutanixProjectInternalConfigWithACPUserGroup(subnetName, name, description, categoryName, categoryVal string) string {
 	return fmt.Sprintf(`
 		data "nutanix_clusters" "clusters" {}
 
@@ -650,13 +595,13 @@ func testAccNutanixProjectInternalConfigWithACPUserGroup(subnetName, name, descr
 			description = "description role"
 			permission_reference_list {
 				kind = "permission"
-				uuid = "%[8]s"
+				uuid = "%[6]s"
 			}
 		}
 
 		resource "nutanix_user_groups" "acctest-managed" {
 			directory_service_user_group {
-				distinguished_name = "%[9]s"
+				distinguished_name = "%[7]s"
 			}
 		}
 
@@ -667,13 +612,6 @@ func testAccNutanixProjectInternalConfigWithACPUserGroup(subnetName, name, descr
 			categories {
 				name  = "%[4]s"
 				value = "%[5]s"
-			}
-
-			resource_domain {
-				resources {
-					limit         = %[6]s
-					resource_type = "%[7]s"
-				}
 			}
 
 			default_subnet_reference {
@@ -690,7 +628,7 @@ func testAccNutanixProjectInternalConfigWithACPUserGroup(subnetName, name, descr
 			}
 
 			external_user_group_reference_list {
-				name= "%[9]s"
+				name= "%[7]s"
 			   	kind= "user_group"
 			   	uuid= nutanix_user_groups.acctest-managed.id
 			}
@@ -704,7 +642,7 @@ func testAccNutanixProjectInternalConfigWithACPUserGroup(subnetName, name, descr
 				}
 
 				user_group_reference_list {
-					name= "%[9]s"
+					name= "%[7]s"
 					kind= "user_group"
 					uuid= nutanix_user_groups.acctest-managed.id
 				}
@@ -712,5 +650,5 @@ func testAccNutanixProjectInternalConfigWithACPUserGroup(subnetName, name, descr
 				description= "untitledAcp-54acc50f-ab94-640a-5f06-5c855cc09539"
 			}
 		}
-	`, subnetName, name, description, categoryName, categoryVal, limit, rsType, testVars.Permissions[0].UUID, testVars.UserGroupWithDistinguishedName[3].DistinguishedName)
+	`, subnetName, name, description, categoryName, categoryVal, testVars.Permissions[0].UUID, testVars.UserGroupWithDistinguishedName[3].DistinguishedName)
 }

--- a/website/docs/d/project.html.markdown
+++ b/website/docs/d/project.html.markdown
@@ -42,13 +42,6 @@ resource "nutanix_project" "project_test" {
     value = "Staging"
   }
 
-  resource_domain {
-    resources {
-      limit         = 4
-      resource_type = "STORAGE"
-    }
-  }
-
   default_subnet_reference {
     uuid = nutanix_subnet.subnet.metadata.uuid
   }
@@ -75,12 +68,7 @@ The following attributes are exported:
 * `description` A description for project.
 
 ### Resource Domain
-* `resource_domain` The status for a resource domain (limits and values)
-* `resource_domain.resources` Array of the utilization/limit for resource types
-* `resource_domain.resources.#.limit` The resource consumption limit (unspecified is unlimited)
-* `resource_domain.resources.#.resource_type` The type of resource (for example storage, CPUs)
-* `resource_domain.resources.#.units` - The units of the resource type
-* `resource_domain.resources.#.value` - The amount of resource consumed
+* `resource_domain` (Deprecated) Not supported starting from provider version `2.4.0` and expected to be empty. Remove any usage from configuration/scripts.
 
 ### Account Reference List
 * `account_reference_list` - List of accounts associated with the project.
@@ -122,10 +110,6 @@ The following attributes are exported:
 * `external_network_list` - List of external networks associated with the project.
 * `external_network_list.#.uuid` - The UUID of a network.
 * `external_network_list.#.name` - The name of a network.
-
-### Resource Domain
-* `resource_domain.resources.#.units` - The units of the resource type
-* `resource_domain.resources.#.value` - The amount of resource consumed
 
 ### Tunnel Reference List
 * `tunnel_reference_list` - (Optional/Computed) List of tunnels associated with the project.

--- a/website/docs/d/projects.html.markdown
+++ b/website/docs/d/projects.html.markdown
@@ -32,12 +32,7 @@ The entities attribute element contains the followings attributes:
 * `description` A description for project.
 
 ### Resource Domain
-* `resource_domain` The status for a resource domain (limits and values)
-* `resource_domain.resources` Array of the utilization/limit for resource types
-* `resource_domain.resources.#.limit` The resource consumption limit (unspecified is unlimited)
-* `resource_domain.resources.#.resource_type` The type of resource (for example storage, CPUs)
-* `resource_domain.resources.#.units` - The units of the resource type
-* `resource_domain.resources.#.value` - The amount of resource consumed
+* `resource_domain` (Deprecated) Not supported starting from provider version `2.4.0` and expected to be empty. Remove any usage from configuration/scripts.
 
 ### Account Reference List
 * `account_reference_list` - List of accounts associated with the project.
@@ -81,8 +76,7 @@ The entities attribute element contains the followings attributes:
 * `external_network_list.#.name` - The name of a network.
 
 ### Resource Domain
-* `resource_domain.resources.#.units` - The units of the resource type
-* `resource_domain.resources.#.value` - The amount of resource consumed
+* `resource_domain` - (Deprecated) Not supported starting from provider version `2.4.0` and expected to be empty.
 
 ### Metadata
 The metadata attribute exports the following:

--- a/website/docs/r/project.markdown
+++ b/website/docs/r/project.markdown
@@ -42,13 +42,6 @@ resource "nutanix_project" "project_test" {
     value = "Staging"
   }
 
-  resource_domain {
-    resources {
-      limit         = 4
-      resource_type = "STORAGE"
-    }
-  }
-
   default_subnet_reference {
     uuid = nutanix_subnet.subnet.metadata.uuid
   }
@@ -162,11 +155,8 @@ The following arguments are supported:
 * `cluster_uuid` - (Optional) The UUID of cluster. (Required when using project_internal flag).
 * `enable_collab` - (Optional) flag to allow collaboration of projects. (Use with project_internal flag)
 
-### Resource Domain
-* `resource_domain` - (Optional) The status for a resource domain (limits and values)
-* `resource_domain.resources` - (Required) Array of the utilization/limit for resource types
-* `resource_domain.resources.#.limit` - (Required) The resource consumption limit.
-* `resource_domain.resources.#.resource_type` - (Required) The type of resource (for example storage, CPUs)
+### Resource Domain (Deprecated)
+* `resource_domain` - (Deprecated) Not supported starting from provider version `2.4.0` and ignored by the provider. Remove it from your configuration/scripts.
 
 ### Account Reference List
 * `account_reference_list` - (Optional/Computed) List of accounts associated with the project.
@@ -291,10 +281,6 @@ The following arguments are supported:
 
 ## Attributes Reference
 The following attributes are exported:
-
-### Resource Domain
-* `resource_domain.resources.#.units` - The units of the resource type
-* `resource_domain.resources.#.value` - The amount of resource consumed
 
 ### ACP
 ACPs will be exported if use_project_internal flag is set.


### PR DESCRIPTION
## Summary

Starting from **v2.4.0**, Prism Central no longer supports `resource_domain` for projects. This PR makes the provider handle this safely by **deprecating** the field and **ignoring it in API requests**, while keeping it in the schema to avoid breaking existing customer configurations.

## What changed

- **Resource `nutanix_project`**
  - Marked `resource_domain` as **Deprecated** (v2.4.0).
  - **Stops sending** `resource_domain` to Prism Central on create/update.
  - **Stops reading/setting** `resource_domain` from Prism Central into state to avoid drift/crashes if the API no longer returns it.
  - Added a **DiffSuppress** to prevent noisy diffs for legacy configs still containing the block.

- **Tests**
  - Updated project resource + datasource acceptance tests to **remove `resource_domain` usage**.

- **Docs**
  - Updated resource/datasource docs to remove `resource_domain` from examples and explicitly state:
    - **Unsupported starting v2.4.0**
    - Must be removed from customer configs/scripts.

- **Changelog**
  - Added a v2.4.0 entry documenting the deprecation/behavior.

## Backward compatibility / safety

- Existing customer scripts that still contain `resource_domain` will **not fail validation**, because the schema still accepts it.
- The provider will **ignore** `resource_domain` so it won’t trigger updates or API errors against newer Prism Central versions.
- Users should remove `resource_domain` blocks going forward (documented in v2.4.0 notes).

## User action required

- If your configuration/scripts include `resource_domain` under `nutanix_project`, **remove it** when upgrading to provider **v2.4.0+**.

## Files changed

- `nutanix/services/prism/resource_nutanix_project.go`
- `nutanix/services/prism/resource_nutanix_project_test.go`
- `nutanix/services/prism/data_source_nutanix_project_test.go`
- `website/docs/r/project.markdown`
- `website/docs/d/project.html.markdown`
- `website/docs/d/projects.html.markdown`
