### PR TITLE
[Feat] API Key and custom headers as an alternative method of authorisation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,5 +18,10 @@ NDB_ENDPOINT="x.x.x.x"
 NDB_USERNAME="x.x.x.x"
 NDB_PASSWORD="x.x.x.x"
 
+# API Key (the `X-Ntnx-Api-Key` header will be used instead of Basic Authentication) and Custom Headers (eg for Cloudflare Access)
+# NUTANIX_API_KEY="xxx" 
+# NUTANIX_HEADER_CF_ACCESS_CLIENT_ID="xxx.access"
+# NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET="xxx"
+
 # Terraform / test log level
 TF_LOG=ERROR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,10 +81,10 @@ under:
    Local Nutanix provider plugin will be used after `terraform init`
    command execution in Terraform template directory
 
-
 ### Running tests of provider
 
 For running unit tests:
+
 ```sh
 make test
 ```
@@ -92,39 +92,56 @@ make test
 For running integration tests:
 
 1. Add environment variables for setup related details:
-```ssh
-export NUTANIX_USERNAME="<username>"
-export NUTANIX_PASSWORD="<password>"
-export NUTANIX_INSECURE=true
-export NUTANIX_PORT=9440
-export NUTANIX_ENDPOINT="<pc-ip>"
-export NUTANIX_STORAGE_CONTAINER="<storage-container-uuid-for-vm-tests>"
-export FOUNDATION_ENDPOINT="<foundation-vm-ip-for-foundation-related-tests>"
-export FOUNDATION_PORT=8000
-export NOS_IMAGE_TEST_URL="<test-image-url>"
-export NDB_ENDPOINT="<ndb-ip>"
-export NDB_USERNAME="<username>"
-export NDB_PASSWORD="<password>"
-```
+
+    ```sh
+    export NUTANIX_USERNAME="<username>"
+    export NUTANIX_PASSWORD="<password>"
+    export NUTANIX_INSECURE=true
+    export NUTANIX_PORT=9440
+    export NUTANIX_ENDPOINT="<pc-ip>"
+    export NUTANIX_STORAGE_CONTAINER="<storage-container-uuid-for-vm-tests>"
+    export FOUNDATION_ENDPOINT="<foundation-vm-ip-for-foundation-related-tests>"
+    export FOUNDATION_PORT=8000
+    export NOS_IMAGE_TEST_URL="<test-image-url>"
+    export NDB_ENDPOINT="<ndb-ip>"
+    export NDB_USERNAME="<username>"
+    export NDB_PASSWORD="<password>"
+    ```
+
+    Alternatively, you can authenticate using an API key instead of username/password:
+
+    ```sh
+    export NUTANIX_API_KEY="<api-key>"
+    ```
+
+    Custom HTTP headers (e.g. for Cloudflare Access) can be injected via environment variables with the `NUTANIX_HEADER_` prefix:
+
+    ```sh
+    export NUTANIX_HEADER_CF_ACCESS_CLIENT_ID="<client-id>"
+    export NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET="<client-secret>"
+    ```
 
 2. Some tests need setup related constants for resource creation. So add/replace details in test_config.json (for pc tests) and test_foundation_config.json (for foundation and foundation central tests and NDB)
 
 3. To run all tests:
-```ssh
-make testacc
-```
+
+    ```sh
+    make testacc
+    ```
 
 4. To run specific tests:
-```ssh 
-export TESTARGS='-run=TestAccNutanixPbr_WithSourceExternalDestinationNetwork'
-make testacc
-```
+
+    ```sh
+    export TESTARGS='-run=TestAccNutanixPbr_WithSourceExternalDestinationNetwork'
+    make testacc
+    ```
 
 5. To run collection of tests:
-``` ssh
-export TESTARGS='-run=TestAccNutanixPbr*'
-make testacc
-```
+
+    ```sh
+    export TESTARGS='-run=TestAccNutanixPbr*'
+    make testacc
+    ```
 
 ### Common Issues using the development binary.
 

--- a/README.md
+++ b/README.md
@@ -108,13 +108,16 @@ Long term, once this is upstream, no pre-compiled binaries will be needed, as te
 The following keys can be used to configure the provider.
 
 * **endpoint** - (Required) IP address for the Nutanix Prism Central.
-* **username** - (Required) Username for Nutanix Prism Central. Could be local cluster auth (e.g. `auth`) or directory auth.
-* **password** - (Required) Password for the provided username.
-* **port** - (Optional) Port for the Nutanix Prism Central. Default port is 9440.
+* **username** - (Optional) Username for Nutanix Prism Central. Could be local cluster auth (e.g. `auth`) or directory auth. Required if `api_key` is not set.
+* **password** - (Optional) Password for the provided username. Required if `api_key` is not set.
+* **api_key** - (Optional) API key for Nutanix Prism Central authentication. Can be used as an alternative to `username`/`password`. When set, the `X-Ntnx-Api-Key` header is used instead of Basic Authentication.
+* **port** - (Optional) Port for the Nutanix Prism Central. Default port is 9440. Can also be set via the `NUTANIX_PORT` environment variable.
 * **insecure** - (Optional) Explicitly allow the provider to perform insecure SSL requests. If omitted, default value is false.
-* **wait_timeout** - (optional) Set if you know that the creation o update of a resource may take long time (minutes).
+* **wait_timeout** - (Optional) Set if you know that the creation or update of a resource may take long time (minutes).
+* **custom_headers** - (Optional) Map of custom HTTP headers to add to all API requests. Useful for environments that require additional headers such as Cloudflare Access service tokens. Headers can also be set via environment variables with the `NUTANIX_HEADER_` prefix (e.g. `NUTANIX_HEADER_CF_ACCESS_CLIENT_ID` becomes `Cf-Access-Client-Id`). Values defined in config take precedence over environment variables.
 
 ```hcl
+# Basic authentication
 provider "nutanix" {
   username     = "admin"
   password     = "myPassword"
@@ -123,9 +126,22 @@ provider "nutanix" {
   insecure     = true
   wait_timeout = 10
 }
+
+# API key authentication with custom headers (e.g. Cloudflare Access)
+provider "nutanix" {
+  api_key      = "my-api-key"
+  port         = 443
+  endpoint     = "10.36.7.201"
+  insecure     = true
+  wait_timeout = 10
+  custom_headers = {
+    "Cf-Access-Client-Id"     = "my-client-id"
+    "Cf-Access-Client-Secret" = "my-client-secret"
+  }
+}
 ```
 
-## From terraform-provider-nutanix v1.5.0-beta :
+## From terraform-provider-nutanix v1.5.0-beta
 
 The following keys can be used to configure the provider.
 
@@ -151,7 +167,7 @@ provider "nutanix" {
 }
 ```
 
-## Additional fields for using Nutanix Database Service:
+## Additional fields for using Nutanix Database Service
 
 * **ndb_username** - (Optional) Username of Nutanix Database Service server
 * **ndb_password** - (Optional) Password of Nutanix Database Service server
@@ -166,10 +182,10 @@ provider "nutanix" {
 ```
 
 ### Provider Configuration Requirements & Warnings
-From foundation getting released in 1.5.0-beta, provider configuration will accomodate prism central and foundation apis connection details. **It will show warnings for disabled api connections as per the attributes given in provider configuration in above mentioned format**. The below are the required attributes for corresponding provider componenets :
-* endpoint, username and password are required fields for using Prism Central & Karbon based resources and data sources
-* foundation_endpoint is required field for using Foundation based resources and data sources
-* ndb_username, ndb_password and ndb_endpoint are required fields for using NDB based resources and data sources
+From foundation getting released in 1.5.0-beta, provider configuration will accommodate Prism Central and foundation API connection details. **It will show warnings for disabled API connections as per the attributes given in provider configuration in above mentioned format**. The below are the required attributes for corresponding provider components:
+* `endpoint` and either (`username` + `password`) or `api_key` are required for using Prism Central & Karbon based resources and data sources.
+* `foundation_endpoint` is required field for using Foundation based resources and data sources
+* `ndb_username`, `ndb_password` and `ndb_endpoint` are required fields for using NDB based resources and data sources
 
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The following keys can be used to configure the provider.
 * **endpoint** - (Required) IP address for the Nutanix Prism Central.
 * **username** - (Optional) Username for Nutanix Prism Central. Could be local cluster auth (e.g. `auth`) or directory auth. Required if `api_key` is not set.
 * **password** - (Optional) Password for the provided username. Required if `api_key` is not set.
-* **api_key** - (Optional) API key for Nutanix Prism Central authentication. Can be used as an alternative to `username`/`password`. When set, the `X-Ntnx-Api-Key` header is used instead of Basic Authentication.
+* **api_key** - (Optional) API key for Prism Central authentication. Can be used as an alternative to `username`/`password` when connecting to a Prism Central instance. **Not supported by Prism Elements**, which requires `username` and `password`. When set, the `X-Ntnx-Api-Key` header is used instead of Basic Authentication.
 * **port** - (Optional) Port for the Nutanix Prism Central. Default port is 9440. Can also be set via the `NUTANIX_PORT` environment variable.
 * **insecure** - (Optional) Explicitly allow the provider to perform insecure SSL requests. If omitted, default value is false.
 * **wait_timeout** - (Optional) Set if you know that the creation or update of a resource may take long time (minutes).

