### PR TITLE
  Fix acceptance test summary double-counting and add local test tooling

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,22 @@
+# Nutanix acceptance test environment (source before running: source .env)
+# Do not commit this file if it contains real credentials.
+
+CGO_ENABLED=0
+NUTANIX_ENDPOINT=""
+NUTANIX_USERNAME=""
+NUTANIX_PASSWORD=""
+NUTANIX_INSECURE=true
+NUTANIX_PORT=9440
+NUTANIX_PE_PASSWORD=""
+NUTANIX_PE_USERNAME=""
+NUTANIX_STORAGE_CONTAINER=""
+FOUNDATION_ENDPOINT=""
+FOUNDATION_PORT=8000
+NOS_IMAGE_TEST_URL="test"
+PROTECTION_RULES_TEST_FLAG=false
+NDB_ENDPOINT=""
+NDB_USERNAME=""
+NDB_PASSWORD=""
+
+# Terraform / test log level
+TF_LOG=ERROR

--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -205,41 +205,52 @@ jobs:
                   exit 1  # Ignore missing file instead of failing
               fi
 
-              # Extract total test cases executed safely
+              # Extract total test cases executed safely (top-level RUN count)
               TOTAL_RUN=$(grep -c '^=== RUN' test_output.log)
               if [ "$TOTAL_RUN" -eq 0 ]; then
                   echo "No test cases executed. Exiting..."
                   exit 1
               fi
 
-              # Extract counts of passed, failed, and skipped tests
-              TOTAL_PASSED=$(grep -c '^--- PASS' test_output.log)
-              TOTAL_FAILED=$(grep -c '^--- FAIL' test_output.log)
-              TOTAL_SKIPPED=$(grep -c '^--- SKIP' test_output.log)
+              # Use last result per test name so tests that run in a subprocess (e.g. NGT Insert ISO retry wrapper)
+              # are counted and listed only once. The last result is the authoritative one (parent test).
+              awk '
+                /^--- (PASS|FAIL|SKIP): / {
+                  result = $2; sub(/:$/, "", result);
+                  name = $3;
+                  last_result[name] = result;
+                  last_line[name] = NR;
+                }
+                END {
+                  for (n in last_result) {
+                    print last_line[n], last_result[n], n
+                  }
+                }
+              ' test_output.log | sort -n > test_results_by_last.txt
+
+              # Count by last result (each test counted once)
+              TOTAL_PASSED=$(awk '$2 == "PASS"' test_results_by_last.txt | wc -l)
+              TOTAL_FAILED=$(awk '$2 == "FAIL"' test_results_by_last.txt | wc -l)
+              TOTAL_SKIPPED=$(awk '$2 == "SKIP"' test_results_by_last.txt | wc -l)
 
               # Set output as successful for GitHub Actions which will be used in subsequent steps, Set only if tests were executed
               echo "tests_executed=tests_execution_successful" >> $GITHUB_OUTPUT
 
-              # Calculate percentages safely
+              # Calculate percentages safely (use unique test count)
+              UNIQUE_TESTS=$((TOTAL_PASSED + TOTAL_FAILED + TOTAL_SKIPPED))
               PASS_PERCENT=0
               FAIL_PERCENT=0
               SKIP_PERCENT=0
-              if [ "$TOTAL_RUN" -gt 0 ]; then
-                  if [ "$TOTAL_PASSED" -gt 0 ]; then
-                      PASS_PERCENT=$((TOTAL_PASSED * 100 / TOTAL_RUN))
-                  fi
-                  if [ "$TOTAL_FAILED" -gt 0 ]; then
-                      FAIL_PERCENT=$((TOTAL_FAILED * 100 / TOTAL_RUN))
-                  fi
-                  if [ "$TOTAL_SKIPPED" -gt 0 ]; then
-                      SKIP_PERCENT=$((TOTAL_SKIPPED * 100 / TOTAL_RUN))
-                  fi
+              if [ "$UNIQUE_TESTS" -gt 0 ]; then
+                  [ "$TOTAL_PASSED" -gt 0 ] && PASS_PERCENT=$((TOTAL_PASSED * 100 / UNIQUE_TESTS))
+                  [ "$TOTAL_FAILED" -gt 0 ] && FAIL_PERCENT=$((TOTAL_FAILED * 100 / UNIQUE_TESTS))
+                  [ "$TOTAL_SKIPPED" -gt 0 ] && SKIP_PERCENT=$((TOTAL_SKIPPED * 100 / UNIQUE_TESTS))
               fi
 
