### PR TITLE
Fix v4 client initialization (port parsing + disable version negotiation) 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.1
 	github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.1
 	github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.2.1
-	github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4 v4.0.1
+	github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4 v4.0.2
 	github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4 v4.2.1
 	github.com/nutanix/ntnx-api-golang-clients/security-go-client/v4 v4.1.1
 	github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4 v4.2.1

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4 v4.2.1
 	github.com/nutanix/ntnx-api-golang-clients/datapolicies-go-client/v4 v4.2.1
 	github.com/nutanix/ntnx-api-golang-clients/dataprotection-go-client/v4 v4.2.1
-	github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4 v4.0.1
+	github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4 v4.1.1-beta.2
 	github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.1
 	github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.1
 	github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.2.1

--- a/go.sum
+++ b/go.sum
@@ -461,8 +461,8 @@ github.com/nutanix/ntnx-api-golang-clients/datapolicies-go-client/v4 v4.2.1 h1:g
 github.com/nutanix/ntnx-api-golang-clients/datapolicies-go-client/v4 v4.2.1/go.mod h1:rucOCp3ocrHS9juBpJGQYPfftCiTlI4fXvy5dirKlz8=
 github.com/nutanix/ntnx-api-golang-clients/dataprotection-go-client/v4 v4.2.1 h1:nbWHd6GtqGiDg7q0nI3Ibx0fVSff2BqqphG0x7/9CCY=
 github.com/nutanix/ntnx-api-golang-clients/dataprotection-go-client/v4 v4.2.1/go.mod h1:S07bx9/6uUbMOY/OUJsaIUdvZ/LDaE46Kx9VX7Pt7Ek=
-github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4 v4.0.1 h1:zWbA2qtSJt0WsBcEhqqv6FQTSz8pIwBnHA5etaQg4qo=
-github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4 v4.0.1/go.mod h1:+HvW0f4QGDRZ3/1jcXvF7xA/gQsvQc4XtZy6OUobaO4=
+github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4 v4.1.1-beta.2 h1:8L9/2CfKhoR6Eewa2uy9R0BV90MR98/S7VVEpaPZQqw=
+github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4 v4.1.1-beta.2/go.mod h1:+HvW0f4QGDRZ3/1jcXvF7xA/gQsvQc4XtZy6OUobaO4=
 github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.1 h1:0jj9dZt1Po1u+J6aq1uOdzcGDEM05yvhNTQV+2VT39o=
 github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.1/go.mod h1:fQTNQlfh5g4SavaQn+sDoMn29K+Lur5lHWtnbq3uA28=
 github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.1 h1:mPwqYXTo3kNoINBLGaz/adB4Lzer4XkmAA5o/i9dl7I=

--- a/go.sum
+++ b/go.sum
@@ -469,8 +469,8 @@ github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.1 h1:mPwqY
 github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.1/go.mod h1:75Ro+aFIepNAkf2eWjFrFR7m+Ct36EVrD9n9pwAYBrc=
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.2.1 h1:xXILK1m5eMvCVg1iisiMSYFKqxOxJ3FNvPjLEiGgBgg=
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.2.1/go.mod h1:+eZgV1+xL/r84qmuFSVt5R8OFRO70rEz92jOnVgJNco=
-github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4 v4.0.1 h1:hfx71E22s7pzuzjSDrexLbgasdlBPqPNp9t7NU4wmmU=
-github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4 v4.0.1/go.mod h1:dZGm3+O01e9X31VTpChM0GBph1tfw9sfZ+G4DVsd3wY=
+github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4 v4.0.2 h1:gD9SlO3tjNrSFA1khrnMwQsAq0eayXgv8vmiZerIHn0=
+github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4 v4.0.2/go.mod h1:dZGm3+O01e9X31VTpChM0GBph1tfw9sfZ+G4DVsd3wY=
 github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4 v4.2.1 h1:fOP5GH16QzVsrcKkNhgarfPmYaSR/rsy0CArV8dLkx8=
 github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4 v4.2.1/go.mod h1:Yhk+xD4mN90OKEHnk5ARf97CX5p4+MEC/B/YIVoZeZ0=
 github.com/nutanix/ntnx-api-golang-clients/security-go-client/v4 v4.1.1 h1:t97gS9rShP2O3Z29Yxo5+TlWzt1rOOR/KlqA1FzFLvY=