--- a/nutanix/acctest/acctest.go
+++ b/nutanix/acctest/acctest.go
@@ -36,13 +36,29 @@ func TestProviderImpl(t *testing.T) {
 }
 
 func TestAccPreCheck(t *testing.T) {
-	if os.Getenv("NUTANIX_USERNAME") == "" ||
-		os.Getenv("NUTANIX_PASSWORD") == "" ||
-		os.Getenv("NUTANIX_INSECURE") == "" ||
+	// Check common required variables
+	if os.Getenv("NUTANIX_INSECURE") == "" ||
 		os.Getenv("NUTANIX_PORT") == "" ||
 		os.Getenv("NUTANIX_ENDPOINT") == "" ||
 		os.Getenv("NUTANIX_STORAGE_CONTAINER") == "" {
-		t.Fatal("`NUTANIX_USERNAME`,`NUTANIX_PASSWORD`,`NUTANIX_INSECURE`,`NUTANIX_PORT`,`NUTANIX_ENDPOINT`, `NUTANIX_STORAGE_CONTAINER` must be set for acceptance testing")
+		t.Fatal("`NUTANIX_INSECURE`,`NUTANIX_PORT`,`NUTANIX_ENDPOINT`,`NUTANIX_STORAGE_CONTAINER` must be set for acceptance testing")
+	}
+
+	// Check authentication - either username/password OR api_key must be set
+	hasBasicAuth := os.Getenv("NUTANIX_USERNAME") != "" && os.Getenv("NUTANIX_PASSWORD") != ""
+	hasAPIKey := os.Getenv("NUTANIX_API_KEY") != ""
+
+	if !hasBasicAuth && !hasAPIKey {
+		t.Fatal("Either `NUTANIX_USERNAME` and `NUTANIX_PASSWORD`, or `NUTANIX_API_KEY` must be set for acceptance testing")
+	}
+}
+
+// TestAccPreCheckStorageContainer checks for storage container requirement
+// Use this in addition to TestAccPreCheck for tests that create VMs with disks
+func TestAccPreCheckStorageContainer(t *testing.T) {
+	TestAccPreCheck(t)
+	if os.Getenv("NUTANIX_STORAGE_CONTAINER") == "" {
+		t.Fatal("`NUTANIX_STORAGE_CONTAINER` must be set for VM creation tests")
 	}
 }
 

