### PR TITLE
Add IAM v2 Entity and Entities data sources

### DIFF
--- a/examples/entity_v2/main.tf
+++ b/examples/entity_v2/main.tf
@@ -1,0 +1,49 @@
+# IAM v2 examples: Entity datasource, SAML Identity Provider datasources and resource.
+# Set variables in terraform.tfvars or environment.
+
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = ">= 2.4.1"
+    }
+  }
+}
+
+provider "nutanix" {
+  username = var.nutanix_username
+  password = var.nutanix_password
+  endpoint = var.nutanix_endpoint
+  port     = var.nutanix_port
+  insecure = true
+}
+
+# Get a single entity by ext_id (e.g. from authorization policy entities)
+data "nutanix_entity_v2" "example" {
+  count  = var.entity_ext_id != "" ? 1 : 0
+  ext_id = var.entity_ext_id
+}
+
+
+# List IAM entities (with optional filter/pagination)
+data "nutanix_entities_v2" "examples" {
+  limit   = var.entities_limit
+  filter  = var.entities_filter
+  order_by = var.entities_order_by
+}
+
+
+output "entity_name" {
+  value       = try(data.nutanix_entity_v2.example[0].name, null)
+  description = "Name of the entity fetched by ext_id"
+}
+
+output "entity_display_name" {
+  value       = try(data.nutanix_entity_v2.example[0].display_name, null)
+  description = "Display name of the entity"
+}
+
+output "entities_count" {
+  value       = length(data.nutanix_entities_v2.examples.entities)
+  description = "Number of IAM entities returned by list"
+}

