### PR TITLE
add poweron Power off retries

### DIFF
--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -1392,30 +1392,19 @@ func ResourceNutanixVirtualMachineV2Create(ctx context.Context, d *schema.Resour
 	}
 	d.SetId(utils.StringValue(uuid))
 
-	// read VM
-
-	readResp, errR := conn.VMAPIInstance.GetVmById(utils.StringPtr(*uuid))
-	if errR != nil {
-		return diag.Errorf("error while reading vm : %v", errR)
-	}
-	args := make(map[string]interface{})
-	args["If-Match"] = getEtagHeader(readResp, conn)
-
 	var PowerTaskRef import1.TaskReference
 	if powerState, ok := d.GetOk("power_state"); ok {
-		if powerState == "ON" {
-			resp, err := conn.VMAPIInstance.PowerOnVm(uuid, args)
-			if err != nil {
-				return diag.Errorf("error while powering on Virtual Machines : %v", err)
-			}
-			PowerTaskRef = resp.Data.GetValue().(import1.TaskReference)
-		} else if powerState == "OFF" {
-			resp, err := conn.VMAPIInstance.PowerOffVm(utils.StringPtr(d.Id()), args)
-			if err != nil {
-				return diag.Errorf("error while powering OFF : %v", err)
-			}
-			PowerTaskRef = resp.Data.GetValue().(import1.TaskReference)
-		}
+		switch powerState {
+    case "ON":
+      PowerTaskRef, err = powerOnVMWithRetry(ctx, conn, uuid)
+    case "OFF":
+      PowerTaskRef, err = powerOffVMWithRetry(ctx, conn, utils.StringPtr(d.Id()))
+    default:
+      return diag.Errorf("invalid power state: %s", powerState)
+    }
+    if err != nil {
+      return diag.Errorf("error while powering %s Virtual Machines: %v", powerState, err)
+    }
 	}
 	powertaskUUID := PowerTaskRef.ExtId
 
@@ -3175,6 +3164,138 @@ func expandPolicyReference(pr interface{}) *config.PolicyReference {
 	return nil
 }
 