--- a/nutanix/client/client.go
+++ b/nutanix/client/client.go
@@ -59,7 +59,7 @@ type Client struct {
 // RequestCompletionCallback defines the type of the request callback function
 type RequestCompletionCallback func(*http.Request, *http.Response, interface{})
 
-// Credentials needed username and password
+// Credentials needed username and password (or API key)
 type Credentials struct {
 	URL                string
 	Username           string
@@ -75,12 +75,39 @@ type Credentials struct {
 	NdbEndpoint        string              // Required field for connecting to Era VM APIs.
 	NdbUsername        string
 	NdbPassword        string
+	APIKey             string            // API key for authentication (alternative to username/password)
+	CustomHeaders      map[string]string // Custom headers to add to all requests (e.g., for Cloudflare Access)
 }
 
 // AdditionalFilter specification for client side filters
 type AdditionalFilter struct {
 	Name   string
 	Values []string
+}
+
+// applyAuthHeaders adds the appropriate authentication header to the request
+// Priority: Cookies (session auth) > API Key > Basic Auth
+func (c *Client) applyAuthHeaders(req *http.Request) {
+	if c.Cookies != nil {
+		// Session-based authentication using cookies
+		for _, cookie := range c.Cookies {
+			req.AddCookie(cookie)
+		}
+	} else if c.Credentials.APIKey != "" {
+		// API key authentication
+		req.Header.Add("X-Ntnx-Api-Key", c.Credentials.APIKey)
+	} else {
+		// Basic authentication (username/password)
+		req.Header.Add("Authorization", "Basic "+
+			base64.StdEncoding.EncodeToString([]byte(c.Credentials.Username+":"+c.Credentials.Password)))
+	}
+}
+
+// applyCustomHeaders adds any custom headers from credentials to the request
+func (c *Client) applyCustomHeaders(req *http.Request) {
+	for key, value := range c.Credentials.CustomHeaders {
+		req.Header.Add(key, value)
+	}
 }
 
 // NewClient returns a wrapper around http/https (as per isHTTP flag) client with additions of proxy & session_auth if given
@@ -204,18 +231,12 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body int
 	req.Header.Add("Content-Type", mediaType)
 	req.Header.Add("Accept", mediaType)
 	req.Header.Add("User-Agent", c.UserAgent)
-	if c.Cookies != nil {
-		for _, i := range c.Cookies {
-			req.AddCookie(i)
-		}
-	} else {
-		req.Header.Add("Authorization", "Basic "+
-			base64.StdEncoding.EncodeToString([]byte(c.Credentials.Username+":"+c.Credentials.Password)))
-	}
+	c.applyAuthHeaders(req)
+	c.applyCustomHeaders(req)
 	return req, nil
 }
 
-// NewRequest creates a request without authorisation headers
+// NewUnAuthRequest creates a request without authorisation headers
 func (c *Client) NewUnAuthRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
 	// check if client exists or not
 	if c.client == nil {
@@ -312,13 +333,13 @@ func (c *Client) NewUploadRequest(ctx context.Context, method, urlStr string, fi
 	req.Header.Add("Content-Type", octetStreamType)
 	req.Header.Add("Accept", mediaType)
 	req.Header.Add("User-Agent", c.UserAgent)
-	req.Header.Add("Authorization", "Basic "+
-		base64.StdEncoding.EncodeToString([]byte(c.Credentials.Username+":"+c.Credentials.Password)))
+	c.applyAuthHeaders(req)
+	c.applyCustomHeaders(req)
 
 	return req, nil
 }
 
-// NewUploadRequest handles image uploads for image service
+// NewUnAuthUploadRequest handles image uploads for image service without auth
 func (c *Client) NewUnAuthUploadRequest(ctx context.Context, method, urlStr string, fileReader *os.File) (*http.Request, error) {
 	// check if client exists or not
 	if c.client == nil {

--- a/nutanix/client/client_test.go
+++ b/nutanix/client/client_test.go
@@ -27,14 +27,40 @@ func setup() (*http.ServeMux, *Client, *httptest.Server) {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
 
-	client, _ := NewClient(&Credentials{"", "username", "password", "", "", true, false, "", "", "", nil, "", "", ""}, testUserAgent, testAbsolutePath, false)
+	client, _ := NewClient(&Credentials{"", "username", "password", "", "", true, false, "", "", "", nil, "", "", "", "", nil}, testUserAgent, testAbsolutePath, false)
+	client.BaseURL, _ = url.Parse(server.URL)
+
+	return mux, client, server
+}
+
+// setupWithAPIKey creates a test client using API key authentication
+func setupWithAPIKey() (*http.ServeMux, *Client, *httptest.Server) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+
+	client, _ := NewClient(&Credentials{"", "", "", "", "", true, false, "", "", "", nil, "", "", "", "test-api-key", nil}, testUserAgent, testAbsolutePath, false)
+	client.BaseURL, _ = url.Parse(server.URL)
+
+	return mux, client, server
+}
+
+// setupWithCustomHeaders creates a test client with custom headers
+func setupWithCustomHeaders() (*http.ServeMux, *Client, *httptest.Server) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+
+	customHeaders := map[string]string{
+		"CF-Access-Client-Id":     "test-client-id",
+		"CF-Access-Client-Secret": "test-client-secret",
+	}
+	client, _ := NewClient(&Credentials{"", "username", "password", "", "", true, false, "", "", "", nil, "", "", "", "", customHeaders}, testUserAgent, testAbsolutePath, false)
 	client.BaseURL, _ = url.Parse(server.URL)
 
 	return mux, client, server
 }
 
 func TestNewClient(t *testing.T) {
-	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", "", nil, "", "", ""}, testUserAgent, testAbsolutePath, false)
+	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", "", nil, "", "", "", "", nil}, testUserAgent, testAbsolutePath, false)
 	if err != nil {
 		t.Errorf("Unexpected Error: %v", err)
 	}
@@ -51,7 +77,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestNewBaseClient(t *testing.T) {
-	c, err := NewBaseClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", "", nil, "", "", ""}, testAbsolutePath, true)
+	c, err := NewBaseClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", "", nil, "", "", "", "", nil}, testAbsolutePath, true)
 	if err != nil {
 		t.Errorf("Unexpected Error: %v", err)
 	}
@@ -68,7 +94,7 @@ func TestNewBaseClient(t *testing.T) {
 }
 
 func TestNewRequest(t *testing.T) {
-	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", "", nil, "", "", ""}, testUserAgent, testAbsolutePath, false)
+	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", "", nil, "", "", "", "", nil}, testUserAgent, testAbsolutePath, false)
 	if err != nil {
 		t.Errorf("Unexpected Error: %v", err)
 	}
@@ -91,7 +117,7 @@ func TestNewRequest(t *testing.T) {
 }
 
 func TestNewUploadRequest(t *testing.T) {
-	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", "", nil, "", "", ""}, testUserAgent, testAbsolutePath, true)
+	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", "", nil, "", "", "", "", nil}, testUserAgent, testAbsolutePath, true)
 	if err != nil {
 		t.Errorf("Unexpected Error: %v", err)
 	}
@@ -133,7 +159,7 @@ func TestNewUploadRequest(t *testing.T) {
 }
 
 func TestNewUnAuthRequest(t *testing.T) {
-	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", "", nil, "", "", ""}, testUserAgent, testAbsolutePath, true)
+	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", "", nil, "", "", "", "", nil}, testUserAgent, testAbsolutePath, true)
 	if err != nil {
 		t.Errorf("Unexpected Error: %v", err)
 	}
@@ -171,7 +197,7 @@ func TestNewUnAuthRequest(t *testing.T) {
 }
 
 func TestNewUnAuthFormEncodedRequest(t *testing.T) {
-	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", "", nil, "", "", ""}, testUserAgent, testAbsolutePath, true)
+	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", "", nil, "", "", "", "", nil}, testUserAgent, testAbsolutePath, true)
 	if err != nil {
 		t.Errorf("Unexpected Error: %v", err)
 	}
@@ -213,7 +239,7 @@ func TestNewUnAuthFormEncodedRequest(t *testing.T) {
 }
 
 func TestNewUnAuthUploadRequest(t *testing.T) {
-	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", "", nil, "", "", ""}, testUserAgent, testAbsolutePath, true)
+	c, err := NewClient(&Credentials{"foo.com", "username", "password", "", "", true, false, "", "", "", nil, "", "", "", "", nil}, testUserAgent, testAbsolutePath, true)
 	if err != nil {
 		t.Errorf("Unexpected Error: %v", err)
 	}
@@ -629,5 +655,155 @@ func Test_fillStruct(t *testing.T) {
 				t.Errorf("fillStruct() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// *********** API Key Authentication Tests ***********
+
+func TestNewRequest_WithAPIKey(t *testing.T) {
+	_, client, server := setupWithAPIKey()
+	defer server.Close()
+
+	req, err := client.NewRequest(context.TODO(), http.MethodGet, "/test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error: %v", err)
+	}
+
+	// Check that X-Ntnx-Api-Key header is set
+	apiKeyHeader := req.Header.Get("X-Ntnx-Api-Key")
+	if apiKeyHeader != "test-api-key" {
+		t.Errorf("NewRequest() X-Ntnx-Api-Key header = %v, expected %v", apiKeyHeader, "test-api-key")
+	}
+
+	// Check that Authorization header is NOT set when using API key
+	authHeader := req.Header.Get("Authorization")
+	if authHeader != "" {
+		t.Errorf("NewRequest() Authorization header should be empty when using API key, got %v", authHeader)
+	}
+}
+
+func TestNewRequest_WithBasicAuth(t *testing.T) {
+	_, client, server := setup()
+	defer server.Close()
+
+	req, err := client.NewRequest(context.TODO(), http.MethodGet, "/test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error: %v", err)
+	}
+
+	// Check that Authorization header is set for basic auth
+	authHeader := req.Header.Get("Authorization")
+	if authHeader == "" {
+		t.Error("NewRequest() Authorization header should be set when using basic auth")
+	}
+	if !strings.HasPrefix(authHeader, "Basic ") {
+		t.Errorf("NewRequest() Authorization header should start with 'Basic ', got %v", authHeader)
+	}
+
+	// Check that X-Ntnx-Api-Key header is NOT set when using basic auth
+	apiKeyHeader := req.Header.Get("X-Ntnx-Api-Key")
+	if apiKeyHeader != "" {
+		t.Errorf("NewRequest() X-Ntnx-Api-Key header should be empty when using basic auth, got %v", apiKeyHeader)
+	}
+}
+
+// *********** Custom Headers Tests ***********
+
+func TestNewRequest_WithCustomHeaders(t *testing.T) {
+	_, client, server := setupWithCustomHeaders()
+	defer server.Close()
+
+	req, err := client.NewRequest(context.TODO(), http.MethodGet, "/test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error: %v", err)
+	}
+
+	// Check that custom headers are set
+	clientID := req.Header.Get("CF-Access-Client-Id")
+	if clientID != "test-client-id" {
+		t.Errorf("NewRequest() CF-Access-Client-Id header = %v, expected %v", clientID, "test-client-id")
+	}
+
+	clientSecret := req.Header.Get("CF-Access-Client-Secret")
+	if clientSecret != "test-client-secret" {
+		t.Errorf("NewRequest() CF-Access-Client-Secret header = %v, expected %v", clientSecret, "test-client-secret")
+	}
+}
+
+func TestNewUploadRequest_WithAPIKey(t *testing.T) {
+	_, client, server := setupWithAPIKey()
+	defer server.Close()
+
+	// Create a temporary file for testing
+	tmpFile, err := os.CreateTemp("", "test-upload-*.txt")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.WriteString("test content")
+	tmpFile.Seek(0, 0)
+
+	req, err := client.NewUploadRequest(context.TODO(), http.MethodPost, "/upload", tmpFile)
+	if err != nil {
+		t.Fatalf("NewUploadRequest() error: %v", err)
+	}
+
+	// Check that X-Ntnx-Api-Key header is set
+	apiKeyHeader := req.Header.Get("X-Ntnx-Api-Key")
+	if apiKeyHeader != "test-api-key" {
+		t.Errorf("NewUploadRequest() X-Ntnx-Api-Key header = %v, expected %v", apiKeyHeader, "test-api-key")
+	}
+}
+
+func TestNewUploadRequest_WithCustomHeaders(t *testing.T) {
+	_, client, server := setupWithCustomHeaders()
+	defer server.Close()
+
+	// Create a temporary file for testing
+	tmpFile, err := os.CreateTemp("", "test-upload-*.txt")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.WriteString("test content")
+	tmpFile.Seek(0, 0)
+
+	req, err := client.NewUploadRequest(context.TODO(), http.MethodPost, "/upload", tmpFile)
+	if err != nil {
+		t.Fatalf("NewUploadRequest() error: %v", err)
+	}
+
+	// Check that custom headers are set
+	clientID := req.Header.Get("CF-Access-Client-Id")
+	if clientID != "test-client-id" {
+		t.Errorf("NewUploadRequest() CF-Access-Client-Id header = %v, expected %v", clientID, "test-client-id")
+	}
+}
+
+func TestApplyAuthHeaders_Priority(t *testing.T) {
+	// Test that cookies take priority over API key
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client, _ := NewClient(&Credentials{"", "", "", "", "", true, false, "", "", "", nil, "", "", "", "test-api-key", nil}, testUserAgent, testAbsolutePath, false)
+	client.BaseURL, _ = url.Parse(server.URL)
+
+	// Set cookies to simulate session auth
+	client.Cookies = []*http.Cookie{
+		{Name: "session", Value: "test-session-id"},
+	}
+
+	req, _ := client.NewRequest(context.TODO(), http.MethodGet, "/test", nil)
+
+	// When cookies are set, they should be used instead of API key
+	if len(req.Cookies()) == 0 {
+		t.Error("Expected cookies to be set when client has cookies")
+	}
+
+	// API key header should NOT be set when using cookies
+	apiKeyHeader := req.Header.Get("X-Ntnx-Api-Key")
+	if apiKeyHeader != "" {
+		t.Errorf("X-Ntnx-Api-Key should not be set when using session cookies, got %v", apiKeyHeader)
 	}
 }

--- a/nutanix/config.go
+++ b/nutanix/config.go
@@ -43,6 +43,8 @@ type Config struct {
 	NdbEndpoint        string
 	NdbUsername        string
 	NdbPassword        string
+	APIKey             string            // API key for authentication (alternative to username/password)
+	CustomHeaders      map[string]string // Custom headers to add to all requests (e.g., for Cloudflare Access)
 }
 
 // Client ...
@@ -62,6 +64,8 @@ func (c *Config) Client() (*Client, error) {
 		NdbUsername:        c.NdbUsername,
 		NdbPassword:        c.NdbPassword,
 		RequiredFields:     c.RequiredFields,
+		APIKey:             c.APIKey,
+		CustomHeaders:      c.CustomHeaders,
 	}
 
 	v3Client, err := v3.NewV3Client(configCreds)

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -115,9 +115,8 @@ func Provider() *schema.Provider {
 			},
 			"port": {
 				Type:        schema.TypeString,
-				Default:     "9440",
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("NUTANIX_PORT", false),
+				DefaultFunc: schema.EnvDefaultFunc("NUTANIX_PORT", "9440"),
 				Description: descriptions["port"],
 			},
 			"endpoint": {

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -623,4 +623,3 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 	return c, diags
 }
-

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"strings"
 
@@ -576,15 +577,23 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 				// Strip prefix, replace underscores with dashes, and title-case
 				headerName := envName[len(headerPrefix):]
 				headerName = strings.ReplaceAll(headerName, "_", "-")
-				headerName = toTitleCase(headerName)
+				headerName = http.CanonicalHeaderKey(headerName)
 				customHeaders[headerName] = envValue
 			}
 		}
 	}
 
-	// Config headers take precedence over environment variables
+	// Config headers take precedence over environment variables.
+	// Preserve the user's casing exactly, but remove any env var entry for the
+	// same header name (compared case-insensitively) before inserting.
 	if v, ok := d.GetOk("custom_headers"); ok {
 		for key, value := range v.(map[string]interface{}) {
+			// Remove any env var-derived entry with the same name (different case).
+			for existing := range customHeaders {
+				if strings.EqualFold(existing, key) && existing != key {
+					delete(customHeaders, existing)
+				}
+			}
 			customHeaders[key] = value.(string)
 		}
 	}
@@ -615,14 +624,3 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	return c, diags
 }
 
-// toTitleCase converts a dash-separated string to title case
-// e.g., "CF-ACCESS-CLIENT-ID" -> "Cf-Access-Client-Id"
-func toTitleCase(s string) string {
-	parts := strings.Split(s, "-")
-	for i, part := range parts {
-		if len(part) > 0 {
-			parts[i] = strings.ToUpper(string(part[0])) + strings.ToLower(part[1:])
-		}
-	}
-	return strings.Join(parts, "-")
-}

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -514,13 +514,29 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	hasBasicAuth := username != "" && password != ""
 	hasAPIKey := apiKey != ""
 
+	if (username != "") != (password != "") {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Invalid authentication configuration",
+			Detail:   "Both username and password must be provided together.",
+		})
+		return nil, diags
+	}
+
 	if endpoint != "" && !hasBasicAuth && !hasAPIKey {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Authentication required",
-			Detail:   "Either (username and password) or api_key must be provided for Prism Central authentication.",
+			Detail:   "Either username and password or api_key must be provided for Prism Central authentication.",
 		})
 		return nil, diags
+	}
+
+	if hasBasicAuth && hasAPIKey {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Both username/password and api_key are set. api_key takes precedence; username and password will be ignored.",
+		})
 	}
 
 	for k, v := range requiredProviderFields {

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -35,11 +36,13 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/volumesv2"
 )
 