-              # Write summary to a file
+              # Write summary to a file (each test appears only once, under its last result)
               {
                 echo "==================================================🧪 TEST SUMMARY 🧪================================================================================="
-                echo "Total Test Cases Run 🚀: $TOTAL_RUN"
+                echo "Total Test Cases Run 🚀: $UNIQUE_TESTS"
                 echo "Total Test Cases Passed ✅: $TOTAL_PASSED ($PASS_PERCENT %)" 
                 echo "Total Test Cases Failed ❌: $TOTAL_FAILED ($FAIL_PERCENT %)"
                 echo "Total Test Cases Skipped ⚠️: $TOTAL_SKIPPED ($SKIP_PERCENT %)"
@@ -248,7 +259,7 @@ jobs:
                 echo "================================================== TESTS SUCCEEDED ✅ ============================================================================="
                 if [ "$TOTAL_PASSED" -gt 0 ]; then
                     echo ""
-                    grep '^--- PASS' test_output.log | awk '{print "✅ " $3}' || true
+                    awk '$2 == "PASS" { print "✅ " $3 }' test_results_by_last.txt || true
                 else
                     echo "No tests passed 😞❗"
                 fi
@@ -257,7 +268,7 @@ jobs:
                 echo "================================================== TESTS FAILED ❌ ================================================================================"
                 if [ "$TOTAL_FAILED" -gt 0 ]; then
                     echo ""
-                    grep '^--- FAIL' test_output.log | awk '{print "❌ " $3}' || true
+                    awk '$2 == "FAIL" { print "❌ " $3 }' test_results_by_last.txt || true
                 else
                     echo "🎉💃 No tests failed 🕺🎉"
                 fi
@@ -265,10 +276,8 @@ jobs:
                 echo ""
                 echo "================================================== TESTS SKIPPED ⚠️ =============================================================================="
                 if [ "$TOTAL_SKIPPED" -gt 0 ]; then
-                    awk '
-                      /^=== RUN/ { testname=$3; reason="No reason provided" }
-                      /--- SKIP/ { print "⚠️ " testname "   : Reason: ➡️ :  " reason }
-                      /^[[:space:]]+/ { reason=$0 }' test_output.log || true
+                    echo ""
+                    awk '$2 == "SKIP" { print "⚠️ " $3 "   : Reason: ➡️ :  See log for details" }' test_results_by_last.txt || true
                 else
                     echo "🎉💃 No tests skipped 🕺🎉"
                 fi
@@ -276,6 +285,7 @@ jobs:
                 echo ""
 
               } > test_summary.txt
+              rm -f test_results_by_last.txt
               echo "TEST_SUMMARY_FILE=test_summary.txt" >> $GITHUB_ENV
 
               # Write to GitHub output for PR comment

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 **/.terraform*
 *.log
 setenv.sh
+.env
 request_log
 .DS_Store
 dist/

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,12 +17,13 @@ testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 500m -coverprofile c.out -covermode=count
 
 # Acceptance tests with .env loaded (same as /ok-to-test). Loads .env from repo root before running.
-# Output streams to terminal in real time and to ACC_TEST_LOG (default: test_output.log); summary appended at end.
-# Usage:
-#   make acc-test TestAccV2NutanixOvaVmDeployResource_DeployVMFromOva   # single test (vmmv2)
-#   make acc-test PKG=vmmv2                                             # all tests in vmmv2
-#   make acc-test v4                                                   # all TestAccV2Nutanix* tests
-#   make acc-test v3                                                   # all TestAccNutanix* tests
+# Output to ACC_TEST_LOG only; summary appended at end. Matches workflow: -p package → package only.
+# Usage (like .github/workflows/acceptance-test.yml /ok-to-test -p <package>):
+#   make acc-test vmmv2                                                # all tests in package vmmv2 (same as -p vmmv2)
+#   make acc-test p=vmmv2                                             # same (make reserves -p, use p=)
+#   make acc-test TestAccV2NutanixOvaVmDeployResource_DeployVMFromOva # single test (vmmv2)
+#   make acc-test v4                                                  # all TestAccV2Nutanix* tests
+#   make acc-test v3                                                  # all TestAccNutanix* tests
 ACC_ARG := $(firstword $(filter-out acc-test,$(MAKECMDGOALS)))
 ACC_TEST_LOG ?= test_output.log
 acc-test:
@@ -45,6 +46,10 @@ acc-test:
 			"") run_pattern="." ;; \
 			*) run_pattern="$$arg"; [ -d nutanix/services/vmmv2 ] && pkg="vmmv2" ;; \
 		esac; \
+		[ -d "nutanix/services/$$arg" ] && pkg="$$arg" && run_pattern="."; \
+		[ -z "$$pkg" ] && [ -n "$(PKG)" ] && pkg="$(PKG)"; \
+		[ -z "$$pkg" ] && [ -n "$(p)" ] && pkg="$(p)"; \
+		[ -n "$(RUN)" ] && run_pattern="$(RUN)"; \
 		if [ -n "$$pkg" ]; then \
 			(cd nutanix/services/$$pkg && go test . -v -run="$$run_pattern" -timeout 500m -count=1 2>&1) | while IFS= read -r line; do echo "$$line" >> "$$logfile"; done; \
 		else \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,49 +17,69 @@ testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 500m -coverprofile c.out -covermode=count
 
 # Acceptance tests with .env loaded (same as /ok-to-test). Loads .env from repo root before running.
-# Output to ACC_TEST_LOG only; summary appended at end. Matches workflow: -p package → package only.
-# Usage (like .github/workflows/acceptance-test.yml /ok-to-test -p <package>):
-#   make acc-test vmmv2                                                # all tests in package vmmv2 (same as -p vmmv2)
-#   make acc-test p=vmmv2                                             # same (make reserves -p, use p=)
-#   make acc-test TestAccV2NutanixOvaVmDeployResource_DeployVMFromOva # single test (vmmv2)
-#   make acc-test v4                                                  # all TestAccV2Nutanix* tests
-#   make acc-test v3                                                  # all TestAccNutanix* tests
-ACC_ARG := $(firstword $(filter-out acc-test,$(MAKECMDGOALS)))
+# Output to ACC_TEST_LOG only; summary appended at end. Matches workflow logic from acceptance-test.yml.
+# Usage:
+#   make acc-test networkingv2                                         # all tests in package networkingv2 (auto-detected)
+#   make acc-test networkingv2 TestAccV2NutanixSubnetResource_Basic    # single test in specific package
+#   make acc-test p=networkingv2                                       # all tests in package (explicit)
+#   make acc-test p=networkingv2 TestAccV2NutanixSubnetResource_Basic  # single test in specific package (explicit)
+#   make acc-test v4                                                   # all TestAccV2Nutanix* tests
+#   make acc-test v3                                                   # all TestAccNutanix* tests
+#   make acc-test TestAccV2NutanixSubnetResource_Basic                 # single test (searches all packages)
+#   make acc-test TestAccV2NutanixSubnet TestAccV2NutanixVpc           # multiple tests (combined with |)
+# Note: Don't use -p flag (it's a Make built-in). Use p= or just the package name directly.
 ACC_TEST_LOG ?= test_output.log
 acc-test:
 	@bash -c '\
-		arg="$(ACC_ARG)"; logfile="$(ACC_TEST_LOG)"; \
+		logfile="$(ACC_TEST_LOG)"; \
 		: > "$$logfile"; \
 		echo "==> Loading .env and running acceptance tests (output to $$logfile only; summary at end)..." >> "$$logfile"; \
 		[ -f .env ] && set -a && . ./.env && set +a; \
 		export TF_ACC=1 GOTRACEBACK=all; \
-		run_pattern="."; pkg=""; \
-		case "$$arg" in \
-			v4) run_pattern="TestAccV2Nutanix*" ;; \
-			v3) run_pattern="TestAccNutanix*" ;; \
-			foundation) run_pattern="TestAccFoundation*" ;; \
-			foundation_central) run_pattern="TestAccFC*" ;; \
-			karbon) run_pattern="TestAccKarbon*" ;; \
-			lcm) run_pattern="TestAccV2NutanixLcm*" ;; \
-			era) run_pattern="TestAccEra*" ;; \
-			PKG=*) pkg="$${arg#PKG=}"; run_pattern="." ;; \
-			"") run_pattern="." ;; \
-			*) run_pattern="$$arg"; [ -d nutanix/services/vmmv2 ] && pkg="vmmv2" ;; \
-		esac; \
-		[ -d "nutanix/services/$$arg" ] && pkg="$$arg" && run_pattern="."; \
-		[ -z "$$pkg" ] && [ -n "$(PKG)" ] && pkg="$(PKG)"; \
-		[ -z "$$pkg" ] && [ -n "$(p)" ] && pkg="$(p)"; \
-		[ -n "$(RUN)" ] && run_pattern="$(RUN)"; \
-		if [ -n "$$pkg" ]; then \
-			(cd nutanix/services/$$pkg && go test . -v -run="$$run_pattern" -timeout 500m -count=1 2>&1) | while IFS= read -r line; do echo "$$line" >> "$$logfile"; done; \
-		else \
-			go test ./... -v -run="$$run_pattern" -timeout 500m -count=1 2>&1 | while IFS= read -r line; do echo "$$line" >> "$$logfile"; done; \
+		args="$(filter-out acc-test,$(MAKECMDGOALS))"; \
+		package_path="./..."; \
+		run_flag=""; \
+		if [ -n "$(p)" ]; then \
+			package_path="./nutanix/services/$(p)"; \
+			echo "📦 Running tests only in package: $$package_path" >> "$$logfile"; \
 		fi; \
+		for arg in $$args; do \
+			if [ -d "nutanix/services/$$arg" ]; then \
+				package_path="./nutanix/services/$$arg"; \
+				echo "📦 Running tests only in package: $$package_path (auto-detected)" >> "$$logfile"; \
+				continue; \
+			fi; \
+			case "$$arg" in \
+				foundation) pattern="TestAccFoundation*" ;; \
+				foundation_central) pattern="TestAccFC*" ;; \
+				karbon) pattern="TestAccKarbon*" ;; \
+				v3) pattern="TestAccNutanix*" ;; \
+				v4) pattern="TestAccV2Nutanix*" ;; \
+				lcm) pattern="TestAccV2NutanixLcm*" ;; \
+				era) pattern="TestAccEra*" ;; \
+				*) pattern="$$arg" ;; \
+			esac; \
+			if [ -n "$$run_flag" ]; then \
+				run_flag="$$run_flag|$$pattern"; \
+			else \
+				run_flag="$$pattern"; \
+			fi; \
+		done; \
+		if [ "$$package_path" != "./..." ] && [ -z "$$run_flag" ]; then \
+			test_args="-run=."; \
+		elif [ -n "$$run_flag" ]; then \
+			test_args="-run=$$run_flag"; \
+		else \
+			test_args="-run=."; \
+		fi; \
+		echo "==> TESTARGS = $$test_args" >> "$$logfile"; \
+		echo "==> Package path = $$package_path" >> "$$logfile"; \
+		go test "$$package_path" -v $$test_args -timeout 500m -count=1 2>&1 | while IFS= read -r line; do echo "$$line" >> "$$logfile"; done; \
 		if [ -f "$$logfile" ] && grep -qE "^--- (PASS|FAIL|SKIP):" "$$logfile" 2>/dev/null; then \
 			"$(CURDIR)/scripts/acc-test-summary.sh" "$$logfile"; \
 		fi'
 	@echo "==> Log file: $(ACC_TEST_LOG)"