+// extractTaskReferenceFromResponse extracts TaskReference from API response using reflection
+func extractTaskReferenceFromResponse(resp interface{}) (import1.TaskReference, error) {
+	respValue := reflect.ValueOf(resp)
+	if respValue.Kind() == reflect.Ptr {
+		respValue = respValue.Elem()
+	}
+	dataField := respValue.FieldByName("Data")
+	if !dataField.IsValid() {
+		return import1.TaskReference{}, fmt.Errorf("unexpected response structure: Data field not found")
+	}
+	getValueMethod := dataField.MethodByName("GetValue")
+	if !getValueMethod.IsValid() {
+		return import1.TaskReference{}, fmt.Errorf("unexpected response structure: GetValue method not found")
+	}
+	result := getValueMethod.Call(nil)[0].Interface()
+	taskRef, ok := result.(import1.TaskReference)
+	if !ok {
+		return import1.TaskReference{}, fmt.Errorf("unexpected response type: expected TaskReference")
+	}
+	return taskRef, nil
+}
+
+// powerOnVMWithRetry attempts to power on a VM with retry logic
+// It fetches the VM and ETag header for each retry attempt to ensure we have the latest ETag
+func powerOnVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (import1.TaskReference, error) {
+	maxRetries := 5
+	retryDelay := 2500 * time.Millisecond // 2.5 seconds
+	var resp interface{}
+	var err error
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		// Fetch VM to get latest ETag for each retry attempt
+		readResp, errR := conn.VMAPIInstance.GetVmById(vmID)
+		if errR != nil {
+			if attempt < maxRetries-1 {
+				log.Printf("[DEBUG] Attempt %d/%d failed to fetch VM for power on, retrying in %v: %v", attempt+1, maxRetries, retryDelay, errR)
+				select {
+				case <-ctx.Done():
+					return import1.TaskReference{}, fmt.Errorf("context cancelled while fetching VM for power on: %v", ctx.Err())
+				case <-time.After(retryDelay):
+					continue
+				}
+			}
+			return import1.TaskReference{}, fmt.Errorf("error while fetching VM for power on after %d attempts: %v", maxRetries, errR)
+		}
+
+		// Build args with fresh ETag for this attempt
+		args := make(map[string]interface{})
+		args["If-Match"] = getEtagHeader(readResp, conn)
+
+		resp, err = conn.VMAPIInstance.PowerOnVm(vmID, args)
+		if err == nil {
+			break
+		}
+
+		if attempt < maxRetries-1 {
+			log.Printf("[DEBUG] Attempt %d/%d failed to power on VM, retrying in %v: %v", attempt+1, maxRetries, retryDelay, err)
+			select {
+			case <-ctx.Done():
+				return import1.TaskReference{}, fmt.Errorf("context cancelled while powering on VM: %v", ctx.Err())
+			case <-time.After(retryDelay):
+				// Continue to next retry
+			}
+		}
+	}
+
+	if err != nil {
+		return import1.TaskReference{}, fmt.Errorf("error while powering on Virtual Machine after %d attempts: %v", maxRetries, err)
+	}
+
+	taskRef, err := extractTaskReferenceFromResponse(resp)
+	if err != nil {
+		return import1.TaskReference{}, fmt.Errorf("error extracting task reference from power on response: %v", err)
+	}
+	return taskRef, nil
+}
+
+// powerOffVMWithRetry attempts to power off a VM with retry logic
+// It fetches the VM and ETag header for each retry attempt to ensure we have the latest ETag
+func powerOffVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (import1.TaskReference, error) {
+	maxRetries := 5
+	retryDelay := 2500 * time.Millisecond // 2.5 seconds
+	var resp interface{}
+	var err error
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		// Fetch VM to get latest ETag for each retry attempt
+		readResp, errR := conn.VMAPIInstance.GetVmById(vmID)
+		if errR != nil {
+			if attempt < maxRetries-1 {
+				log.Printf("[DEBUG] Attempt %d/%d failed to fetch VM for power off, retrying in %v: %v", attempt+1, maxRetries, retryDelay, errR)
+				select {
+				case <-ctx.Done():
+					return import1.TaskReference{}, fmt.Errorf("context cancelled while fetching VM for power off: %v", ctx.Err())
+				case <-time.After(retryDelay):
+					continue
+				}
+			}
+			return import1.TaskReference{}, fmt.Errorf("error while fetching VM for power off after %d attempts: %v", maxRetries, errR)
+		}
+
+		// Build args with fresh ETag for this attempt
+		args := make(map[string]interface{})
+		args["If-Match"] = getEtagHeader(readResp, conn)
+
+		resp, err = conn.VMAPIInstance.PowerOffVm(vmID, args)
+		if err == nil {
+			break
+		}
+
+		if attempt < maxRetries-1 {
+			log.Printf("[DEBUG] Attempt %d/%d failed to power off VM, retrying in %v: %v", attempt+1, maxRetries, retryDelay, err)
+			select {
+			case <-ctx.Done():
+				return import1.TaskReference{}, fmt.Errorf("context cancelled while powering off VM: %v", ctx.Err())
+			case <-time.After(retryDelay):
+				// Continue to next retry
+			}
+		}
+	}
+
+	if err != nil {
+		return import1.TaskReference{}, fmt.Errorf("error while powering off Virtual Machine after %d attempts: %v", maxRetries, err)
+	}
+
+	taskRef, err := extractTaskReferenceFromResponse(resp)
+	if err != nil {
+		return import1.TaskReference{}, fmt.Errorf("error extracting task reference from power off response: %v", err)
+	}
+	return taskRef, nil
+}
+
 func flattenPowerState(pr *config.PowerState) string {
 	if pr != nil {
 		const two, three, four, five = 2, 3, 4, 5
@@ -3207,17 +3328,11 @@ func callForPowerOffVM(ctx context.Context, conn *vmm.Client, d *schema.Resource
 		return nil
 	}
 
-	// Extract E-Tag Header
-	args := make(map[string]interface{})
-	args["If-Match"] = getEtagHeader(readResp, conn)
-
-	// Power off the VM
-	powerOffResp, err := conn.VMAPIInstance.PowerOffVm(utils.StringPtr(d.Id()), args)
+	// Power off the VM with retry logic (ETag is fetched inside the retry function)
+	TaskRef, err := powerOffVMWithRetry(ctx, conn, utils.StringPtr(d.Id()))
 	if err != nil {
-		return diag.Errorf("error while powering off Virtual Machine : %v", err)
+		return diag.Errorf("error while powering off Virtual Machine: %v", err)
 	}
-
-	TaskRef := powerOffResp.Data.GetValue().(import1.TaskReference)
 	taskUUID := TaskRef.ExtId
 
 	prismConn := meta.(*conns.Client).PrismAPI
@@ -3249,19 +3364,13 @@ func callForPowerOnVM(ctx context.Context, conn *vmm.Client, d *schema.ResourceD
 		return nil
 	}
 
-	// Extract E-Tag Header
-	args := make(map[string]interface{})
-	args["If-Match"] = getEtagHeader(readResp, conn)
-	// Power on the VM
-	powerOnResp, err := conn.VMAPIInstance.PowerOnVm(utils.StringPtr(d.Id()), args)
+	// Power on the VM with retry logic (ETag is fetched inside the retry function)
+	TaskRef, err := powerOnVMWithRetry(ctx, conn, utils.StringPtr(d.Id()))
 	if err != nil {
-		return diag.Errorf("error while powering on Virtual Machine : %v", err)
+		return diag.Errorf("error while powering on Virtual Machine: %v", err)
 	}
 
-	aJSON, _ := json.Marshal(powerOnResp)
-	log.Printf("[DEBUG] PowerOn Response: %s", string(aJSON))
-
-	TaskRef := powerOnResp.Data.GetValue().(import1.TaskReference)
+	log.Printf("[DEBUG] PowerOn Response: TaskReference ExtId: %s", utils.StringValue(TaskRef.ExtId))
 	taskUUID := TaskRef.ExtId
 
 	prismConn := meta.(*conns.Client).PrismAPI

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -3204,6 +3204,7 @@ func powerOnVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (im
 				case <-ctx.Done():
 					return import1.TaskReference{}, fmt.Errorf("context cancelled while fetching VM for power on: %v", ctx.Err())
 				case <-time.After(retryDelay):
+					log.Printf("[DEBUG] Attempt %d/%d failed to fetch VM for power on, retrying in %v: %v", attempt+1, maxRetries, retryDelay, errR)
 					continue
 				}
 			}
@@ -3226,6 +3227,7 @@ func powerOnVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (im
 				return import1.TaskReference{}, fmt.Errorf("context cancelled while powering on VM: %v", ctx.Err())
 			case <-time.After(retryDelay):
 				// Continue to next retry
+				log.Printf("[DEBUG] Attempt %d/%d failed to power on VM, retrying in %v: %v", attempt+1, maxRetries, retryDelay, err)
 			}
 		}
 	}