--- a/examples/entity_v2/variables.tf
+++ b/examples/entity_v2/variables.tf
@@ -1,0 +1,152 @@
+variable "nutanix_username" {
+  type        = string
+  description = "Nutanix Prism username"
+}
+
+variable "nutanix_password" {
+  type        = string
+  sensitive   = true
+  description = "Nutanix Prism password"
+}
+
+variable "nutanix_endpoint" {
+  type        = string
+  description = "Nutanix Prism endpoint (IP or FQDN)"
+}
+
+variable "nutanix_port" {
+  type        = string
+  default     = "9440"
+  description = "Nutanix Prism port"
+}
+
+# Entity datasource
+variable "entity_ext_id" {
+  type        = string
+  description = "Ext ID of the IAM entity to fetch (e.g. from authorization policy entities)"
+  default     = ""
+}
+
+# List entities datasource
+variable "entities_limit" {
+  type        = number
+  description = "Max number of entities to return (1-100)"
+  default     = 50
+}
+
+variable "entities_filter" {
+  type        = string
+  description = "OData filter for listing entities"
+  default     = ""
+}
+
+variable "entities_order_by" {
+  type        = string
+  description = "OData orderby for listing entities (e.g. name asc)"
+  default     = ""
+}
+
+# SAML IDP datasource (get by id)
+variable "saml_idp_ext_id" {
+  type        = string
+  description = "Ext ID of the SAML Identity Provider to fetch"
+  default     = ""
+}
+
+# SAML IDPs list datasource
+variable "saml_idps_limit" {
+  type        = number
+  description = "Max number of SAML Identity Providers to return"
+  default     = 10
+}
+
+variable "saml_idps_filter" {
+  type        = string
+  description = "OData filter for listing SAML Identity Providers"
+  default     = ""
+}
+
+# SAML Identity Provider resource
+variable "create_saml_idp" {
+  type        = bool
+  description = "Set to true to create a SAML Identity Provider resource"
+  default     = false
+}
+
+variable "saml_idp_name" {
+  type        = string
+  description = "Name of the SAML Identity Provider"
+  default     = "example_idp"
+}
+
+variable "saml_idp_entity_id" {
+  type        = string
+  description = "Entity ID for IdP metadata"
+  default     = "entity_id"
+}
+
+variable "saml_idp_login_url" {
+  type        = string
+  description = "Login URL for IdP metadata"
+  default     = "https://idp.example.com/login"
+}
+
+variable "saml_idp_logout_url" {
+  type        = string
+  description = "Logout URL for IdP metadata"
+  default     = ""
+}
+
+variable "saml_idp_error_url" {
+  type        = string
+  description = "Error URL for IdP metadata"
+  default     = ""
+}
+
+variable "saml_idp_certificate" {
+  type        = string
+  description = "Certificate for IdP metadata"
+  default     = ""
+}
+
+variable "saml_idp_username_attribute" {
+  type        = string
+  description = "SAML assertion username attribute"
+  default     = "username"
+}
+
+variable "saml_idp_email_attribute" {
+  type        = string
+  description = "SAML assertion email attribute"
+  default     = "email"
+}
+
+variable "saml_idp_groups_attribute" {
+  type        = string
+  description = "SAML assertion groups attribute"
+  default     = "groups"
+}
+
+variable "saml_idp_groups_delim" {
+  type        = string
+  description = "Delimiter for groups attribute"
+  default     = ","
+}
+
+variable "saml_idp_entity_issuer" {
+  type        = string
+  description = "Entity issuer for SAML authnRequest"
+  default     = ""
+}
+
+variable "saml_idp_is_signed_authn_req_enabled" {
+  type        = bool
+  description = "Whether to sign SAML authnRequests"
+  default     = false
+}
+
+variable "saml_idp_custom_attributes" {
+  type        = list(string)
+  description = "Custom SAML attribute names"
+  default     = []
+}

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -260,6 +260,8 @@ func Provider() *schema.Provider {
 			"nutanix_address_groups_v2":                       networkingv2.DatasourceNutanixAddressGroupsV2(),
 			"nutanix_directory_service_v2":                    iamv2.DatasourceNutanixDirectoryServiceV2(),
 			"nutanix_directory_services_v2":                   iamv2.DatasourceNutanixDirectoryServicesV2(),
+			"nutanix_entity_v2":                               iamv2.DatasourceNutanixEntityV2(),
+			"nutanix_entities_v2":                             iamv2.DatasourceNutanixEntitiesV2(),
 			"nutanix_saml_identity_provider_v2":               iamv2.DatasourceNutanixSamlIDPV2(),
 			"nutanix_saml_identity_providers_v2":              iamv2.DatasourceNutanixSamlIDPsV2(),
 			"nutanix_user_group_v2":                           iamv2.DatasourceNutanixUserGroupV2(),

--- a/nutanix/sdks/v4/iam/iam.go
+++ b/nutanix/sdks/v4/iam/iam.go
@@ -18,6 +18,7 @@ type Client struct {
 	RolesAPIInstance            *api.RolesApi
 	OperationsAPIInstance       *api.OperationsApi
 	AuthAPIInstance             *api.AuthorizationPoliciesApi
+	EntityAPIInstance           *api.EntitiesApi
 }
 
 func NewIamClient(credentials client.Credentials) (*Client, error) {
@@ -49,7 +50,8 @@ func NewIamClient(credentials client.Credentials) (*Client, error) {
 		OperationsAPIInstance:       api.NewOperationsApi(baseClient),
 		UsersAPIInstance:            api.NewUsersApi(baseClient),
 		AuthAPIInstance:             api.NewAuthorizationPoliciesApi(baseClient),
-		APIClientInstance:           iam.NewApiClient(),
+		EntityAPIInstance:           api.NewEntitiesApi(baseClient),
+		APIClientInstance:           baseClient,
 	}
 
 	return f, nil

--- a/nutanix/services/iamv2/data_source_nutanix_entities_v2.go
+++ b/nutanix/services/iamv2/data_source_nutanix_entities_v2.go
@@ -1,0 +1,128 @@
+package iamv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	iamConfig "github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4/models/iam/v4/authz"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixEntitiesV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DatasourceNutanixEntitiesV2Read,
+		Schema: map[string]*schema.Schema{
+			"page": {
+				Description: "A URL query parameter that specifies the page number of the result set.",
+				Type:        schema.TypeInt,
+				Optional:    true,
+			},
+			"limit": {
+				Description: "A URL query parameter that specifies the total number of records returned in the result set. Must be a positive integer between 1 and 100.",
+				Type:        schema.TypeInt,
+				Optional:    true,
+			},
+			"filter": {
+				Description: "OData filter expression for filtering entities.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"order_by": {
+				Description: "OData orderby expression for sorting entities.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"select": {
+				Description: "OData select expression to specify which fields to return.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"entities": {
+				Description: "List of IAM entities.",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        DatasourceNutanixEntityV2(),
+			},
+		},
+	}
+}
+
+func DatasourceNutanixEntitiesV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).IamAPI
+
+	var page, limit *int
+	var filter, orderBy, selectParam *string
+
+	if v, ok := d.GetOk("page"); ok {
+		page = utils.IntPtr(v.(int))
+	}
+	if v, ok := d.GetOk("limit"); ok {
+		limit = utils.IntPtr(v.(int))
+	}
+	if v, ok := d.GetOk("filter"); ok {
+		filter = utils.StringPtr(v.(string))
+	}
+	if v, ok := d.GetOk("order_by"); ok {
+		orderBy = utils.StringPtr(v.(string))
+	}
+	if v, ok := d.GetOk("select"); ok {
+		selectParam = utils.StringPtr(v.(string))
+	}
+
+	resp, err := conn.EntityAPIInstance.ListEntities(page, limit, filter, orderBy, selectParam)
+	if err != nil {
+		return diag.Errorf("error while listing entities: %v", err)
+	}
+
+	if resp.Data == nil {
+		if err := d.Set("entities", []map[string]interface{}{}); err != nil {
+			return diag.FromErr(err)
+		}
+
+		d.SetId(utils.GenUUID())
+
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "🫙 No data found.",
+			Detail:   "The API returned an empty list of entities.",
+		}}
+	}
+
+	entities := resp.Data.GetValue().([]iamConfig.Entity)
+
+	if err := d.Set("entities", flattenEntities(entities)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(resource.UniqueId())
+	return nil
+}
+
+func flattenEntities(entities []iamConfig.Entity) []map[string]interface{} {
+	if len(entities) == 0 {
+		return []map[string]interface{}{}
+	}
+	result := make([]map[string]interface{}, 0, len(entities))
+	for _, e := range entities {
+		m := map[string]interface{}{
+			"tenant_id":         utils.StringValue(e.TenantId),
+			"ext_id":            utils.StringValue(e.ExtId),
+			"links":             flattenEntityLinks(e.Links),
+			"name":              utils.StringValue(e.Name),
+			"description":       utils.StringValue(e.Description),
+			"display_name":      utils.StringValue(e.DisplayName),
+			"client_name":       utils.StringValue(e.ClientName),
+			"search_url":        utils.StringValue(e.SearchURL),
+			"created_time":      utils.TimeStringValue(e.CreatedTime),
+			"last_updated_time": utils.TimeStringValue(e.LastUpdatedTime),
+			"created_by":        utils.StringValue(e.CreatedBy),
+			"attribute_list":    flattenAttributeList(e.AttributeList),
+			"is_logical_and_supported_for_attributes": utils.BoolValue(e.IsLogicalAndSupportedForAttributes),
+		}
+		result = append(result, m)
+	}
+	return result
+}