-# Dummy target so "make acc-test v4" etc. do not fail (argument is consumed by ACC_ARG)
+# Dummy target so "make acc-test v4" etc. do not fail (arguments are consumed)
 %: acc-test
 	@true
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,6 +16,48 @@ testacc: fmtcheck
 	@echo "TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 500m -coverprofile c.out -covermode=count"
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 500m -coverprofile c.out -covermode=count
 
+# Acceptance tests with .env loaded (same as /ok-to-test). Loads .env from repo root before running.
+# Output streams to terminal in real time and to ACC_TEST_LOG (default: test_output.log); summary appended at end.
+# Usage:
+#   make acc-test TestAccV2NutanixOvaVmDeployResource_DeployVMFromOva   # single test (vmmv2)
+#   make acc-test PKG=vmmv2                                             # all tests in vmmv2
+#   make acc-test v4                                                   # all TestAccV2Nutanix* tests
+#   make acc-test v3                                                   # all TestAccNutanix* tests
+ACC_ARG := $(firstword $(filter-out acc-test,$(MAKECMDGOALS)))
+ACC_TEST_LOG ?= test_output.log
+acc-test:
+	@bash -c '\
+		arg="$(ACC_ARG)"; logfile="$(ACC_TEST_LOG)"; \
+		: > "$$logfile"; \
+		echo "==> Loading .env and running acceptance tests (output to $$logfile only; summary at end)..." >> "$$logfile"; \
+		[ -f .env ] && set -a && . ./.env && set +a; \
+		export TF_ACC=1 GOTRACEBACK=all; \
+		run_pattern="."; pkg=""; \
+		case "$$arg" in \
+			v4) run_pattern="TestAccV2Nutanix*" ;; \
+			v3) run_pattern="TestAccNutanix*" ;; \
+			foundation) run_pattern="TestAccFoundation*" ;; \
+			foundation_central) run_pattern="TestAccFC*" ;; \
+			karbon) run_pattern="TestAccKarbon*" ;; \
+			lcm) run_pattern="TestAccV2NutanixLcm*" ;; \
+			era) run_pattern="TestAccEra*" ;; \
+			PKG=*) pkg="$${arg#PKG=}"; run_pattern="." ;; \
+			"") run_pattern="." ;; \
+			*) run_pattern="$$arg"; [ -d nutanix/services/vmmv2 ] && pkg="vmmv2" ;; \
+		esac; \
+		if [ -n "$$pkg" ]; then \
+			(cd nutanix/services/$$pkg && go test . -v -run="$$run_pattern" -timeout 500m -count=1 2>&1) | while IFS= read -r line; do echo "$$line" >> "$$logfile"; done; \
+		else \
+			go test ./... -v -run="$$run_pattern" -timeout 500m -count=1 2>&1 | while IFS= read -r line; do echo "$$line" >> "$$logfile"; done; \
+		fi; \
+		if [ -f "$$logfile" ] && grep -qE "^--- (PASS|FAIL|SKIP):" "$$logfile" 2>/dev/null; then \
+			"$(CURDIR)/scripts/acc-test-summary.sh" "$$logfile"; \
+		fi'
+	@echo "==> Log file: $(ACC_TEST_LOG)"
+# Dummy target so "make acc-test v4" etc. do not fail (argument is consumed by ACC_ARG)
+%: acc-test
+	@true
+
 fmt:
 	@echo "==> Fixing source code with gofmt..."
 	goimports -w ./$(PKG_NAME)