@@ -3238,6 +3240,7 @@ func powerOnVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (im
 	if err != nil {
 		return import1.TaskReference{}, fmt.Errorf("error extracting task reference from power on response: %v", err)
 	}
+	log.Printf("[DEBUG] PowerOn Response: TaskReference ExtId: %s", utils.StringValue(taskRef.ExtId))
 	return taskRef, nil
 }
 
@@ -3259,6 +3262,7 @@ func powerOffVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (i
 				case <-ctx.Done():
 					return import1.TaskReference{}, fmt.Errorf("context cancelled while fetching VM for power off: %v", ctx.Err())
 				case <-time.After(retryDelay):
+					log.Printf("[DEBUG] Attempt %d/%d failed to fetch VM for power off, retrying in %v: %v", attempt+1, maxRetries, retryDelay, errR)
 					continue
 				}
 			}
@@ -3281,6 +3285,7 @@ func powerOffVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (i
 				return import1.TaskReference{}, fmt.Errorf("context cancelled while powering off VM: %v", ctx.Err())
 			case <-time.After(retryDelay):
 				// Continue to next retry
+				log.Printf("[DEBUG] Attempt %d/%d failed to power off VM, retrying in %v: %v", attempt+1, maxRetries, retryDelay, err)
 			}
 		}
 	}