--- a/nutanix/sdks/v4/clusters/clusters.go
+++ b/nutanix/sdks/v4/clusters/clusters.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/api"
 	cluster "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
 )
 
 type Client struct {
@@ -26,14 +27,14 @@ func NewClustersClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Host = credentials.Endpoint
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
-		pcClient.Port = 9440
+		pcClient.Port = sdkconfig.DefaultPort
 		if credentials.Port != "" {
 			if p, err := strconv.Atoi(credentials.Port); err == nil {
 				pcClient.Port = p
 			}
 		}
 		pcClient.VerifySSL = false
-		// pcClient.AllowVersionNegotiation = false
+		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/clusters/clusters.go
+++ b/nutanix/sdks/v4/clusters/clusters.go
@@ -1,7 +1,6 @@
 package clusters
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/api"
@@ -27,13 +26,14 @@ func NewClustersClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Host = credentials.Endpoint
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
-		port, err := strconv.Atoi(credentials.Port)
-		if err != nil {
-			return nil, fmt.Errorf("invalid port: %w", err)
+		pcClient.Port = 9440
+		if credentials.Port != "" {
+			if p, err := strconv.Atoi(credentials.Port); err == nil {
+				pcClient.Port = p
+			}
 		}
-		pcClient.Port = port
 		pcClient.VerifySSL = false
-
+		pcClient.AllowVersionNegotiation = false
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/clusters/clusters.go
+++ b/nutanix/sdks/v4/clusters/clusters.go
@@ -33,7 +33,7 @@ func NewClustersClient(credentials client.Credentials) (*Client, error) {
 			}
 		}
 		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = false
+		// pcClient.AllowVersionNegotiation = false
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/datapolicies/datapolicies.go
+++ b/nutanix/sdks/v4/datapolicies/datapolicies.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nutanix/ntnx-api-golang-clients/datapolicies-go-client/v4/api"
 	datapolicies "github.com/nutanix/ntnx-api-golang-clients/datapolicies-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
 )
 
 type Client struct {
@@ -23,14 +24,14 @@ func NewDataPoliciesClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Host = credentials.Endpoint
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
-		pcClient.Port = 9440
+		pcClient.Port = sdkconfig.DefaultPort
 		if credentials.Port != "" {
 			if p, err := strconv.Atoi(credentials.Port); err == nil {
 				pcClient.Port = p
 			}
 		}
 		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = false
+		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/datapolicies/datapolicies.go
+++ b/nutanix/sdks/v4/datapolicies/datapolicies.go
@@ -23,14 +23,14 @@ func NewDataPoliciesClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Host = credentials.Endpoint
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
-		port, err := strconv.Atoi(credentials.Port)
-		if err != nil {
-			pcClient.Port = 9440
+		pcClient.Port = 9440
+		if credentials.Port != "" {
+			if p, err := strconv.Atoi(credentials.Port); err == nil {
+				pcClient.Port = p
+			}
 		}
-		pcClient.Port = port
-
 		pcClient.VerifySSL = false
-
+		pcClient.AllowVersionNegotiation = false
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/dataprotection/dataprotection.go
+++ b/nutanix/sdks/v4/dataprotection/dataprotection.go
@@ -1,6 +1,8 @@
 package dataprotection
 
 import (
+	"strconv"
+
 	"github.com/nutanix/ntnx-api-golang-clients/dataprotection-go-client/v4/api"
 	dataprotection "github.com/nutanix/ntnx-api-golang-clients/dataprotection-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -22,8 +24,13 @@ func NewDataProtectionClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
 		pcClient.Port = 9440
+		if credentials.Port != "" {
+			if p, err := strconv.Atoi(credentials.Port); err == nil {
+				pcClient.Port = p
+			}
+		}
 		pcClient.VerifySSL = false
-
+		pcClient.AllowVersionNegotiation = false
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/dataprotection/dataprotection.go
+++ b/nutanix/sdks/v4/dataprotection/dataprotection.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nutanix/ntnx-api-golang-clients/dataprotection-go-client/v4/api"
 	dataprotection "github.com/nutanix/ntnx-api-golang-clients/dataprotection-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
 )
 
 type Client struct {
@@ -23,14 +24,14 @@ func NewDataProtectionClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Host = credentials.Endpoint
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
-		pcClient.Port = 9440
+		pcClient.Port = sdkconfig.DefaultPort
 		if credentials.Port != "" {
 			if p, err := strconv.Atoi(credentials.Port); err == nil {
 				pcClient.Port = p
 			}
 		}
 		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = false
+		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/iam/iam.go
+++ b/nutanix/sdks/v4/iam/iam.go
@@ -36,6 +36,7 @@ func NewIamClient(credentials client.Credentials) (*Client, error) {
 			}
 		}
 		pcClient.VerifySSL = false
+		pcClient.AllowVersionNegotiation = false
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/iam/iam.go
+++ b/nutanix/sdks/v4/iam/iam.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4/api"
 	iam "github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
 )
 
 type Client struct {
@@ -29,14 +30,14 @@ func NewIamClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Host = credentials.Endpoint
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
-		pcClient.Port = 9440
+		pcClient.Port = sdkconfig.DefaultPort
 		if credentials.Port != "" {
 			if p, err := strconv.Atoi(credentials.Port); err == nil {
 				pcClient.Port = p
 			}
 		}
 		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = false
+		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/iam/iam.go
+++ b/nutanix/sdks/v4/iam/iam.go
@@ -1,6 +1,8 @@
 package iam
 
 import (
+	"strconv"
+
 	"github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4/api"
 	iam "github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -28,8 +30,12 @@ func NewIamClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
 		pcClient.Port = 9440
+		if credentials.Port != "" {
+			if p, err := strconv.Atoi(credentials.Port); err == nil {
+				pcClient.Port = p
+			}
+		}
 		pcClient.VerifySSL = false
-
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/lcm/lcm.go
+++ b/nutanix/sdks/v4/lcm/lcm.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4/api"
 	lcm "github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
 )
 
 type Client struct {
@@ -27,14 +28,14 @@ func NewLcmClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Host = credentials.Endpoint
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
-		pcClient.Port = 9440
+		pcClient.Port = sdkconfig.DefaultPort
 		if credentials.Port != "" {
 			if p, err := strconv.Atoi(credentials.Port); err == nil {
 				pcClient.Port = p
 			}
 		}
 		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = false
+		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/lcm/lcm.go
+++ b/nutanix/sdks/v4/lcm/lcm.go
@@ -1,6 +1,8 @@
 package lcm
 
 import (
+	"strconv"
+
 	"github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4/api"
 	lcm "github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -26,8 +28,13 @@ func NewLcmClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
 		pcClient.Port = 9440
+		if credentials.Port != "" {
+			if p, err := strconv.Atoi(credentials.Port); err == nil {
+				pcClient.Port = p
+			}
+		}
 		pcClient.VerifySSL = false
-
+		pcClient.AllowVersionNegotiation = false
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/microseg/microseg.go
+++ b/nutanix/sdks/v4/microseg/microseg.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4/api"
 	microseg "github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
 )
 
 type Client struct {
@@ -24,14 +25,14 @@ func NewMicrosegClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Host = credentials.Endpoint
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
-		pcClient.Port = 9440
+		pcClient.Port = sdkconfig.DefaultPort
 		if credentials.Port != "" {
 			if p, err := strconv.Atoi(credentials.Port); err == nil {
 				pcClient.Port = p
 			}
 		}
 		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = false
+		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/microseg/microseg.go
+++ b/nutanix/sdks/v4/microseg/microseg.go
@@ -1,6 +1,8 @@
 package microseg
 
 import (
+	"strconv"
+
 	"github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4/api"
 	microseg "github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -23,8 +25,13 @@ func NewMicrosegClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
 		pcClient.Port = 9440
+		if credentials.Port != "" {
+			if p, err := strconv.Atoi(credentials.Port); err == nil {
+				pcClient.Port = p
+			}
+		}
 		pcClient.VerifySSL = false
-
+		pcClient.AllowVersionNegotiation = false
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/networking/networking.go
+++ b/nutanix/sdks/v4/networking/networking.go
@@ -1,6 +1,8 @@
 package networking
 
 import (
+	"strconv"
+
 	"github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/api"
 	network "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -27,8 +29,13 @@ func NewNetworkingClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
 		pcClient.Port = 9440
+		if credentials.Port != "" {
+			if p, err := strconv.Atoi(credentials.Port); err == nil {
+				pcClient.Port = p
+			}
+		}
 		pcClient.VerifySSL = false
-
+		pcClient.AllowVersionNegotiation = false
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/networking/networking.go
+++ b/nutanix/sdks/v4/networking/networking.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/api"
 	network "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
 )
 
 type Client struct {
@@ -28,14 +29,14 @@ func NewNetworkingClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Host = credentials.Endpoint
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
-		pcClient.Port = 9440
+		pcClient.Port = sdkconfig.DefaultPort
 		if credentials.Port != "" {
 			if p, err := strconv.Atoi(credentials.Port); err == nil {
 				pcClient.Port = p
 			}
 		}
 		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = false
+		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/objectstores/objectstores.go
+++ b/nutanix/sdks/v4/objectstores/objectstores.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4/api"
 	object "github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
 )
 
 type Client struct {
@@ -22,14 +23,14 @@ func NewObjectStoresClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Host = credentials.Endpoint
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
-		pcClient.Port = 9440
+		pcClient.Port = sdkconfig.DefaultPort
 		if credentials.Port != "" {
 			if p, err := strconv.Atoi(credentials.Port); err == nil {
 				pcClient.Port = p
 			}
 		}
 		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = false
+		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/objectstores/objectstores.go
+++ b/nutanix/sdks/v4/objectstores/objectstores.go
@@ -1,7 +1,6 @@
 package objectstores
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4/api"
@@ -23,13 +22,13 @@ func NewObjectStoresClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Host = credentials.Endpoint
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
-		port, err := strconv.Atoi(credentials.Port)
-		if err != nil {
-			return nil, fmt.Errorf("invalid port: %w", err)
+		pcClient.Port = 9440
+		if credentials.Port != "" {
+			if p, err := strconv.Atoi(credentials.Port); err == nil {
+				pcClient.Port = p
+			}
 		}
-		pcClient.Port = port
 		pcClient.VerifySSL = false
-
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/objectstores/objectstores.go
+++ b/nutanix/sdks/v4/objectstores/objectstores.go
@@ -29,6 +29,7 @@ func NewObjectStoresClient(credentials client.Credentials) (*Client, error) {
 			}
 		}
 		pcClient.VerifySSL = false
+		pcClient.AllowVersionNegotiation = false
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/prism/prism.go
+++ b/nutanix/sdks/v4/prism/prism.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/api"
 	prism "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
 )
 
 type Client struct {
@@ -25,14 +26,14 @@ func NewPrismClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Host = credentials.Endpoint
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
-		pcClient.Port = 9440
+		pcClient.Port = sdkconfig.DefaultPort
 		if credentials.Port != "" {
 			if p, err := strconv.Atoi(credentials.Port); err == nil {
 				pcClient.Port = p
 			}
 		}
 		pcClient.VerifySSL = false
-		// pcClient.AllowVersionNegotiation = false
+		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/prism/prism.go
+++ b/nutanix/sdks/v4/prism/prism.go
@@ -1,6 +1,8 @@
 package prism
 
 import (
+	"strconv"
+
 	"github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/api"
 	prism "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -24,7 +26,13 @@ func NewPrismClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
 		pcClient.Port = 9440
+		if credentials.Port != "" {
+			if p, err := strconv.Atoi(credentials.Port); err == nil {
+				pcClient.Port = p
+			}
+		}
 		pcClient.VerifySSL = false
+		pcClient.AllowVersionNegotiation = false
 
 		baseClient = pcClient
 	}

--- a/nutanix/sdks/v4/prism/prism.go
+++ b/nutanix/sdks/v4/prism/prism.go
@@ -32,8 +32,7 @@ func NewPrismClient(credentials client.Credentials) (*Client, error) {
 			}
 		}
 		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = false
-
+		// pcClient.AllowVersionNegotiation = false
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/sdkconfig/constants.go
+++ b/nutanix/sdks/v4/sdkconfig/constants.go
@@ -5,7 +5,7 @@ package sdkconfig
 //
 // Keep this centralized so the behavior can be toggled across all v4 clients by changing
 // a single value.
-const AllowVersionNegotiation = false
+const AllowVersionNegotiation = true
 
 // DefaultPort is the default Prism Central port used by v4 SDK clients when no port is provided.
 const DefaultPort = 9440

--- a/nutanix/sdks/v4/sdkconfig/constants.go
+++ b/nutanix/sdks/v4/sdkconfig/constants.go
@@ -1,0 +1,11 @@
+package sdkconfig
+
+// AllowVersionNegotiation controls whether Nutanix v4 generated SDK clients will attempt
+// server-side API version negotiation.
+//
+// Keep this centralized so the behavior can be toggled across all v4 clients by changing
+// a single value.
+const AllowVersionNegotiation = false
+
+// DefaultPort is the default Prism Central port used by v4 SDK clients when no port is provided.
+const DefaultPort = 9440

--- a/nutanix/sdks/v4/security/security.go
+++ b/nutanix/sdks/v4/security/security.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nutanix/ntnx-api-golang-clients/security-go-client/v4/api"
 	prism "github.com/nutanix/ntnx-api-golang-clients/security-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
 )
 
 type Client struct {
@@ -23,14 +24,14 @@ func NewSecurityClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Host = credentials.Endpoint
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
-		pcClient.Port = 9440
+		pcClient.Port = sdkconfig.DefaultPort
 		if credentials.Port != "" {
 			if p, err := strconv.Atoi(credentials.Port); err == nil {
 				pcClient.Port = p
 			}
 		}
 		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = false
+		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/security/security.go
+++ b/nutanix/sdks/v4/security/security.go
@@ -20,16 +20,17 @@ func NewSecurityClient(credentials client.Credentials) (*Client, error) {
 	if credentials.Username != "" && credentials.Password != "" && credentials.Endpoint != "" {
 		pcClient := prism.NewApiClient()
 
-		port, err := strconv.Atoi(credentials.Port)
-		if err != nil {
-			pcClient.Port = 9440
-		}
 		pcClient.Host = credentials.Endpoint
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
-		pcClient.Port = port
+		pcClient.Port = 9440
+		if credentials.Port != "" {
+			if p, err := strconv.Atoi(credentials.Port); err == nil {
+				pcClient.Port = p
+			}
+		}
 		pcClient.VerifySSL = false
-
+		pcClient.AllowVersionNegotiation = false
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/vmm/vmm.go
+++ b/nutanix/sdks/v4/vmm/vmm.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/api"
 	vmm "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
 )
 
 type Client struct {
@@ -26,14 +27,14 @@ func NewVmmClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Host = credentials.Endpoint
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
-		pcClient.Port = 9440
+		pcClient.Port = sdkconfig.DefaultPort
 		if credentials.Port != "" {
 			if p, err := strconv.Atoi(credentials.Port); err == nil {
 				pcClient.Port = p
 			}
 		}
 		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = false
+		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/vmm/vmm.go
+++ b/nutanix/sdks/v4/vmm/vmm.go
@@ -1,6 +1,8 @@
 package vmm
 
 import (
+	"strconv"
+
 	"github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/api"
 	vmm "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -25,8 +27,13 @@ func NewVmmClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
 		pcClient.Port = 9440
+		if credentials.Port != "" {
+			if p, err := strconv.Atoi(credentials.Port); err == nil {
+				pcClient.Port = p
+			}
+		}
 		pcClient.VerifySSL = false
-
+		pcClient.AllowVersionNegotiation = false
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/volumes/volumes.go
+++ b/nutanix/sdks/v4/volumes/volumes.go
@@ -1,6 +1,8 @@
 package volumes
 
 import (
+	"strconv"
+
 	"github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4/api"
 	prism "github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -22,8 +24,13 @@ func NewVolumeClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
 		pcClient.Port = 9440
+		if credentials.Port != "" {
+			if p, err := strconv.Atoi(credentials.Port); err == nil {
+				pcClient.Port = p
+			}
+		}
 		pcClient.VerifySSL = false
-
+		pcClient.AllowVersionNegotiation = false
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/volumes/volumes.go
+++ b/nutanix/sdks/v4/volumes/volumes.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4/api"
 	prism "github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
 )
 
 type Client struct {
@@ -23,14 +24,14 @@ func NewVolumeClient(credentials client.Credentials) (*Client, error) {
 		pcClient.Host = credentials.Endpoint
 		pcClient.Password = credentials.Password
 		pcClient.Username = credentials.Username
-		pcClient.Port = 9440
+		pcClient.Port = sdkconfig.DefaultPort
 		if credentials.Port != "" {
 			if p, err := strconv.Atoi(credentials.Port); err == nil {
 				pcClient.Port = p
 			}
 		}
 		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = false
+		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 

--- a/nutanix/services/passwordmanagerv2/resource_nutanix_password_manager_v2.go
+++ b/nutanix/services/passwordmanagerv2/resource_nutanix_password_manager_v2.go
@@ -33,8 +33,7 @@ func isUnauthorizedErr(err error) bool {
 		strings.Contains(msg, "invalid credentials") ||
 		// prism-go-client tries to follow OIDC redirects but incorrectly builds a relative URL,
 		// which results in: `unsupported protocol scheme ""`
-		strings.Contains(msg, "unsupported protocol scheme") ||
-		strings.Contains(msg, "/api/iam/authn/v1/oidc/auth")
+		strings.Contains(msg, "unsupported protocol scheme")
 }
 
 func ResourceNutanixPasswordManagerV2() *schema.Resource {
@@ -92,6 +91,9 @@ func resourceNutanixPasswordManagerV2Create(ctx context.Context, d *schema.Resou
 	_, taskErr := taskconn.TaskRefAPI.GetTaskById(taskUUID, nil)
 	if taskErr != nil && isUnauthorizedErr(taskErr) {
 		log.Printf("[DEBUG] prism task fetch returned unauthorized after password change; recreating prism client with new password and retrying")
+
+		aJSON, _ = json.MarshalIndent(taskErr, "", "  ")
+		log.Printf("[DEBUG]  task error object: %s", string(aJSON))
 
 		newCredentials := client.Credentials{
 			Username: taskconn.TaskRefAPI.ApiClient.Username,

--- a/nutanix/services/passwordmanagerv2/resource_nutanix_password_manager_v2.go
+++ b/nutanix/services/passwordmanagerv2/resource_nutanix_password_manager_v2.go
@@ -20,6 +20,23 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/utils"
 )
 
+func isUnauthorizedErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Different generated clients format auth failures differently; be permissive.
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "401") ||
+		strings.Contains(msg, "unauthorized") ||
+		strings.Contains(msg, "invalid auth credentials") ||
+		strings.Contains(msg, "invalid credentials") ||
+		// prism-go-client tries to follow OIDC redirects but incorrectly builds a relative URL,
+		// which results in: `unsupported protocol scheme ""`
+		strings.Contains(msg, "unsupported protocol scheme") ||
+		strings.Contains(msg, "/api/iam/authn/v1/oidc/auth")
+}
+
 func ResourceNutanixPasswordManagerV2() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceNutanixPasswordManagerV2Create,
@@ -73,69 +90,29 @@ func resourceNutanixPasswordManagerV2Create(ctx context.Context, d *schema.Resou
 	taskconn := meta.(*conns.Client).PrismAPI
 
 	_, taskErr := taskconn.TaskRefAPI.GetTaskById(taskUUID, nil)
-	if taskErr != nil {
-		log.Printf("[DEBUG] Checking if the error is due to password change for the user configured in the provider configuration")
-		// if the error is 401, it means the password has been changed for the
-		// user configured in the provider configuration, so we need to set the new password
-		// and retry to fetch the task
-		// Convert the struct to JSON bytes
-		rawJSON, _ := json.Marshal(taskErr)
+	if taskErr != nil && isUnauthorizedErr(taskErr) {
+		log.Printf("[DEBUG] prism task fetch returned unauthorized after password change; recreating prism client with new password and retrying")
 
-		var taskErrMap map[string]interface{}
-
-		if unmarshalErr := json.Unmarshal(rawJSON, &taskErrMap); unmarshalErr == nil {
-			log.Printf("[DEBUG]  Error message: %s", taskErrMap["Message"])
-			if status, ok := taskErrMap["Status"].(string); ok && strings.Contains(status, "401") {
-				log.Printf("[DEBUG]  Status code is %s, indicating a 401 Unauthorized error", taskErrMap["Status"])
-				// password changed for the user configured in the provider configuration
-				// set the task conn client password to the new password and retry to fetch the task
-
-				newCredentials := client.Credentials{
-					Username: taskconn.TaskRefAPI.ApiClient.Username,
-					Password: utils.StringValue(body.NewPassword),
-					Endpoint: taskconn.TaskRefAPI.ApiClient.Host,
-					Port:     strconv.Itoa(taskconn.TaskRefAPI.ApiClient.Port),
-				}
-
-				newPrismClient, prismErr := prism.NewPrismClient(newCredentials)
-				if prismErr != nil {
-					return diag.Errorf("error while creating new prism client: %v", prismErr)
-				}
-
-				// retry to fetch the task
-				_, taskErr = newPrismClient.TaskRefAPI.GetTaskById(taskUUID, nil)
-				if taskErr != nil {
-					return diag.Errorf("error while fetching task by ID %s: %v", utils.StringValue(taskUUID), taskErr)
-				}
-
-				// Wait for the password change to complete
-				stateConf := &resource.StateChangeConf{
-					Pending: []string{"PENDING", "RUNNING", "QUEUED"},
-					Target:  []string{"SUCCEEDED"},
-					Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, newPrismClient, utils.StringValue(taskUUID)),
-					Timeout: d.Timeout(schema.TimeoutCreate),
-				}
-
-				if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
-					return diag.Errorf("error waiting for password change (%s) to complete: %s", utils.StringValue(taskUUID), errWaitTask)
-				}
-
-				// Get task details for logging
-				taskResp, err := newPrismClient.TaskRefAPI.GetTaskById(taskUUID, nil)
-				if err != nil {
-					return diag.Errorf("error while fetching password change task: %v", err)
-				}
-				taskDetails := taskResp.Data.GetValue().(prismConfig.Task)
-				aJSON, _ = json.MarshalIndent(taskDetails, "", "  ")
-				log.Printf("[DEBUG] Create Password Manager Task Details: %s", string(aJSON))
-
-				// This is an action resource that does not maintain state.
-				// The resource ID is set to the task ExtId for traceability.
-				d.SetId(utils.StringValue(taskDetails.ExtId))
-				return resourceNutanixPasswordManagerV2Read(ctx, d, meta)
-			}
-			return diag.Errorf("error while fetching task by ID %s: %v", utils.StringValue(taskUUID), taskErr)
+		newCredentials := client.Credentials{
+			Username: taskconn.TaskRefAPI.ApiClient.Username,
+			Password: utils.StringValue(body.NewPassword),
+			Endpoint: taskconn.TaskRefAPI.ApiClient.Host,
+			Port:     strconv.Itoa(taskconn.TaskRefAPI.ApiClient.Port),
+			// ApiClient.VerifySSL=false means "insecure".
+			Insecure: !taskconn.TaskRefAPI.ApiClient.VerifySSL,
 		}
+
+		newPrismClient, prismErr := prism.NewPrismClient(newCredentials)
+		if prismErr != nil {
+			return diag.Errorf("error while creating new prism client: %v", prismErr)
+		}
+		newPrismClient.TaskRefAPI.ApiClient.AllowVersionNegotiation = false
+
+		taskconn = newPrismClient
+		_, taskErr = taskconn.TaskRefAPI.GetTaskById(taskUUID, nil)
+	}
+	if taskErr != nil {
+		return diag.Errorf("error while fetching task by ID %s: %v", utils.StringValue(taskUUID), taskErr)
 	}
 
 	// The password change is not for the user configured in the provider configuration

--- a/nutanix/services/passwordmanagerv2/resource_nutanix_password_manager_v2.go
+++ b/nutanix/services/passwordmanagerv2/resource_nutanix_password_manager_v2.go
@@ -106,7 +106,7 @@ func resourceNutanixPasswordManagerV2Create(ctx context.Context, d *schema.Resou
 		if prismErr != nil {
 			return diag.Errorf("error while creating new prism client: %v", prismErr)
 		}
-		newPrismClient.TaskRefAPI.ApiClient.AllowVersionNegotiation = false
+		// newPrismClient.TaskRefAPI.ApiClient.AllowVersionNegotiation = false
 
 		taskconn = newPrismClient
 		_, taskErr = taskconn.TaskRefAPI.GetTaskById(taskUUID, nil)


### PR DESCRIPTION
## Summary
This PR improves Prism v4 client initialization and makes the Password Manager v2 password-change flow more reliable.

## Changes
- **v4 SDK client init**
  - Default **port to 9440** when `credentials.Port` is empty/invalid (avoid setting port `0` or returning errors)
  - Set `AllowVersionNegotiation = false` on v4 clients that support it

- **Password Manager v2**
  - Add tolerant detection for “unauthorized” errors during task polling after a password change
  - Recreate the Prism client with the **new password** and retry task fetch (preserving “insecure” behavior)
  - Ensure `AllowVersionNegotiation` is disabled on the recreated Prism client