+// requiredProviderFields defines the required fields for each provider service.
+// Note: prism_central and karbon now accept either (username + password) OR api_key
 var requiredProviderFields map[string][]string = map[string][]string{
-	"prism_central":      {"username", "password", "endpoint"},
-	"karbon":             {"username", "password", "endpoint"},
+	"prism_central":      {"endpoint"}, // username+password OR api_key validated separately
+	"karbon":             {"endpoint"}, // username+password OR api_key validated separately
 	"foundation":         {"foundation_endpoint"},
-	"foundation_central": {"username", "password", "endpoint"},
+	"foundation_central": {"endpoint"}, // username+password OR api_key validated separately
 	"ndb":                {"ndb_endpoint", "ndb_username", "ndb_password"},
 }
 
@@ -71,6 +74,16 @@ func Provider() *schema.Provider {
 		"foundation_port": "Port for foundation VM",
 
 		"ndb_endpoint": "endpoint for Era VM (era ip)",
+
+		"api_key": "API key for Nutanix Prism authentication. Can be used as an\n" +
+			"alternative to username/password. When set, the X-Ntnx-Api-Key header\n" +
+			"will be used instead of Basic Authentication.",
+
+		"custom_headers": "Custom HTTP headers to add to all API requests. Useful for\n" +
+			"environments that require additional headers such as Cloudflare Access\n" +
+			"service tokens. Headers can also be set via environment variables with\n" +
+			"the NUTANIX_HEADER_ prefix (e.g., NUTANIX_HEADER_CF_ACCESS_CLIENT_ID\n" +
+			"becomes Cf-Access-Client-Id). Config values take precedence over env vars.",
 	}
 
 	// Nutanix provider schema
@@ -155,6 +168,20 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("NDB_PASSWORD", nil),
 				Description: descriptions["ndb_password"],
+			},
+			"api_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				DefaultFunc: schema.EnvDefaultFunc("NUTANIX_API_KEY", nil),
+				Description: descriptions["api_key"],
+			},
+			"custom_headers": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Sensitive:   true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: descriptions["custom_headers"],
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
@@ -477,6 +504,26 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	disabledProviders := make([]string, 0)
 	// create warnings for disabled provider services
 	var diags diag.Diagnostics
+
+	// Get authentication credentials
+	username := d.Get("username").(string)
+	password := d.Get("password").(string)
+	apiKey := d.Get("api_key").(string)
+	endpoint := d.Get("endpoint").(string)
+
+	// Validate authentication: need either (username + password) OR api_key for Prism Central services
+	hasBasicAuth := username != "" && password != ""
+	hasAPIKey := apiKey != ""
+
+	if endpoint != "" && !hasBasicAuth && !hasAPIKey {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Authentication required",
+			Detail:   "Either (username and password) or api_key must be provided for Prism Central authentication.",
+		})
+		return nil, diags
+	}
+
 	for k, v := range requiredProviderFields {
 		// check if any field is not provided
 		for _, attr := range v {
@@ -495,10 +542,42 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		})
 	}
 
+	// Parse custom headers from environment variables and config
+	// Environment variables with prefix NUTANIX_HEADER_ are converted to HTTP headers:
+	// - Strip the NUTANIX_HEADER_ prefix
+	// - Replace underscores with dashes
+	// - Apply title-casing (e.g., NUTANIX_HEADER_CF_ACCESS_CLIENT_ID -> Cf-Access-Client-Id)
+	// Headers defined in config take precedence over environment variables
+	customHeaders := make(map[string]string)
+
+	// First, scan environment variables for NUTANIX_HEADER_ prefix
+	const headerPrefix = "NUTANIX_HEADER_"
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, headerPrefix) {
+			parts := strings.SplitN(env, "=", 2)
+			if len(parts) == 2 {
+				envName := parts[0]
+				envValue := parts[1]
+				// Strip prefix, replace underscores with dashes, and title-case
+				headerName := envName[len(headerPrefix):]
+				headerName = strings.ReplaceAll(headerName, "_", "-")
+				headerName = toTitleCase(headerName)
+				customHeaders[headerName] = envValue
+			}
+		}
+	}
+
+	// Config headers take precedence over environment variables
+	if v, ok := d.GetOk("custom_headers"); ok {
+		for key, value := range v.(map[string]interface{}) {
+			customHeaders[key] = value.(string)
+		}
+	}
+
 	config := conns.Config{
-		Endpoint:           d.Get("endpoint").(string),
-		Username:           d.Get("username").(string),
-		Password:           d.Get("password").(string),
+		Endpoint:           endpoint,
+		Username:           username,
+		Password:           password,
 		Insecure:           d.Get("insecure").(bool),
 		SessionAuth:        d.Get("session_auth").(bool),
 		Port:               d.Get("port").(string),
@@ -510,6 +589,8 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		NdbUsername:        d.Get("ndb_username").(string),
 		NdbPassword:        d.Get("ndb_password").(string),
 		RequiredFields:     requiredProviderFields,
+		APIKey:             apiKey,
+		CustomHeaders:      customHeaders,
 	}
 	c, err := config.Client()
 	if err != nil {
@@ -517,4 +598,16 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	}
 
 	return c, diags
+}
+
+// toTitleCase converts a dash-separated string to title case
+// e.g., "CF-ACCESS-CLIENT-ID" -> "Cf-Access-Client-Id"
+func toTitleCase(s string) string {
+	parts := strings.Split(s, "-")
+	for i, part := range parts {
+		if len(part) > 0 {
+			parts[i] = strings.ToUpper(string(part[0])) + strings.ToLower(part[1:])
+		}
+	}
+	return strings.Join(parts, "-")
 }