@@ -3288,11 +3293,11 @@ func powerOffVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (i
 	if err != nil {
 		return import1.TaskReference{}, fmt.Errorf("error while powering off Virtual Machine after %d attempts: %v", maxRetries, err)
 	}
-
 	taskRef, err := extractTaskReferenceFromResponse(resp)
 	if err != nil {
 		return import1.TaskReference{}, fmt.Errorf("error extracting task reference from power off response: %v", err)
 	}
+	log.Printf("[DEBUG] PowerOff Response: TaskReference ExtId: %s", utils.StringValue(taskRef.ExtId))
 	return taskRef, nil
 }
 

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -1395,16 +1395,16 @@ func ResourceNutanixVirtualMachineV2Create(ctx context.Context, d *schema.Resour
 	var PowerTaskRef import1.TaskReference
 	if powerState, ok := d.GetOk("power_state"); ok {
 		switch powerState {
-    case "ON":
-      PowerTaskRef, err = powerOnVMWithRetry(ctx, conn, uuid)
-    case "OFF":
-      PowerTaskRef, err = powerOffVMWithRetry(ctx, conn, utils.StringPtr(d.Id()))
-    default:
-      return diag.Errorf("invalid power state: %s", powerState)
-    }
-    if err != nil {
-      return diag.Errorf("error while powering %s Virtual Machines: %v", powerState, err)
-    }
+		case "ON":
+			PowerTaskRef, err = powerOnVMWithRetry(ctx, conn, uuid)
+		case "OFF":
+			PowerTaskRef, err = powerOffVMWithRetry(ctx, conn, utils.StringPtr(d.Id()))
+		default:
+			return diag.Errorf("invalid power state: %s", powerState)
+		}
+		if err != nil {
+			return diag.Errorf("error while powering %s Virtual Machines: %v", powerState, err)
+		}
 	}
 	powertaskUUID := PowerTaskRef.ExtId
 

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -1396,7 +1396,7 @@ func ResourceNutanixVirtualMachineV2Create(ctx context.Context, d *schema.Resour
 	if powerState, ok := d.GetOk("power_state"); ok {
 		switch powerState {
 		case "ON":
-			PowerTaskRef, err = powerOnVMWithRetry(ctx, conn, uuid)
+			PowerTaskRef, err = powerOnVMWithRetry(ctx, conn, utils.StringPtr(d.Id()))
 		case "OFF":
 			PowerTaskRef, err = powerOffVMWithRetry(ctx, conn, utils.StringPtr(d.Id()))
 		default:
@@ -3210,14 +3210,13 @@ func powerOnVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (im
 			break
 		}
 
-		if attempt < maxRetries-1 {
-			log.Printf("[DEBUG] Attempt %d/%d failed to power on VM, retrying in %v: %v", attempt+1, maxRetries, retryDelay, err)
+		if attempt < maxRetries {
+			log.Printf("[DEBUG] Attempt %d/%d failed to power on VM, retrying in %v: %v", attempt + 1, maxRetries, retryDelay, err)
 			select {
 			case <-ctx.Done():
 				return import1.TaskReference{}, fmt.Errorf("context cancelled while powering on VM: %v", ctx.Err())
 			case <-time.After(retryDelay):
 				// Continue to next retry
-				log.Printf("[DEBUG] Attempt %d/%d failed to power on VM, retrying in %v: %v", attempt+1, maxRetries, retryDelay, err)
 			}
 		}
 	}
@@ -3258,14 +3257,13 @@ func powerOffVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (i
 			break
 		}
 
-		if attempt < maxRetries-1 {
-			log.Printf("[DEBUG] Attempt %d/%d failed to power off VM, retrying in %v: %v", attempt+1, maxRetries, retryDelay, err)
+		if attempt < maxRetries {
+			log.Printf("[DEBUG] Attempt %d/%d failed to power off VM, retrying in %v: %v", attempt + 1, maxRetries, retryDelay, err)
 			select {
 			case <-ctx.Done():
 				return import1.TaskReference{}, fmt.Errorf("context cancelled while powering off VM: %v", ctx.Err())
 			case <-time.After(retryDelay):
 				// Continue to next retry
-				log.Printf("[DEBUG] Attempt %d/%d failed to power off VM, retrying in %v: %v", attempt+1, maxRetries, retryDelay, err)
 			}
 		}
 	}

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -3189,7 +3189,7 @@ func extractTaskReferenceFromResponse(resp interface{}) (import1.TaskReference, 
 // powerOnVMWithRetry attempts to power on a VM with retry logic
 // It fetches the VM and ETag header for each retry attempt to ensure we have the latest ETag
 func powerOnVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (import1.TaskReference, error) {
-	maxRetries := 5
+	maxRetries := 10
 	retryDelay := 2500 * time.Millisecond // 2.5 seconds
 	var resp interface{}
 	var err error
@@ -3198,17 +3198,7 @@ func powerOnVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (im
 		// Fetch VM to get latest ETag for each retry attempt
 		readResp, errR := conn.VMAPIInstance.GetVmById(vmID)
 		if errR != nil {
-			if attempt < maxRetries-1 {
-				log.Printf("[DEBUG] Attempt %d/%d failed to fetch VM for power on, retrying in %v: %v", attempt+1, maxRetries, retryDelay, errR)
-				select {
-				case <-ctx.Done():
-					return import1.TaskReference{}, fmt.Errorf("context cancelled while fetching VM for power on: %v", ctx.Err())
-				case <-time.After(retryDelay):
-					log.Printf("[DEBUG] Attempt %d/%d failed to fetch VM for power on, retrying in %v: %v", attempt+1, maxRetries, retryDelay, errR)
-					continue
-				}
-			}
-			return import1.TaskReference{}, fmt.Errorf("error while fetching VM for power on after %d attempts: %v", maxRetries, errR)
+			return import1.TaskReference{}, fmt.Errorf("error while fetching vm : %v", errR)
 		}
 
 		// Build args with fresh ETag for this attempt
@@ -3247,7 +3237,7 @@ func powerOnVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (im
 // powerOffVMWithRetry attempts to power off a VM with retry logic
 // It fetches the VM and ETag header for each retry attempt to ensure we have the latest ETag
 func powerOffVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (import1.TaskReference, error) {
-	maxRetries := 5
+	maxRetries := 10
 	retryDelay := 2500 * time.Millisecond // 2.5 seconds
 	var resp interface{}
 	var err error
@@ -3256,17 +3246,7 @@ func powerOffVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (i
 		// Fetch VM to get latest ETag for each retry attempt
 		readResp, errR := conn.VMAPIInstance.GetVmById(vmID)
 		if errR != nil {
-			if attempt < maxRetries-1 {
-				log.Printf("[DEBUG] Attempt %d/%d failed to fetch VM for power off, retrying in %v: %v", attempt+1, maxRetries, retryDelay, errR)
-				select {
-				case <-ctx.Done():
-					return import1.TaskReference{}, fmt.Errorf("context cancelled while fetching VM for power off: %v", ctx.Err())
-				case <-time.After(retryDelay):
-					log.Printf("[DEBUG] Attempt %d/%d failed to fetch VM for power off, retrying in %v: %v", attempt+1, maxRetries, retryDelay, errR)
-					continue
-				}
-			}
-			return import1.TaskReference{}, fmt.Errorf("error while fetching VM for power off after %d attempts: %v", maxRetries, errR)
+			return import1.TaskReference{}, fmt.Errorf("error while fetching vm : %v", errR)
 		}
 
 		// Build args with fresh ETag for this attempt

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -3211,7 +3211,7 @@ func powerOnVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (im
 		}
 
 		if attempt < maxRetries {
-			log.Printf("[DEBUG] Attempt %d/%d failed to power on VM, retrying in %v: %v", attempt + 1, maxRetries, retryDelay, err)
+			log.Printf("[DEBUG] Attempt %d/%d failed to power on VM, retrying in %v: %v", attempt+1, maxRetries, retryDelay, err)
 			select {
 			case <-ctx.Done():
 				return import1.TaskReference{}, fmt.Errorf("context cancelled while powering on VM: %v", ctx.Err())
@@ -3258,7 +3258,7 @@ func powerOffVMWithRetry(ctx context.Context, conn *vmm.Client, vmID *string) (i
 		}
 
 		if attempt < maxRetries {
-			log.Printf("[DEBUG] Attempt %d/%d failed to power off VM, retrying in %v: %v", attempt + 1, maxRetries, retryDelay, err)
+			log.Printf("[DEBUG] Attempt %d/%d failed to power off VM, retrying in %v: %v", attempt+1, maxRetries, retryDelay, err)
 			select {
 			case <-ctx.Done():
 				return import1.TaskReference{}, fmt.Errorf("context cancelled while powering off VM: %v", ctx.Err())


### PR DESCRIPTION

### Summary

This PR adds **retry logic** for VM **power on** and **power off** operations in the Virtual Machine resource v2 (`nutanix_virtual_machine_v2`). When these operations fail (e.g. due to ETag mismatch or transient API issues), the provider now retries up to **5 times** with a **2.5 second** delay between attempts. On each retry, the VM is **re-read** to obtain a fresh ETag before calling the power API, which avoids ETag mismatch errors that commonly occur during Create and Update.

### Problem

- Power on/off during **Create** (when `power_state` is set) and **Update** (when `power_state` is changed) can fail with ETag mismatch if the VM state changes between the read and the power request.
- A single failed attempt forces users to re-run Terraform; retries with a fresh ETag make these operations more resilient.

### What's New

- **Create context:** When `power_state` is `ON` or `OFF`, power on/off is performed via `powerOnVMWithRetry` and `powerOffVMWithRetry` instead of a single API call. Each retry fetches the VM again for a fresh ETag.
- **Update context:** `callForPowerOnVM` and `callForPowerOffVM` now use the same retry helpers, so power state changes on update are also retried with fresh ETags.
- **Retry configuration:** Up to **5 attempts**, **2.5 s** delay between attempts; context cancellation is respected during waits.
- **Helper:** `extractTaskReferenceFromResponse` is introduced to obtain the task reference from the power API response in a type-safe way (used by both retry functions).

### Changes in This PR

- **`nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go`**
  - **Create:** Replaced inline power on/off with `powerOnVMWithRetry` / `powerOffVMWithRetry`; removed the single pre-read used only for ETag (ETag is now fetched inside the retry loop).
  - **Update:** `callForPowerOnVM` and `callForPowerOffVM` now call `powerOnVMWithRetry` and `powerOffVMWithRetry` instead of a single power API call with a one-time ETag.
  - **New functions:**
    - `powerOnVMWithRetry(ctx, conn, vmID)` – retries power on with fresh ETag per attempt.
    - `powerOffVMWithRetry(ctx, conn, vmID)` – retries power off with fresh ETag per attempt.
    - `extractTaskReferenceFromResponse(resp)` – extracts `TaskReference` from the power API response (reflection-based for API response type).
  - Debug logging on retries and on success (e.g. task reference ExtId) for easier troubleshooting.

### Testing

- Existing acceptance and unit tests for the VM v2 resource should continue to pass; behavior is unchanged from the user’s perspective except for improved resilience on power operations.
- Manual testing: create/update VMs with `power_state` set to `ON` or `OFF` in environments where ETag mismatches have been observed; operations should succeed after retries when applicable.

### Backward compatibility

- No schema or attribute changes. Only the internal handling of power on/off is updated; existing configurations remain valid.