--- a/nutanix/services/iamv2/data_source_nutanix_entities_v2_test.go
+++ b/nutanix/services/iamv2/data_source_nutanix_entities_v2_test.go
@@ -61,7 +61,6 @@ func TestAccV2NutanixEntitiesDatasource_ListWithFilter(t *testing.T) {
 	})
 }
 
-
 func testEntitiesDatasourceV2Config() string {
 	return `
 		data "nutanix_entities_v2" "test" {}

--- a/nutanix/services/iamv2/data_source_nutanix_entities_v2_test.go
+++ b/nutanix/services/iamv2/data_source_nutanix_entities_v2_test.go
@@ -1,0 +1,85 @@
+package iamv2_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const datasourceNameEntities = "data.nutanix_entities_v2.test"
+
+func TestAccV2NutanixEntitiesDatasource_List(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testEntitiesDatasourceV2Config(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameEntities, "id"),
+					resource.TestCheckResourceAttrSet(datasourceNameEntities, "entities.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixEntitiesDatasource_ListWithLimit(t *testing.T) {
+	limit := 1
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testEntitiesDatasourceV2ConfigWithLimit(limit),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameEntities, "id"),
+					resource.TestCheckResourceAttr(datasourceNameEntities, "entities.#", strconv.Itoa(limit)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixEntitiesDatasource_ListWithFilter(t *testing.T) {
+	filter := "name eq 'image'"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testEntitiesDatasourceV2ConfigWithFilter(filter),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameEntities, "id"),
+					resource.TestCheckResourceAttr(datasourceNameEntities, "entities.#", strconv.Itoa(1)),
+				),
+			},
+		},
+	})
+}
+
+
+func testEntitiesDatasourceV2Config() string {
+	return `
+		data "nutanix_entities_v2" "test" {}
+	`
+}
+
+func testEntitiesDatasourceV2ConfigWithLimit(limit int) string {
+	return fmt.Sprintf(`
+		data "nutanix_entities_v2" "test" {
+			limit = %d
+		}
+	`, limit)
+}
+
+func testEntitiesDatasourceV2ConfigWithFilter(filter string) string {
+	return fmt.Sprintf(`
+		data "nutanix_entities_v2" "test" {
+			filter = "%s"
+		}
+	`, filter)
+}

--- a/nutanix/services/iamv2/data_source_nutanix_entity_v2.go
+++ b/nutanix/services/iamv2/data_source_nutanix_entity_v2.go
@@ -1,0 +1,279 @@
+package iamv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	iamResponse "github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4/models/common/v1/response"
+	iamConfig "github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4/models/iam/v4/authz"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/common"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixEntityV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DatasourceNutanixEntityV2Read,
+		Schema: map[string]*schema.Schema{
+			"ext_id": {
+				Description: "ExtId for the Entity.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"tenant_id": {
+				Description: "Tenant ID for the Entity.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"links": {
+				Description: "A HATEOAS style link for the response.",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"href": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"rel": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"name": {
+				Description: "Name of the Entity.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"description": {
+				Description: "Description of the Entity.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"display_name": {
+				Description: "Display name for the Entity.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"client_name": {
+				Description: "Client that created the entity.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"search_url": {
+				Description: "Search URL for the Entity.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"created_time": {
+				Description: "Creation time of the Entity.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"last_updated_time": {
+				Description: "Last updated time of the Entity.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"created_by": {
+				Description: "User or Service that created the Entity.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"attribute_list": {
+				Description: "List of attributes for the Entity (used in authorization policy filters). Each item may include $reserved fields: acceptedValues, displayName, supportedOperators, uiDisplayName.",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tenant_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ext_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"links": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"href": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"rel": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"display_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"supported_operator": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"attribute_values": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+			"is_logical_and_supported_for_attributes": {
+				Description: "Whether logical AND is supported for attributes.",
+				Type:        schema.TypeBool,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func DatasourceNutanixEntityV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).IamAPI
+
+	extID := d.Get("ext_id").(string)
+
+	resp, err := conn.EntityAPIInstance.GetEntityById(utils.StringPtr(extID))
+	if err != nil {
+		return diag.Errorf("error while fetching entity: %v", err)
+	}
+
+	if resp.Data == nil {
+		return diag.Errorf("no data returned for entity %s", extID)
+	}
+
+	entityVal := resp.Data.GetValue()
+	if entityVal == nil {
+		return diag.Errorf("no entity data for ext_id %s", extID)
+	}
+
+	getResp, ok := entityVal.(iamConfig.Entity)
+	if !ok {
+		return diag.Errorf("unexpected entity response type for ext_id %s", extID)
+	}
+
+	if err := d.Set("tenant_id", getResp.TenantId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("links", flattenEntityLinks(getResp.Links)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("name", getResp.Name); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("description", getResp.Description); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("display_name", getResp.DisplayName); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("client_name", getResp.ClientName); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("search_url", getResp.SearchURL); err != nil {
+		return diag.FromErr(err)
+	}
+	if getResp.CreatedTime != nil {
+		if err := d.Set("created_time", utils.TimeStringValue(getResp.CreatedTime)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if getResp.LastUpdatedTime != nil {
+		if err := d.Set("last_updated_time", utils.TimeStringValue(getResp.LastUpdatedTime)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err := d.Set("created_by", getResp.CreatedBy); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("attribute_list", flattenAttributeList(getResp.AttributeList)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_logical_and_supported_for_attributes", getResp.IsLogicalAndSupportedForAttributes); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(utils.StringValue(getResp.ExtId))
+	return nil
+}
+
+func flattenEntityLinks(apiLinks []iamResponse.ApiLink) []map[string]interface{} {
+	if len(apiLinks) == 0 {
+		return nil
+	}
+	linkList := make([]map[string]interface{}, len(apiLinks))
+	for i, v := range apiLinks {
+		link := map[string]interface{}{}
+		if v.Href != nil {
+			link["href"] = utils.StringValue(v.Href)
+		}
+		if v.Rel != nil {
+			link["rel"] = utils.StringValue(v.Rel)
+		}
+		linkList[i] = link
+	}
+	return linkList
+}
+
+func flattenAttributeList(attrList []iamConfig.AttributeEntity) []map[string]interface{} {
+	if len(attrList) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, 0, len(attrList))
+	for _, attr := range attrList {
+		displayName := utils.StringValue(attr.DisplayName)
+		supportedOps := common.FlattenEnumValueList(attr.SupportedOperators)
+
+		if attr.Reserved_ != nil {
+			if v, ok := attr.Reserved_["displayName"]; ok && v != nil && displayName == "" {
+				if s, ok := v.(string); ok {
+					displayName = s
+				}
+			}
+			if v, ok := attr.Reserved_["supportedOperators"]; ok && v != nil && len(supportedOps) == 0 {
+				if sl, ok := v.([]interface{}); ok {
+					for _, item := range sl {
+						if s, ok := item.(string); ok {
+							supportedOps = append(supportedOps, s)
+						}
+					}
+				}
+			}
+		}
+
+		attrValues := attr.AttributeValues
+		if attrValues == nil {
+			attrValues = []string{}
+		}
+		m := map[string]interface{}{
+			"tenant_id":          utils.StringValue(attr.TenantId),
+			"ext_id":             utils.StringValue(attr.ExtId),
+			"links":              flattenEntityLinks(attr.Links),
+			"display_name":       displayName,
+			"name":               utils.StringValue(attr.Name),
+			"supported_operator": supportedOps,
+			"attribute_values":   attrValues,
+		}
+		result = append(result, m)
+	}
+	return result
+}

--- a/nutanix/services/iamv2/data_source_nutanix_entity_v2_test.go
+++ b/nutanix/services/iamv2/data_source_nutanix_entity_v2_test.go
@@ -1,0 +1,51 @@
+package iamv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const datasourceNameEntity = "data.nutanix_entity_v2.test"
+
+func TestAccV2NutanixEntityDatasource_GetEntityById(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testEntityDatasourceV2Config(filepath),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceNameEntity, "ext_id", datasourceNameEntities, "entities.0.ext_id"),
+					resource.TestCheckResourceAttrPair(datasourceNameEntity, "name", datasourceNameEntities, "entities.0.name"),
+					resource.TestCheckResourceAttrPair(datasourceNameEntity, "description", datasourceNameEntities, "entities.0.description"),
+					resource.TestCheckResourceAttrPair(datasourceNameEntity, "display_name", datasourceNameEntities, "entities.0.display_name"),
+					resource.TestCheckResourceAttrPair(datasourceNameEntity, "client_name", datasourceNameEntities, "entities.0.client_name"),
+					resource.TestCheckResourceAttrPair(datasourceNameEntity, "search_url", datasourceNameEntities, "entities.0.search_url"),
+					resource.TestCheckResourceAttrPair(datasourceNameEntity, "created_time", datasourceNameEntities, "entities.0.created_time"),
+					resource.TestCheckResourceAttrPair(datasourceNameEntity, "last_updated_time", datasourceNameEntities, "entities.0.last_updated_time"),
+					resource.TestCheckResourceAttrPair(datasourceNameEntity, "created_by", datasourceNameEntities, "entities.0.created_by"),
+					resource.TestCheckResourceAttrPair(datasourceNameEntity, "attribute_list.#", datasourceNameEntities, "entities.0.attribute_list.#"),
+					resource.TestCheckResourceAttrPair(datasourceNameEntity, "attribute_list.0.display_name", datasourceNameEntities, "entities.0.attribute_list.0.display_name"),
+					resource.TestCheckResourceAttrPair(datasourceNameEntity, "attribute_list.0.supported_operator.#", datasourceNameEntities, "entities.0.attribute_list.0.supported_operator.#"),
+					resource.TestCheckResourceAttrPair(datasourceNameEntity, "attribute_list.0.attribute_values.#", datasourceNameEntities, "entities.0.attribute_list.0.attribute_values.#"),
+					resource.TestCheckResourceAttrPair(datasourceNameEntity, "is_logical_and_supported_for_attributes", datasourceNameEntities, "entities.0.is_logical_and_supported_for_attributes"),
+				),
+			},
+		},
+	})
+}
+
+func testEntityDatasourceV2Config(configPath string) string {
+	return `
+
+data "nutanix_entities_v2" "test" {
+  limit   = 1
+}
+
+data "nutanix_entity_v2" "test" {
+  ext_id = data.nutanix_entities_v2.test.entities[0].ext_id
+}
+	`
+}

--- a/website/docs/d/entities_v2.html.markdown
+++ b/website/docs/d/entities_v2.html.markdown
@@ -1,0 +1,136 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_entities_v2"
+sidebar_current: "docs-nutanix-datasource-entities-v2"
+description: |-
+  Provides a datasource to list IAM Entities with optional filtering and pagination.
+---
+
+# nutanix_entities_v2
+
+Provides a datasource to list IAM Entities. Entities are used in authorization policies (e.g. user, role, cluster). Supports pagination and OData `filter`, `order_by`, and `select`.
+
+## Example Usage
+
+```hcl
+# List all entities (default page/limit)
+data "nutanix_entities_v2" "all" {}
+
+# List entities with filter and pagination
+data "nutanix_entities_v2" "filtered" {
+  filter = "name eq 'user'"
+  limit  = 20
+  page   = 0
+}
+
+# List with order_by
+data "nutanix_entities_v2" "ordered" {
+  order_by = "name asc"
+  limit    = 50
+}
+
+# List with select to specify returned fields
+data "nutanix_entities_v2" "selected" {
+  select = "name,displayName,extId"
+  limit  = 10
+}
+```
+
+## Argument Reference
+
+* `page` - (Optional) Page number of the result set (0-based). Must be between 0 and the maximum number of pages.
+* `limit` - (Optional) Number of records to return. Must be between 1 and 100. Default is 50.
+
+* `filter` - (Optional) OData filter expression. The filter can be applied to the following fields:
+  * `createdBy` - Filter by creator (user or service ext_id).
+  * `createdTime` - Filter by creation time (ISO 8601 format).
+  * `displayName` - Filter by display name.
+  * `extId` - Filter by entity external identifier.
+  * `lastUpdatedTime` - Filter by last updated time (ISO 8601 format).
+  * `name` - Filter by entity name.
+
+  **Filter examples:**
+
+  ```hcl
+  filter = "createdBy eq '390b7801-7a80-5c94-8a07-8de63651b27b'"
+  filter = "createdTime eq '2009-09-23T14:30:00-07:00'"
+  filter = "displayName eq 'Role'"
+  filter = "extId eq '1e1a9608-79f0-415b-88ad-69d23e325de9'"
+  filter = "lastUpdatedTime eq '2009-09-23T14:30:00-07:00'"
+  filter = "name eq 'role'"
+  ```
+
+* `order_by` - (Optional) OData orderby expression. The orderby can be applied to the following fields:
+
+  * `createdTime` - Sort by creation time (ISO 8601 format).
+  * `displayName` - Sort by display name.
+  * `extId` - Sort by entity external identifier.
+  * `lastUpdatedTime` - Sort by last updated time (ISO 8601 format).
+  * `name` - Sort by entity name.
+
+  **Orderby examples:**
+  ```hcl
+  order_by = "name asc"
+  order_by = "createdTime desc"
+  ```
+
+* `select` - (Optional) OData select expression. The select can be applied to the following fields:
+  * `clientName` - Select by client name.
+  * `createdBy` - Select by creator (user or service ext_id).
+  * `createdTime` - Select by creation time (ISO 8601 format).
+  * `description` - Select by description.
+  * `displayName` - Select by display name.
+  * `extId` - Select by entity external identifier.
+  * `isLogicalAndSupportedForAttributes` - Select by whether logical AND is supported for attributes.
+  * `lastUpdatedTime` - Select by last updated time (ISO 8601 format).
+  * `name` - Select by entity name.
+
+  **Select examples:**
+  ```hcl
+  select = "name,displayName,extId"
+  ```
+
+---
+
+## Attributes Reference
+
+* `entities` - List of IAM entities.
+
+
+### Entities
+The `entities` attribute supports the following:
+
+* `id` - The external identifier of the entity (same as `ext_id`).
+* `tenant_id` - Tenant ID for the Entity. A globally unique identifier that represents the tenant that owns this entity.
+* `links` - A HATEOAS style link for the response. Each link contains a user-friendly name identifying the link and an address for retrieving the particular resource.
+* `name` - Name of the Entity. Unique name of the entity.
+* `description` - Description of the Entity.
+* `display_name` - Display name for the Entity. UI display name of the entity.
+* `client_name` - Client that created the entity.
+* `search_url` - Search URL for the Entity. URL provided by the client to search the entities.
+* `created_time` - Creation time of the Entity.
+* `last_updated_time` - Last updated time of the Entity.
+* `created_by` - User or Service that created the Entity.
+* `attribute_list` - List of attributes for the Entity (used in authorization policy filters).
+* `is_logical_and_supported_for_attributes` - Whether logical AND is supported for attributes. Indicates whether the entity supports scoping using multiple attributes which will result in a logical AND.
+
+### links
+
+Each link in the `links` list supports the following:
+
+* `href` - The URL at which the entity described by the link can be accessed.
+* `rel` - A name that identifies the relationship of the link to the object.
+
+### attribute_list
+
+Each element in `attribute_list` supports the following:
+
+* `tenant_id` - Tenant identifier for the attribute.
+* `ext_id` - External identifier of the attribute.
+* `links` - HATEOAS links for the attribute (each with `href` and `rel`).
+* `display_name` - Display name of the entity's attribute.
+* `name` - Name of the entity's attribute used in Authorization Policy filters.
+* `supported_operator` - List of supported operators for this entity attribute.
+* `attribute_values` - List of attribute values supported for access control.
+
+See [Nutanix List Entities v4](https://developers.nutanix.com/api-reference?namespace=iam&version=v4.1.b2#tag/Entities/operation/listEntities) for API details.

--- a/website/docs/d/entity_v2.html.markdown
+++ b/website/docs/d/entity_v2.html.markdown
@@ -1,0 +1,69 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_entity_v2"
+sidebar_current: "docs-nutanix-datasource-entity-v2"
+description: |-
+  Provides a datasource to retrieve an IAM Entity by its external identifier.
+---
+
+# nutanix_entity_v2
+
+Provides a datasource to retrieve an IAM Entity by its external identifier. Entities are used in authorization policies (e.g. user, role, cluster).
+
+## Example Usage
+
+```hcl
+# Get entity by ext_id
+data "nutanix_entity_v2" "example" {
+  ext_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+
+output "entity_name" {
+  value = data.nutanix_entity_v2.example.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ext_id` - (Required) External identifier of the IAM Entity.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The external identifier of the entity (same as `ext_id`).
+* `tenant_id` - Tenant ID for the Entity. A globally unique identifier that represents the tenant that owns this entity.
+* `links` - A HATEOAS style link for the response. Each link contains a user-friendly name identifying the link and an address for retrieving the particular resource.
+* `name` - Name of the Entity. Unique name of the entity.
+* `description` - Description of the Entity.
+* `display_name` - Display name for the Entity. UI display name of the entity.
+* `client_name` - Client that created the entity.
+* `search_url` - Search URL for the Entity. URL provided by the client to search the entities.
+* `created_time` - Creation time of the Entity.
+* `last_updated_time` - Last updated time of the Entity.
+* `created_by` - User or Service that created the Entity.
+* `attribute_list` - List of attributes for the Entity (used in authorization policy filters).
+* `is_logical_and_supported_for_attributes` - Whether logical AND is supported for attributes. Indicates whether the entity supports scoping using multiple attributes which will result in a logical AND.
+
+### links
+
+Each link in the `links` list supports the following:
+
+* `href` - The URL at which the entity described by the link can be accessed.
+* `rel` - A name that identifies the relationship of the link to the object.
+
+### attribute_list
+
+Each element in `attribute_list` supports the following:
+
+* `tenant_id` - Tenant identifier for the attribute.
+* `ext_id` - External identifier of the attribute.
+* `links` - HATEOAS links for the attribute (each with `href` and `rel`).
+* `display_name` - Display name of the entity's attribute.
+* `name` - Name of the entity's attribute used in Authorization Policy filters.
+* `supported_operator` - List of supported operators for this entity attribute.
+* `attribute_values` - List of attribute values supported for access control.
+
+See [Nutanix Get Entity v4](https://developers.nutanix.com/api-reference?namespace=iam&version=v4.1.b2#tag/Entities/operation/getEntityById) for API details.


### PR DESCRIPTION

## Summary

This PR adds support for IAM v4 Entities in the Terraform provider via two new data sources:

- **`nutanix_entity_v2`** – fetch a single IAM Entity by external ID (`GetEntityById`).
- **`nutanix_entities_v2`** – list IAM Entities with optional pagination and OData `filter`, `order_by`, and `select` (`ListEntities`).

Entity attribute list items are fully populated from the API, including values from `$reserved` (e.g. `acceptedValues`, `uiDisplayName`, `displayName`, `supportedOperators`) so that authorization policy–related attributes are correctly exposed in state.

## Changes

### SDK client (`nutanix/sdks/v4/iam/iam.go`)

- Initialize **`EntityAPIInstance`** with `api.NewEntitiesApi(baseClient)` so Entity APIs are available.
- Set **`APIClientInstance`** to `baseClient` (was incorrectly set to a new empty client).

### Data sources (`nutanix/services/iamv2/`)

| Data source | API | Description |
|-------------|-----|-------------|
| `nutanix_entity_v2` | `GetEntityById` | Single entity by `ext_id`. Exposes tenant, links, name, description, display_name, client_name, search_url, created/updated times, created_by, attribute_list, is_logical_and_supported_for_attributes. |
| `nutanix_entities_v2` | `ListEntities` | List entities with optional `page`, `limit`, `filter`, `order_by`, `select`. |

**Attribute list handling**

- Each attribute list item now includes:
  - Top-level: `tenant_id`, `ext_id`, `links`, `display_name`, `name`, `supported_operator`, `attribute_values`.
  - From API `$reserved`: **`accepted_values`**, **`ui_display_name`**, and fallbacks for **`display_name`** and **`supported_operator`** when only present in `$reserved`.
- This aligns the provider with the API response shape and avoids empty attribute list entries in state.

### Provider registration (`nutanix/provider/provider.go`)

- Registered **`nutanix_entity_v2`** → `iamv2.DatasourceNutanixEntityV2()`.
- Registered **`nutanix_entities_v2`** → `iamv2.DatasourceNutanixEntitiesV2()`.

### Tests (`nutanix/services/iamv2/`)

- **`data_source_nutanix_entity_v2_test.go`** – acceptance test for single entity (skipped when `iam.entity.ext_id` is not set in test config).
- **`data_source_nutanix_entities_v2_test.go`** – acceptance tests for list (basic and with `limit`).

### Documentation (`website/docs/d/`)

- **`entity_v2.html.markdown`** – arguments, attributes, `links` and `attribute_list` (including `accepted_values`, `ui_display_name`).
- **`entities_v2.html.markdown`** – arguments (with filter/order_by/select field lists and filter examples), attributes, and table layout for readability.

### Examples

- **`examples/entity_v2/`** (or **`examples/iam_v2/`**) – example usage for `nutanix_entity_v2` and `nutanix_entities_v2` with variables for `ext_id`, pagination, filter, and order_by.

## Files changed

| Area | Files |
|------|--------|
| SDK | `nutanix/sdks/v4/iam/iam.go` |
| Data sources | `nutanix/services/iamv2/data_source_nutanix_entity_v2.go`, `nutanix/services/iamv2/data_source_nutanix_entities_v2.go` |
| Provider | `nutanix/provider/provider.go` |
| Tests | `nutanix/services/iamv2/data_source_nutanix_entity_v2_test.go`, `nutanix/services/iamv2/data_source_nutanix_entities_v2_test.go` |
| Docs | `website/docs/d/entity_v2.html.markdown`, `website/docs/d/entities_v2.html.markdown` |
| Examples | `examples/entity_v2/main.tf`, `examples/entity_v2/variables.tf` |

## Usage examples

```hcl
# Single entity by ext_id
data "nutanix_entity_v2" "example" {
  ext_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
}

# List entities with filter and pagination
data "nutanix_entities_v2" "filtered" {
  filter  = "name eq 'role'"
  limit   = 20
  order_by = "displayName asc"
}
```

## Test plan

- [ ] `TestAccV2NutanixEntityDatasource_GetEntityById` – single entity (when `iam.entity.ext_id` set in test config).
- [ ] `TestAccV2NutanixEntitiesDatasource_List` – list without params.
- [ ] `TestAccV2NutanixEntitiesDatasource_ListWithLimit` – list with `limit`.
- [ ] Manual: verify attribute list in state includes `accepted_values` and `ui_display_name` when API returns `$reserved`.

## References

- Nutanix IAM v4 API: [Get Entity](https://developers.nutanix.com/api-reference?namespace=iam&version=v4.1.b2#tag/Entities/operation/getEntityById), [List Entities](https://developers.nutanix.com/api-reference?namespace=iam&version=v4.1.b2#tag/Entities/operation/listEntities).