@@ -104,4 +146,4 @@ endif
 
 .NOTPARALLEL:
 
-.PHONY: default build test testacc fmt fmtcheck errcheck lint tools vet test-compile cibuild citest website website-lint website-test
+.PHONY: default build test testacc acc-test fmt fmtcheck errcheck lint tools vet test-compile cibuild citest website website-lint website-test

--- a/README.md
+++ b/README.md
@@ -452,23 +452,18 @@ From the **repository root**:
 
 3. **Run tests** (from repo root; `.env` is loaded automatically by `make acc-test`):
 
-   Output streams to the terminal in real time and to `test_output.log`; a test summary is appended at the end of the same file. To watch the log in another Cursor terminal: `tail -f test_output.log`.
+   Output goes to `test_output.log`; a test summary is appended at the end. To watch the log: `tail -f test_output.log`.
 
-   ```bash
-   # Single test case
-   make acc-test TestAccV2NutanixOvaVmDeployResource_DeployVMFromOva
+   | Command | What it does |
+   | :--- | :--- |
+   | `make acc-test networkingv2` | All tests in networkingv2 package (auto-detected) |
+   | `make acc-test networkingv2 TestAccV2NutanixSubnetResource_Basic` | Specific test in networkingv2 package |
+   | `make acc-test TestAccV2NutanixSubnetResource_Basic` | Search all packages for test |
+   | `make acc-test p=networkingv2` | All tests in networkingv2 (explicit package) |
+   | `make acc-test v4` | All V4 tests (`TestAccV2Nutanix*`) |
+   | `make acc-test v3` | All V3 tests (`TestAccNutanix*`) |
 
-   # All tests in a package
-   make acc-test PKG=vmmv2
-
-   # V4 test cases (TestAccV2Nutanix*)
-   make acc-test v4
-
-   # V3 test cases (TestAccNutanix*)
-   make acc-test v3
-   ```
-
-   Use a different log file: `make acc-test PKG=vmmv2 ACC_TEST_LOG=my_tests.log`
+   Use a different log file: `make acc-test networkingv2 ACC_TEST_LOG=my_tests.log`
 
    Or use the script (also loads env if you `source .env` first):
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,43 @@ The Nutanix Provider for Terraform is the work of many contributors. We apprecia
 * [Contribution Guidelines](./CONTRIBUTING.md)
 * [Code of Conduct](./CODE_OF_CONDUCT.md)
 