--- a/nutanix/provider/provider_test.go
+++ b/nutanix/provider/provider_test.go
@@ -1,0 +1,263 @@
+package provider
+
+import (
+	"os"
+	"testing"
+)
+
+func TestToTitleCase(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple header",
+			input:    "CONTENT-TYPE",
+			expected: "Content-Type",
+		},
+		{
+			name:     "cloudflare access header",
+			input:    "CF-ACCESS-CLIENT-ID",
+			expected: "Cf-Access-Client-Id",
+		},
+		{
+			name:     "single word",
+			input:    "AUTHORIZATION",
+			expected: "Authorization",
+		},
+		{
+			name:     "already lowercase",
+			input:    "content-type",
+			expected: "Content-Type",
+		},
+		{
+			name:     "mixed case",
+			input:    "Content-TYPE",
+			expected: "Content-Type",
+		},
+		{
+			name:     "x-custom header",
+			input:    "X-CUSTOM-HEADER",
+			expected: "X-Custom-Header",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "single char parts",
+			input:    "A-B-C",
+			expected: "A-B-C",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := toTitleCase(tt.input)
+			if result != tt.expected {
+				t.Errorf("toTitleCase(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseHeadersFromEnv(t *testing.T) {
+	// Save original environment and restore after test
+	originalEnv := os.Environ()
+	defer func() {
+		os.Clearenv()
+		for _, env := range originalEnv {
+			for i := 0; i < len(env); i++ {
+				if env[i] == '=' {
+					os.Setenv(env[:i], env[i+1:])
+					break
+				}
+			}
+		}
+	}()
+
+	tests := []struct {
+		name           string
+		envVars        map[string]string
+		expectedHeader string
+		expectedValue  string
+	}{
+		{
+			name: "cloudflare client id",
+			envVars: map[string]string{
+				"NUTANIX_HEADER_CF_ACCESS_CLIENT_ID": "test-client-id",
+			},
+			expectedHeader: "Cf-Access-Client-Id",
+			expectedValue:  "test-client-id",
+		},
+		{
+			name: "cloudflare client secret",
+			envVars: map[string]string{
+				"NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET": "test-secret",
+			},
+			expectedHeader: "Cf-Access-Client-Secret",
+			expectedValue:  "test-secret",
+		},
+		{
+			name: "custom x header",
+			envVars: map[string]string{
+				"NUTANIX_HEADER_X_CUSTOM_HEADER": "custom-value",
+			},
+			expectedHeader: "X-Custom-Header",
+			expectedValue:  "custom-value",
+		},
+		{
+			name: "authorization header",
+			envVars: map[string]string{
+				"NUTANIX_HEADER_AUTHORIZATION": "Bearer token123",
+			},
+			expectedHeader: "Authorization",
+			expectedValue:  "Bearer token123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear relevant env vars
+			for key := range tt.envVars {
+				os.Unsetenv(key)
+			}
+
+			// Set test env vars
+			for key, value := range tt.envVars {
+				os.Setenv(key, value)
+			}
+
+			// Parse headers using the same logic as providerConfigure
+			customHeaders := parseHeadersFromEnv()
+
+			// Check the result
+			if val, ok := customHeaders[tt.expectedHeader]; !ok {
+				t.Errorf("Expected header %q not found in parsed headers", tt.expectedHeader)
+			} else if val != tt.expectedValue {
+				t.Errorf("Header %q = %q, expected %q", tt.expectedHeader, val, tt.expectedValue)
+			}
+
+			// Cleanup
+			for key := range tt.envVars {
+				os.Unsetenv(key)
+			}
+		})
+	}
+}
+
+func TestParseHeadersFromEnv_MultipleHeaders(t *testing.T) {
+	// Save original environment and restore after test
+	originalEnv := os.Environ()
+	defer func() {
+		os.Clearenv()
+		for _, env := range originalEnv {
+			for i := 0; i < len(env); i++ {
+				if env[i] == '=' {
+					os.Setenv(env[:i], env[i+1:])
+					break
+				}
+			}
+		}
+	}()
+
+	// Set multiple header env vars
+	os.Setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_ID", "client-id")
+	os.Setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET", "client-secret")
+	os.Setenv("NUTANIX_HEADER_X_CUSTOM", "custom-value")
+
+	customHeaders := parseHeadersFromEnv()
+
+	expected := map[string]string{
+		"Cf-Access-Client-Id":     "client-id",
+		"Cf-Access-Client-Secret": "client-secret",
+		"X-Custom":                "custom-value",
+	}
+
+	for header, expectedValue := range expected {
+		if val, ok := customHeaders[header]; !ok {
+			t.Errorf("Expected header %q not found", header)
+		} else if val != expectedValue {
+			t.Errorf("Header %q = %q, expected %q", header, val, expectedValue)
+		}
+	}
+
+	// Cleanup
+	os.Unsetenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_ID")
+	os.Unsetenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET")
+	os.Unsetenv("NUTANIX_HEADER_X_CUSTOM")
+}
+
+func TestParseHeadersFromEnv_IgnoresNonHeaderEnvVars(t *testing.T) {
+	// Save original environment and restore after test
+	originalEnv := os.Environ()
+	defer func() {
+		os.Clearenv()
+		for _, env := range originalEnv {
+			for i := 0; i < len(env); i++ {
+				if env[i] == '=' {
+					os.Setenv(env[:i], env[i+1:])
+					break
+				}
+			}
+		}
+	}()
+
+	// Set various env vars, only one should be picked up
+	os.Setenv("NUTANIX_HEADER_X_VALID", "valid")
+	os.Setenv("NUTANIX_USERNAME", "should-ignore")
+	os.Setenv("NUTANIX_PASSWORD", "should-ignore")
+	os.Setenv("OTHER_HEADER_X_TEST", "should-ignore")
+
+	customHeaders := parseHeadersFromEnv()
+
+	if len(customHeaders) != 1 {
+		t.Errorf("Expected 1 header, got %d: %v", len(customHeaders), customHeaders)
+	}
+
+	if val, ok := customHeaders["X-Valid"]; !ok || val != "valid" {
+		t.Errorf("Expected X-Valid header with value 'valid', got %v", customHeaders)
+	}
+
+	// Cleanup
+	os.Unsetenv("NUTANIX_HEADER_X_VALID")
+	os.Unsetenv("NUTANIX_USERNAME")
+	os.Unsetenv("NUTANIX_PASSWORD")
+	os.Unsetenv("OTHER_HEADER_X_TEST")
+}
+
+// parseHeadersFromEnv extracts the header parsing logic for testing
+// This mirrors the logic in providerConfigure
+func parseHeadersFromEnv() map[string]string {
+	customHeaders := make(map[string]string)
+	const headerPrefix = "NUTANIX_HEADER_"
+
+	for _, env := range os.Environ() {
+		if len(env) > len(headerPrefix) && env[:len(headerPrefix)] == headerPrefix {
+			for i := 0; i < len(env); i++ {
+				if env[i] == '=' {
+					envName := env[:i]
+					envValue := env[i+1:]
+					// Strip prefix, replace underscores with dashes, and title-case
+					headerName := envName[len(headerPrefix):]
+					// Replace underscores with dashes
+					result := make([]byte, len(headerName))
+					for j := 0; j < len(headerName); j++ {
+						if headerName[j] == '_' {
+							result[j] = '-'
+						} else {
+							result[j] = headerName[j]
+						}
+					}
+					headerName = string(result)
+					headerName = toTitleCase(headerName)
+					customHeaders[headerName] = envValue
+					break
+				}
+			}
+		}
+	}
+	return customHeaders
+}

--- a/nutanix/provider/provider_test.go
+++ b/nutanix/provider/provider_test.go
@@ -1,67 +1,10 @@
 package provider
 
 import (
+	"net/http"
 	"os"
 	"testing"
 )
-
-func TestToTitleCase(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "simple header",
-			input:    "CONTENT-TYPE",
-			expected: "Content-Type",
-		},
-		{
-			name:     "cloudflare access header",
-			input:    "CF-ACCESS-CLIENT-ID",
-			expected: "Cf-Access-Client-Id",
-		},
-		{
-			name:     "single word",
-			input:    "AUTHORIZATION",
-			expected: "Authorization",
-		},
-		{
-			name:     "already lowercase",
-			input:    "content-type",
-			expected: "Content-Type",
-		},
-		{
-			name:     "mixed case",
-			input:    "Content-TYPE",
-			expected: "Content-Type",
-		},
-		{
-			name:     "x-custom header",
-			input:    "X-CUSTOM-HEADER",
-			expected: "X-Custom-Header",
-		},
-		{
-			name:     "empty string",
-			input:    "",
-			expected: "",
-		},
-		{
-			name:     "single char parts",
-			input:    "A-B-C",
-			expected: "A-B-C",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := toTitleCase(tt.input)
-			if result != tt.expected {
-				t.Errorf("toTitleCase(%q) = %q, expected %q", tt.input, result, tt.expected)
-			}
-		})
-	}
-}
 
 func TestParseHeadersFromEnv(t *testing.T) {
 	// Save original environment and restore after test
@@ -205,6 +148,9 @@ func TestParseHeadersFromEnv_IgnoresNonHeaderEnvVars(t *testing.T) {
 		}
 	}()
 
+	// Clear environment so ambient NUTANIX_HEADER_* vars don't leak in.
+	os.Clearenv()
+
 	// Set various env vars, only one should be picked up
 	os.Setenv("NUTANIX_HEADER_X_VALID", "valid")
 	os.Setenv("NUTANIX_USERNAME", "should-ignore")
@@ -252,7 +198,7 @@ func parseHeadersFromEnv() map[string]string {
 						}
 					}
 					headerName = string(result)
-					headerName = toTitleCase(headerName)
+					headerName = http.CanonicalHeaderKey(headerName)
 					customHeaders[headerName] = envValue
 					break
 				}

--- a/nutanix/sdks/v3/prism/prism.go
+++ b/nutanix/sdks/v3/prism/prism.go
@@ -2,7 +2,6 @@ package prism
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
 )