+### Running acceptance tests locally (same as /ok-to-test on GitHub)
+
+From the **repository root**:
+
+1. **Set environment variables** (required by `TestAccPreCheck`):
+   - `NUTANIX_USERNAME`, `NUTANIX_PASSWORD`, `NUTANIX_ENDPOINT`
+   - `NUTANIX_INSECURE`, `NUTANIX_PORT`, `NUTANIX_STORAGE_CONTAINER`
+
+2. **Config files** (for V4/vmmv2 tests): ensure `test_config_v2.json` exists at the repo root (same content as the `V4_CONFIG` secret used in CI).
+
+3. **Run tests** (from repo root; `.env` is loaded automatically by `make acc-test`):
+
+   Output streams to the terminal in real time and to `test_output.log`; a test summary is appended at the end of the same file. To watch the log in another Cursor terminal: `tail -f test_output.log`.
+
+   ```bash
+   # Single test case
+   make acc-test TestAccV2NutanixOvaVmDeployResource_DeployVMFromOva
+
+   # All tests in a package
+   make acc-test PKG=vmmv2
+
+   # V4 test cases (TestAccV2Nutanix*)
+   make acc-test v4
+
+   # V3 test cases (TestAccNutanix*)
+   make acc-test v3
+   ```
+
+   Use a different log file: `make acc-test PKG=vmmv2 ACC_TEST_LOG=my_tests.log`
+
+   Or use the script (also loads env if you `source .env` first):
+
+   ```bash
+   source .env
+   ./scripts/run-acceptance-test.sh -p vmmv2 TestAccV2NutanixOvaVmDeployResource_DeployVMFromOva
+   ```
+
 
 ## Support
 

--- a/scripts/acc-test-summary.sh
+++ b/scripts/acc-test-summary.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Appends test summary (last result per test name) to the given log file.
+# Usage: scripts/acc-test-summary.sh <test_output.log>
+
+set -e
+
+LOGFILE="${1:?Usage: $0 <test_output.log>}"
+
+if [[ ! -f "$LOGFILE" ]] || ! grep -qE '^--- (PASS|FAIL|SKIP):' "$LOGFILE" 2>/dev/null; then
+  exit 0
+fi
+
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+
+awk '
+  /^--- (PASS|FAIL|SKIP): / {
+    result = $2; sub(/:$/, "", result);
+    name = $3;
+    last_result[name] = result;
+    last_line[name] = NR;
+  }
+  END {
+    for (n in last_result) {
+      print last_line[n], last_result[n], n
+    }
+  }
+' "$LOGFILE" | sort -n > "$TMP"
+
+TOTAL_PASSED=$(awk '$2 == "PASS"' "$TMP" | wc -l | tr -d ' ')
+TOTAL_FAILED=$(awk '$2 == "FAIL"' "$TMP" | wc -l | tr -d ' ')
+TOTAL_SKIPPED=$(awk '$2 == "SKIP"' "$TMP" | wc -l | tr -d ' ')
+UNIQUE_TESTS=$((TOTAL_PASSED + TOTAL_FAILED + TOTAL_SKIPPED))
+
+PASS_PERCENT=0
+FAIL_PERCENT=0
+SKIP_PERCENT=0
+if [[ $UNIQUE_TESTS -gt 0 ]]; then
+  [[ $TOTAL_PASSED -gt 0 ]] && PASS_PERCENT=$((TOTAL_PASSED * 100 / UNIQUE_TESTS))
+  [[ $TOTAL_FAILED -gt 0 ]] && FAIL_PERCENT=$((TOTAL_FAILED * 100 / UNIQUE_TESTS))
+  [[ $TOTAL_SKIPPED -gt 0 ]] && SKIP_PERCENT=$((TOTAL_SKIPPED * 100 / UNIQUE_TESTS))
+fi
+
+{
+  echo ""
+  echo "================================================== 🧪 TEST SUMMARY 🧪 ================================================================================="
+  echo "Total Test Cases Run 🚀: $UNIQUE_TESTS"
+  echo "Total Test Cases Passed ✅: $TOTAL_PASSED ($PASS_PERCENT %)"
+  echo "Total Test Cases Failed ❌: $TOTAL_FAILED ($FAIL_PERCENT %)"
+  echo "Total Test Cases Skipped ⚠️: $TOTAL_SKIPPED ($SKIP_PERCENT %)"
+  echo "================================================================================================================================================"
+  echo ""
+  echo "================================================== TESTS SUCCEEDED ✅ ============================================================================="
+  if [[ $TOTAL_PASSED -gt 0 ]]; then
+    awk '$2 == "PASS" { print "✅ " $3 }' "$TMP"
+  else
+    echo "No tests passed 😞❗"
+  fi
+  echo "================================================================================================================================================"
+  echo ""
+  echo "================================================== TESTS FAILED ❌ ================================================================================"
+  if [[ $TOTAL_FAILED -gt 0 ]]; then
+    awk '$2 == "FAIL" { print "❌ " $3 }' "$TMP"
+  else
+    echo "🎉💃 No tests failed 🕺🎉"
+  fi
+  echo "================================================================================================================================================"
+  echo ""
+  echo "================================================== TESTS SKIPPED ⚠️ =============================================================================="
+  if [[ $TOTAL_SKIPPED -gt 0 ]]; then
+    awk '$2 == "SKIP" { print "⚠️ " $3 "   : Reason: ➡️ :  See log for details" }' "$TMP"
+  else
+    echo "🎉💃 No tests skipped 🕺🎉"
+  fi
+  echo "================================================================================================================================================"
+} >> "$LOGFILE"
+
+echo ""
+echo "==> Test summary appended to $LOGFILE"