@@ -25,7 +24,12 @@ func NewV3Client(credentials client.Credentials) (*Client, error) {
 	var baseClient *client.Client
 
 	// check if all required fields are present. Else create an empty client
-	if credentials.Username != "" && credentials.Password != "" && credentials.Endpoint != "" {
+	// Accept either (username + password) OR api_key for authentication
+	hasBasicAuth := credentials.Username != "" && credentials.Password != ""
+	hasAPIKey := credentials.APIKey != ""
+	hasEndpoint := credentials.Endpoint != ""
+
+	if hasEndpoint && (hasBasicAuth || hasAPIKey) {
 		c, err := client.NewClient(&credentials, userAgent, absolutePath, false)
 		if err != nil {
 			return nil, err
@@ -33,7 +37,7 @@ func NewV3Client(credentials client.Credentials) (*Client, error) {
 		baseClient = c
 	} else {
 		errorMsg := fmt.Sprintf("Prism Central (PC) Client is missing. "+
-			"Please provide required details - %s in provider configuration.", strings.Join(credentials.RequiredFields[clientName], ", "))
+			"Please provide endpoint and either (username + password) or api_key in provider configuration.")
 
 		baseClient = &client.Client{UserAgent: userAgent, ErrorMsg: errorMsg}
 	}

--- a/nutanix/sdks/v3/prism/prism.go
+++ b/nutanix/sdks/v3/prism/prism.go
@@ -36,7 +36,7 @@ func NewV3Client(credentials client.Credentials) (*Client, error) {
 		}
 		baseClient = c
 	} else {
-		errorMsg := fmt.Sprintf("Prism Central (PC) Client is missing. "+
+		errorMsg := fmt.Sprintf("Prism Central (PC) Client is missing. " +
 			"Please provide endpoint and either (username + password) or api_key in provider configuration.")
 
 		baseClient = &client.Client{UserAgent: userAgent, ErrorMsg: errorMsg}

--- a/nutanix/sdks/v4/clusters/clusters.go
+++ b/nutanix/sdks/v4/clusters/clusters.go
@@ -1,8 +1,6 @@
 package clusters
 
 import (
-	"strconv"
-
 	"github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/api"
 	cluster "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -20,31 +18,22 @@ type Client struct {
 func NewClustersClient(credentials client.Credentials) (*Client, error) {
 	var baseClient *cluster.ApiClient
 
-	// check if all required fields are present. Else create an empty client
-	if credentials.Username != "" && credentials.Password != "" && credentials.Endpoint != "" {
-		pcClient := cluster.NewApiClient()
-
-		pcClient.Host = credentials.Endpoint
-		pcClient.Password = credentials.Password
-		pcClient.Username = credentials.Username
-		pcClient.Port = sdkconfig.DefaultPort
-		if credentials.Port != "" {
-			if p, err := strconv.Atoi(credentials.Port); err == nil {
-				pcClient.Port = p
-			}
-		}
-		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
+	pcClient := cluster.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 
-	f := &Client{
+	return &Client{
 		ClusterEntityAPI:     api.NewClustersApi(baseClient),
 		StorageContainersAPI: api.NewStorageContainersApi(baseClient),
 		PasswordManagerAPI:   api.NewPasswordManagerApi(baseClient),
 		ClusterProfilesAPI:   api.NewClusterProfilesApi(baseClient),
 		SSLCertificateAPI:    api.NewSSLCertificateApi(baseClient),
-	}
-
-	return f, nil
+	}, nil
 }

--- a/nutanix/sdks/v4/datapolicies/datapolicies.go
+++ b/nutanix/sdks/v4/datapolicies/datapolicies.go
@@ -1,8 +1,6 @@
 package datapolicies
 
 import (
-	"strconv"
-
 	"github.com/nutanix/ntnx-api-golang-clients/datapolicies-go-client/v4/api"
 	datapolicies "github.com/nutanix/ntnx-api-golang-clients/datapolicies-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -17,28 +15,19 @@ type Client struct {
 func NewDataPoliciesClient(credentials client.Credentials) (*Client, error) {
 	var baseClient *datapolicies.ApiClient
 
-	// check if all required fields are present. Else create an empty client
-	if credentials.Username != "" && credentials.Password != "" && credentials.Endpoint != "" {
-		pcClient := datapolicies.NewApiClient()
-
-		pcClient.Host = credentials.Endpoint
-		pcClient.Password = credentials.Password
-		pcClient.Username = credentials.Username
-		pcClient.Port = sdkconfig.DefaultPort
-		if credentials.Port != "" {
-			if p, err := strconv.Atoi(credentials.Port); err == nil {
-				pcClient.Port = p
-			}
-		}
-		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
+	pcClient := datapolicies.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 
-	f := &Client{
+	return &Client{
 		ProtectionPolicies: api.NewProtectionPoliciesApi(baseClient),
 		StoragePolicies:    api.NewStoragePoliciesApi(baseClient),
-	}
-
-	return f, nil
+	}, nil
 }

--- a/nutanix/sdks/v4/dataprotection/dataprotection.go
+++ b/nutanix/sdks/v4/dataprotection/dataprotection.go
@@ -1,8 +1,6 @@
 package dataprotection
 
 import (
-	"strconv"
-
 	"github.com/nutanix/ntnx-api-golang-clients/dataprotection-go-client/v4/api"
 	dataprotection "github.com/nutanix/ntnx-api-golang-clients/dataprotection-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -17,28 +15,19 @@ type Client struct {
 func NewDataProtectionClient(credentials client.Credentials) (*Client, error) {
 	var baseClient *dataprotection.ApiClient
 
-	// check if all required fields are present. Else create an empty client
-	if credentials.Username != "" && credentials.Password != "" && credentials.Endpoint != "" {
-		pcClient := dataprotection.NewApiClient()
-
-		pcClient.Host = credentials.Endpoint
-		pcClient.Password = credentials.Password
-		pcClient.Username = credentials.Username
-		pcClient.Port = sdkconfig.DefaultPort
-		if credentials.Port != "" {
-			if p, err := strconv.Atoi(credentials.Port); err == nil {
-				pcClient.Port = p
-			}
-		}
-		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
+	pcClient := dataprotection.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 
-	f := &Client{
+	return &Client{
 		RecoveryPoint:     api.NewRecoveryPointsApi(baseClient),
 		ProtectedResource: api.NewProtectedResourcesApi(baseClient),
-	}
-
-	return f, nil
+	}, nil
 }

--- a/nutanix/sdks/v4/iam/iam.go
+++ b/nutanix/sdks/v4/iam/iam.go
@@ -1,8 +1,6 @@
 package iam
 
 import (
-	"strconv"
-
 	"github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4/api"
 	iam "github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -23,25 +21,18 @@ type Client struct {
 func NewIamClient(credentials client.Credentials) (*Client, error) {
 	var baseClient *iam.ApiClient
 
-	// check if all required fields are present. Else create an empty client
-	if credentials.Username != "" && credentials.Password != "" && credentials.Endpoint != "" {
-		pcClient := iam.NewApiClient()
-
-		pcClient.Host = credentials.Endpoint
-		pcClient.Password = credentials.Password
-		pcClient.Username = credentials.Username
-		pcClient.Port = sdkconfig.DefaultPort
-		if credentials.Port != "" {
-			if p, err := strconv.Atoi(credentials.Port); err == nil {
-				pcClient.Port = p
-			}
-		}
-		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
+	pcClient := iam.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 
-	f := &Client{
+	return &Client{
 		DirectoryServiceAPIInstance: api.NewDirectoryServicesApi(baseClient),
 		SamlIdentityAPIInstance:     api.NewSAMLIdentityProvidersApi(baseClient),
 		UserGroupsAPIInstance:       api.NewUserGroupsApi(baseClient),
@@ -50,7 +41,5 @@ func NewIamClient(credentials client.Credentials) (*Client, error) {
 		UsersAPIInstance:            api.NewUsersApi(baseClient),
 		AuthAPIInstance:             api.NewAuthorizationPoliciesApi(baseClient),
 		APIClientInstance:           iam.NewApiClient(),
-	}
-
-	return f, nil
+	}, nil
 }

--- a/nutanix/sdks/v4/lcm/lcm.go
+++ b/nutanix/sdks/v4/lcm/lcm.go
@@ -1,8 +1,6 @@
 package lcm
 
 import (
-	"strconv"
-
 	"github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4/api"
 	lcm "github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -21,31 +19,23 @@ type Client struct {
 func NewLcmClient(credentials client.Credentials) (*Client, error) {
 	var baseClient *lcm.ApiClient
 
-	// check if all required fields are present. Else create an empty client
-	if credentials.Username != "" && credentials.Password != "" && credentials.Endpoint != "" {
-		pcClient := lcm.NewApiClient()
-
-		pcClient.Host = credentials.Endpoint
-		pcClient.Password = credentials.Password
-		pcClient.Username = credentials.Username
-		pcClient.Port = sdkconfig.DefaultPort
-		if credentials.Port != "" {
-			if p, err := strconv.Atoi(credentials.Port); err == nil {
-				pcClient.Port = p
-			}
-		}
-		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
+	pcClient := lcm.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 
-	f := &Client{
+	return &Client{
 		LcmInventoryAPIInstance: api.NewInventoryApi(baseClient),
 		LcmConfigAPIInstance:    api.NewConfigApi(baseClient),
 		LcmPreChecksAPIInstance: api.NewPrechecksApi(baseClient),
 		LcmStatusAPIInstance:    api.NewStatusApi(baseClient),
 		LcmEntitiesAPIInstance:  api.NewEntitiesApi(baseClient),
 		LcmUpgradeAPIInstance:   api.NewUpgradesApi(baseClient),
-	}
-	return f, nil
+	}, nil
 }

--- a/nutanix/sdks/v4/microseg/microseg.go
+++ b/nutanix/sdks/v4/microseg/microseg.go
@@ -1,8 +1,6 @@
 package microseg
 
 import (
-	"strconv"
-
 	"github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4/api"
 	microseg "github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -18,29 +16,20 @@ type Client struct {
 func NewMicrosegClient(credentials client.Credentials) (*Client, error) {
 	var baseClient *microseg.ApiClient
 
-	// check if all required fields are present. Else create an empty client
-	if credentials.Username != "" && credentials.Password != "" && credentials.Endpoint != "" {
-		pcClient := microseg.NewApiClient()
-
-		pcClient.Host = credentials.Endpoint
-		pcClient.Password = credentials.Password
-		pcClient.Username = credentials.Username
-		pcClient.Port = sdkconfig.DefaultPort
-		if credentials.Port != "" {
-			if p, err := strconv.Atoi(credentials.Port); err == nil {
-				pcClient.Port = p
-			}
-		}
-		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
+	pcClient := microseg.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 
-	f := &Client{
+	return &Client{
 		AddressGroupAPIInstance:    api.NewAddressGroupsApi(baseClient),
 		ServiceGroupAPIInstance:    api.NewServiceGroupsApi(baseClient),
 		NetworkingSecurityInstance: api.NewNetworkSecurityPoliciesApi(baseClient),
-	}
-
-	return f, nil
+	}, nil
 }

--- a/nutanix/sdks/v4/networking/networking.go
+++ b/nutanix/sdks/v4/networking/networking.go
@@ -1,8 +1,6 @@
 package networking
 
 import (
-	"strconv"
-
 	"github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/api"
 	network "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -22,32 +20,23 @@ type Client struct {
 func NewNetworkingClient(credentials client.Credentials) (*Client, error) {
 	var baseClient *network.ApiClient
 
-	// check if all required fields are present. Else create an empty client
-	if credentials.Username != "" && credentials.Password != "" && credentials.Endpoint != "" {
-		pcClient := network.NewApiClient()
-
-		pcClient.Host = credentials.Endpoint
-		pcClient.Password = credentials.Password
-		pcClient.Username = credentials.Username
-		pcClient.Port = sdkconfig.DefaultPort
-		if credentials.Port != "" {
-			if p, err := strconv.Atoi(credentials.Port); err == nil {
-				pcClient.Port = p
-			}
-		}
-		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
+	pcClient := network.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 
-	f := &Client{
+	return &Client{
 		Routes:                api.NewRoutesApi(baseClient),
 		RoutesTable:           api.NewRouteTablesApi(baseClient),
 		RoutingPolicy:         api.NewRoutingPoliciesApi(baseClient),
 		SubnetAPIInstance:     api.NewSubnetsApi(baseClient),
 		VpcAPIInstance:        api.NewVpcsApi(baseClient),
 		FloatingIPAPIInstance: api.NewFloatingIpsApi(baseClient),
-	}
-
-	return f, nil
+	}, nil
 }

--- a/nutanix/sdks/v4/objectstores/objectstores.go
+++ b/nutanix/sdks/v4/objectstores/objectstores.go
@@ -1,10 +1,8 @@
 package objectstores
 
 import (
-	"strconv"
-
 	"github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4/api"
-	object "github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4/client"
+	objects "github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
 )
@@ -14,29 +12,20 @@ type Client struct {
 }
 
 func NewObjectStoresClient(credentials client.Credentials) (*Client, error) {
-	var baseClient *object.ApiClient
+	var baseClient *objects.ApiClient
 
-	// check if all required fields are present. Else create an empty client
-	if credentials.Username != "" && credentials.Password != "" && credentials.Endpoint != "" {
-		pcClient := object.NewApiClient()
-
-		pcClient.Host = credentials.Endpoint
-		pcClient.Password = credentials.Password
-		pcClient.Username = credentials.Username
-		pcClient.Port = sdkconfig.DefaultPort
-		if credentials.Port != "" {
-			if p, err := strconv.Atoi(credentials.Port); err == nil {
-				pcClient.Port = p
-			}
-		}
-		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
+	pcClient := objects.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 
-	f := &Client{
+	return &Client{
 		ObjectStoresAPIInstance: api.NewObjectStoresApi(baseClient),
-	}
-
-	return f, nil
+	}, nil
 }

--- a/nutanix/sdks/v4/prism/prism.go
+++ b/nutanix/sdks/v4/prism/prism.go
@@ -1,8 +1,6 @@
 package prism
 
 import (
-	"strconv"
-
 	"github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/api"
 	prism "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -19,30 +17,21 @@ type Client struct {
 func NewPrismClient(credentials client.Credentials) (*Client, error) {
 	var baseClient *prism.ApiClient
 
-	// check if all required fields are present. Else create an empty client
-	if credentials.Username != "" && credentials.Password != "" && credentials.Endpoint != "" {
-		pcClient := prism.NewApiClient()
-
-		pcClient.Host = credentials.Endpoint
-		pcClient.Password = credentials.Password
-		pcClient.Username = credentials.Username
-		pcClient.Port = sdkconfig.DefaultPort
-		if credentials.Port != "" {
-			if p, err := strconv.Atoi(credentials.Port); err == nil {
-				pcClient.Port = p
-			}
-		}
-		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
+	pcClient := prism.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 
-	f := &Client{
+	return &Client{
 		TaskRefAPI:                      api.NewTasksApi(baseClient),
 		CategoriesAPIInstance:           api.NewCategoriesApi(baseClient),
 		DomainManagerAPIInstance:        api.NewDomainManagerApi(baseClient),
 		DomainManagerBackupsAPIInstance: api.NewDomainManagerBackupsApi(baseClient),
-	}
-
-	return f, nil
+	}, nil
 }

--- a/nutanix/sdks/v4/sdkconfig/config.go
+++ b/nutanix/sdks/v4/sdkconfig/config.go
@@ -1,0 +1,65 @@
+package sdkconfig
+
+import (
+	"strconv"
+
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+)
+
+// V4ApiClient is the common interface for all Nutanix v4 SDK ApiClient types.
+// All v4 SDK ApiClient types implement this method.
+type V4ApiClient interface {
+	AddDefaultHeader(headerName string, headerValue string)
+}
+
+// V4ApiClientConfig holds the settable fields common to all v4 ApiClient types.
+type V4ApiClientConfig struct {
+	Host                    string
+	Port                    int
+	Username                string
+	Password                string
+	VerifySSL               bool
+	AllowVersionNegotiation bool
+}
+
+// ConfigureV4Client checks credentials and returns configuration for a v4 SDK client.
+// Returns nil if credentials are insufficient (no endpoint, or neither basic auth nor API key).
+// Applies API key and custom headers to the apiClient via AddDefaultHeader.
+func ConfigureV4Client(credentials client.Credentials, apiClient V4ApiClient) *V4ApiClientConfig {
+	hasBasicAuth := credentials.Username != "" && credentials.Password != ""
+	hasAPIKey := credentials.APIKey != ""
+	hasEndpoint := credentials.Endpoint != ""
+
+	if !hasEndpoint || (!hasBasicAuth && !hasAPIKey) {
+		return nil
+	}
+
+	port := DefaultPort
+	if credentials.Port != "" {
+		if p, err := strconv.Atoi(credentials.Port); err == nil {
+			port = p
+		}
+	}
+
+	cfg := &V4ApiClientConfig{
+		Host:                    credentials.Endpoint,
+		Port:                    port,
+		VerifySSL:               false,
+		AllowVersionNegotiation: AllowVersionNegotiation,
+	}
+
+	// Set authentication - API key takes precedence if both are provided
+	if hasAPIKey {
+		apiClient.AddDefaultHeader("X-Ntnx-Api-Key", credentials.APIKey)
+	} else {
+		cfg.Username = credentials.Username
+		cfg.Password = credentials.Password
+	}
+
+	// Add custom headers (e.g., for Cloudflare Access)
+	for key, value := range credentials.CustomHeaders {
+		apiClient.AddDefaultHeader(key, value)
+	}
+
+	return cfg
+}

--- a/nutanix/sdks/v4/security/security.go
+++ b/nutanix/sdks/v4/security/security.go
@@ -1,10 +1,8 @@
 package security
 
 import (
-	"strconv"
-
 	"github.com/nutanix/ntnx-api-golang-clients/security-go-client/v4/api"
-	prism "github.com/nutanix/ntnx-api-golang-clients/security-go-client/v4/client"
+	security "github.com/nutanix/ntnx-api-golang-clients/security-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
 )
@@ -15,30 +13,21 @@ type Client struct {
 }
 
 func NewSecurityClient(credentials client.Credentials) (*Client, error) {
-	var baseClient *prism.ApiClient
+	var baseClient *security.ApiClient
 
-	// check if all required fields are present. Else create an empty client
-	if credentials.Username != "" && credentials.Password != "" && credentials.Endpoint != "" {
-		pcClient := prism.NewApiClient()
-
-		pcClient.Host = credentials.Endpoint
-		pcClient.Password = credentials.Password
-		pcClient.Username = credentials.Username
-		pcClient.Port = sdkconfig.DefaultPort
-		if credentials.Port != "" {
-			if p, err := strconv.Atoi(credentials.Port); err == nil {
-				pcClient.Port = p
-			}
-		}
-		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
+	pcClient := security.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 
-	f := &Client{
+	return &Client{
 		KeyManagementServersAPIInstance: api.NewKeyManagementServersApi(baseClient),
 		STIGsAPI:                        api.NewSTIGsApi(baseClient),
-	}
-
-	return f, nil
+	}, nil
 }

--- a/nutanix/sdks/v4/vmm/vmm.go
+++ b/nutanix/sdks/v4/vmm/vmm.go
@@ -1,8 +1,6 @@
 package vmm
 
 import (
-	"strconv"
-
 	"github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/api"
 	vmm "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
@@ -22,21 +20,14 @@ type Client struct {
 func NewVmmClient(credentials client.Credentials) (*Client, error) {
 	var baseClient *vmm.ApiClient
 
-	// check if all required fields are present. Else create an empty client
-	if credentials.Username != "" && credentials.Password != "" && credentials.Endpoint != "" {
-		pcClient := vmm.NewApiClient()
-
-		pcClient.Host = credentials.Endpoint
-		pcClient.Password = credentials.Password
-		pcClient.Username = credentials.Username
-		pcClient.Port = sdkconfig.DefaultPort
-		if credentials.Port != "" {
-			if p, err := strconv.Atoi(credentials.Port); err == nil {
-				pcClient.Port = p
-			}
-		}
-		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
+	pcClient := vmm.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 

--- a/nutanix/sdks/v4/volumes/volumes.go
+++ b/nutanix/sdks/v4/volumes/volumes.go
@@ -1,10 +1,8 @@
 package volumes
 
 import (
-	"strconv"
-
 	"github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4/api"
-	prism "github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4/client"
+	volumes "github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
 )
@@ -15,30 +13,21 @@ type Client struct {
 }
 
 func NewVolumeClient(credentials client.Credentials) (*Client, error) {
-	var baseClient *prism.ApiClient
+	var baseClient *volumes.ApiClient
 
-	// check if all required fields are present. Else create an empty client
-	if credentials.Username != "" && credentials.Password != "" && credentials.Endpoint != "" {
-		pcClient := prism.NewApiClient()
-
-		pcClient.Host = credentials.Endpoint
-		pcClient.Password = credentials.Password
-		pcClient.Username = credentials.Username
-		pcClient.Port = sdkconfig.DefaultPort
-		if credentials.Port != "" {
-			if p, err := strconv.Atoi(credentials.Port); err == nil {
-				pcClient.Port = p
-			}
-		}
-		pcClient.VerifySSL = false
-		pcClient.AllowVersionNegotiation = sdkconfig.AllowVersionNegotiation
+	pcClient := volumes.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
 		baseClient = pcClient
 	}
 
-	f := &Client{
+	return &Client{
 		VolumeAPIInstance:      api.NewVolumeGroupsApi(baseClient),
 		IscsiClientAPIInstance: api.NewIscsiClientsApi(baseClient),
-	}
-
-	return f, nil
+	}, nil
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -385,7 +385,7 @@ The following arguments are used to configure the Nutanix Provider:
 * `username` - (Optional) This is the username for the Prism Elements or Prism Central instance. This can also be specified with the `NUTANIX_USERNAME` environment variable. Required if `api_key` is not provided.
 * `password` - (Optional) This is the password for the Prism Elements or Prism Central instance. This can also be specified with the `NUTANIX_PASSWORD` environment variable. Required if `api_key` is not provided.
 * `endpoint` - **(Required)** This is the endpoint for the Prism Elements or Prism Central instance. This can also be specified with the `NUTANIX_ENDPOINT` environment variable.
-* `api_key` - (Optional) This is an API key for Prism Central authentication. Can be used as an alternative to `username`/`password`. When set, the `X-Ntnx-Api-Key` header will be used instead of Basic Authentication. This can also be specified with the `NUTANIX_API_KEY` environment variable.
+* `api_key` - (Optional) This is an API key for Prism Central authentication. Can be used as an alternative to `username`/`password` when connecting to a Prism Central instance. **Not supported by Prism Elements**, which requires `username` and `password`. When set, the `X-Ntnx-Api-Key` header will be used instead of Basic Authentication. This can also be specified with the `NUTANIX_API_KEY` environment variable.
 * `custom_headers` - (Optional) A map of custom HTTP headers to add to all API requests. Useful for environments that require additional headers such as Cloudflare Access service tokens. Headers can also be set via environment variables with the `NUTANIX_HEADER_` prefix (e.g., `NUTANIX_HEADER_CF_ACCESS_CLIENT_ID` becomes `Cf-Access-Client-Id`). Config values take precedence over environment variables.
 * `insecure` - (Optional) This specifies whether to allow verify ssl certificates. This can also be specified with `NUTANIX_INSECURE`. Defaults to `false`.
 * `port` - (Optional) This is the port for the Prism Elements or Prism Central instance. This can also be specified with the `NUTANIX_PORT` environment variable. Defaults to `9440`.
@@ -410,7 +410,9 @@ provider "nutanix" {
 
 ### API Key Authentication
 
-API key authentication can be used as an alternative to username/password authentication. When an API key is provided, the `X-Ntnx-Api-Key` header is used for authentication instead of Basic Authentication.
+API key authentication can be used as an alternative to username/password authentication when connecting to a **Prism Central** instance. When an API key is provided, the `X-Ntnx-Api-Key` header is used for authentication instead of Basic Authentication.
+
+-> **Note:** API key authentication is a Prism Central feature and is not supported by Prism Elements. Use `username` and `password` when connecting to a Prism Elements endpoint.
 
 Usage:
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -382,9 +382,11 @@ provider "nutanix" {
 ## Argument Reference
 
 The following arguments are used to configure the Nutanix Provider:
-* `username` - **(Required)** This is the username for the Prism Elements or Prism Central instance. This can also be specified with the `NUTANIX_USERNAME` environment variable.
-* `password` - **(Required)** This is the password for the Prism Elements or Prism Central instance. This can also be specified with the `NUTANIX_PASSWORD` environment variable.
+* `username` - (Optional) This is the username for the Prism Elements or Prism Central instance. This can also be specified with the `NUTANIX_USERNAME` environment variable. Required if `api_key` is not provided.
+* `password` - (Optional) This is the password for the Prism Elements or Prism Central instance. This can also be specified with the `NUTANIX_PASSWORD` environment variable. Required if `api_key` is not provided.
 * `endpoint` - **(Required)** This is the endpoint for the Prism Elements or Prism Central instance. This can also be specified with the `NUTANIX_ENDPOINT` environment variable.
+* `api_key` - (Optional) This is an API key for Prism Central authentication. Can be used as an alternative to `username`/`password`. When set, the `X-Ntnx-Api-Key` header will be used instead of Basic Authentication. This can also be specified with the `NUTANIX_API_KEY` environment variable.
+* `custom_headers` - (Optional) A map of custom HTTP headers to add to all API requests. Useful for environments that require additional headers such as Cloudflare Access service tokens. Headers can also be set via environment variables with the `NUTANIX_HEADER_` prefix (e.g., `NUTANIX_HEADER_CF_ACCESS_CLIENT_ID` becomes `Cf-Access-Client-Id`). Config values take precedence over environment variables.
 * `insecure` - (Optional) This specifies whether to allow verify ssl certificates. This can also be specified with `NUTANIX_INSECURE`. Defaults to `false`.
 * `port` - (Optional) This is the port for the Prism Elements or Prism Central instance. This can also be specified with the `NUTANIX_PORT` environment variable. Defaults to `9440`.
 * `session_auth` - (Optional) This specifies whether to use [session authentication](#session-based-authentication). This can also be specified with the `NUTANIX_SESSION_AUTH` environment variable. Defaults to `true`
@@ -405,6 +407,62 @@ provider "nutanix" {
   ...
 }
 ```
+
+### API Key Authentication
+
+API key authentication can be used as an alternative to username/password authentication. When an API key is provided, the `X-Ntnx-Api-Key` header is used for authentication instead of Basic Authentication.
+
+Usage:
+
+```terraform
+provider "nutanix" {
+  endpoint = var.nutanix_endpoint
+  api_key  = var.nutanix_api_key
+  port     = var.nutanix_port
+  insecure = true
+}
+```
+
+Or using environment variable:
+```bash
+export NUTANIX_API_KEY="your-api-key"
+```
+
+### Custom Headers (Cloudflare Access)
+
+For environments that require additional HTTP headers (such as Cloudflare Access service tokens), you can specify custom headers that will be added to all API requests.
+
+Usage with provider configuration:
+
+```terraform
+provider "nutanix" {
+  endpoint = var.nutanix_endpoint
+  api_key  = var.nutanix_api_key
+  custom_headers = {
+    "CF-Access-Client-Id"     = var.cf_client_id
+    "CF-Access-Client-Secret" = var.cf_client_secret
+  }
+}
+```
+
+Or using environment variables with the `NUTANIX_HEADER_` prefix:
+```bash
+export NUTANIX_HEADER_CF_ACCESS_CLIENT_ID="your-client-id"
+export NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET="your-client-secret"
+```
+
+Environment variables are converted to HTTP headers by:
+1. Stripping the `NUTANIX_HEADER_` prefix
+2. Replacing underscores with dashes
+3. Applying title-casing
+
+For example:
+| Environment Variable | HTTP Header |
+| :--- | :--- |
+| `NUTANIX_HEADER_CF_ACCESS_CLIENT_ID` | `Cf-Access-Client-Id` |
+| `NUTANIX_HEADER_X_CUSTOM_HEADER` | `X-Custom-Header` |
+
+Headers defined in the provider configuration take precedence over environment variables.
 
 ## Notes
 
@@ -479,9 +537,8 @@ NDB based examples : https://github.com/nutanix/terraform-provider-nutanix/blob/
 
 ## Provider configuration required details
 
-Going from 1.8.0-beta release of nutanix provider, fields inside provider configuration would be mandatory as per the usecase : 
+Going from 1.8.0-beta release of nutanix provider, fields inside provider configuration would be mandatory as per the usecase :
 
-* `Prism Central & Karbon` : For prism central and karbon related resources and data sources, `username`, `password` & `endpoint` are manadatory.
-* `Foundation` : For foundation related resources and data sources, `foundation_endpoint` in manadatory.
-* `NDB` : For Nutanix Database Service (NDB) related resources and data sources. 
-
+* `Prism Central & Karbon` : For prism central and karbon related resources and data sources, `endpoint` is mandatory plus either (`username` and `password`) or `api_key` for authentication.
+* `Foundation` : For foundation related resources and data sources, `foundation_endpoint` is mandatory.
+* `NDB` : For Nutanix Database Service (NDB) related resources and data sources, `ndb_endpoint`, `ndb_username`, and `ndb_password` are mandatory. 


### PR DESCRIPTION
- API Key allowed as an alternative to credentials
- Custom headers (e.g. for Cloudflare) are supported
- API Key and custom headers can be specified by environment variables
- Logic for configuring provider for v4 APIs centralized

Closes #1057
Closes #1040