--- a/scripts/run-acceptance-test.sh
+++ b/scripts/run-acceptance-test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Run acceptance tests locally (same as /ok-to-test on GitHub).
+# Must be run from the repository root. Requires NUTANIX_* env vars and test config files.
+#
+# Usage:
+#   ./scripts/run-acceptance-test.sh [-p package] <test_pattern>
+#
+# Examples (equivalent to /ok-to-test on GitHub):
+#   ./scripts/run-acceptance-test.sh -p vmmv2 TestAccV2NutanixOvaVmDeployResource_DeployVMFromOva
+#   ./scripts/run-acceptance-test.sh -p vmmv2 TestAccV2NutanixNGTInsertIsoResource_InsertNGTIsoIntoVmHaveNGTTest
+#   ./scripts/run-acceptance-test.sh v4                                    # all TestAccV2Nutanix* (runs from repo root)
+#   ./scripts/run-acceptance-test.sh TestAccV2NutanixOvaVmDeployResource_DeployVMFromOva  # single test (needs -p for vmmv2)
+#
+# Options:
+#   -p package   Package under nutanix/services/ (e.g. vmmv2). Required for vmmv2 so test_config_v2.json is found.
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+PACKAGE=""
+RUN_PATTERN=""
+
+while getopts "p:" opt; do
+  case "$opt" in
+    p) PACKAGE="$OPTARG" ;;
+    *) exit 1 ;;
+  esac
+done
+shift "$((OPTIND - 1))"
+RUN_PATTERN="${1:?Usage: $0 [-p package] <test_pattern>}"
+
+# Map provider names to -run patterns (same as GitHub workflow)
+case "$RUN_PATTERN" in
+  foundation)           RUN_PATTERN="TestAccFoundation*" ;;
+  foundation_central)   RUN_PATTERN="TestAccFC*" ;;
+  karbon)               RUN_PATTERN="TestAccKarbon*" ;;
+  v3)                   RUN_PATTERN="TestAccNutanix*" ;;
+  v4)                   RUN_PATTERN="TestAccV2Nutanix*" ;;
+  lcm)                  RUN_PATTERN="TestAccV2NutanixLcm*" ;;
+  era)                  RUN_PATTERN="TestAccEra*" ;;
+esac
+
+export TF_ACC=1
+export TF_LOG="${TF_LOG:-ERROR}"
+export GOTRACEBACK=all
+
+# Pre-check: NUTANIX_* required by TestAccPreCheck
+if [[ -z "${NUTANIX_USERNAME:-}" || -z "${NUTANIX_PASSWORD:-}" || -z "${NUTANIX_ENDPOINT:-}" ]]; then
+  echo "Error: NUTANIX_USERNAME, NUTANIX_PASSWORD, NUTANIX_ENDPOINT (and NUTANIX_INSECURE, NUTANIX_PORT, NUTANIX_STORAGE_CONTAINER) must be set for acceptance tests."
+  echo "Copy from your GitHub Actions secrets or set in .env and source it."
+  exit 1
+fi
+
+if [[ -n "$PACKAGE" ]]; then
+  # Run from package dir so paths like ../../../test_config_v2.json resolve to repo root
+  PKG_DIR="$REPO_ROOT/nutanix/services/$PACKAGE"
+  if [[ ! -d "$PKG_DIR" ]]; then
+    echo "Error: Package directory not found: $PKG_DIR"
+    exit 1
+  fi
+  if [[ "$PACKAGE" == "vmmv2" && ! -f "$REPO_ROOT/test_config_v2.json" ]]; then
+    echo "Warning: test_config_v2.json not found at repo root; vmmv2 tests may fail."
+  fi
+  echo "==> Running acceptance tests in package: $PACKAGE (pattern: $RUN_PATTERN)"
+  (cd "$PKG_DIR" && go test . -v -run="$RUN_PATTERN" -timeout 500m -count=1)
+else
+  # Run all packages matching the pattern from repo root
+  echo "==> Running acceptance tests in ./... (pattern: $RUN_PATTERN)"
+  go test ./... -v -run="$RUN_PATTERN" -timeout 500m -count=1
+fi


### PR DESCRIPTION
## Summary
- Fix test summary logic to count each test only once using its last (authoritative) result, resolving double-counting for tests that spawn subprocesses (e.g., NGT Insert ISO retry wrapper)
- Add `make acc-test` target and helper scripts for running acceptance tests locally with the same behavior as `/ok-to-test` in CI
- Update README with documentation for local acceptance test usage

## Changes
- **`.github/workflows/acceptance-test.yml`**: Refactored summary generation to deduplicate test results by taking the last outcome per test name
- **`GNUmakefile`**: Added `acc-test` target with support for single tests, packages, and test suites (v3, v4, etc.)
- **`scripts/acc-test-summary.sh`**: New script to append test summary to log files
- **`scripts/run-acceptance-test.sh`**: New script for running acceptance tests with proper env setup
- **`README.md`**: Added documentation for local acceptance test workflow
- **`.gitignore`**: Added `.env` to prevent accidental commits of credentials

**Run tests** (from repo root; `.env` is loaded automatically by `make acc-test`):

   Output goes to `test_output.log`; a test summary is appended at the end. To watch the log: `tail -f test_output.log`.

   | Command | What it does |
   | :--- | :--- |
   | `make acc-test networkingv2` | All tests in networkingv2 package (auto-detected) |
   | `make acc-test networkingv2 TestAccV2NutanixSubnetResource_Basic` | Specific test in networkingv2 package |
   | `make acc-test TestAccV2NutanixSubnetResource_Basic` | Search all packages for test |
   | `make acc-test p=networkingv2` | All tests in networkingv2 (explicit package) |
   | `make acc-test v4` | All V4 tests (`TestAccV2Nutanix*`) |
   | `make acc-test v3` | All V3 tests (`TestAccNutanix*`) |

   Use a different log file: `make acc-test networkingv2 ACC_TEST_LOG=my_tests.log`

## Test plan
- [x] Run `make acc-test TestAccV2Nutanix*` locally and verify summary shows correct counts
- [x] Trigger `/ok-to-test` in CI and verify test summary no longer double-counts subprocess tests
- [x] Verify tests with retry wrappers (e.g., NGT tests) appear only once in the summary
