### PR TITLE
add support for invoking tests using API keys

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -91,6 +91,7 @@ jobs:
             echo "NUTANIX_PE_USERNAME=${{ secrets.NUTANIX_PE_USERNAME }}" >> $GITHUB_ENV
             echo "NUTANIX_USERNAME=${{ secrets.NUTANIX_USERNAME }}" >> $GITHUB_ENV
             echo "NUTANIX_PASSWORD=${{ secrets.NUTANIX_PASSWORD }}" >> $GITHUB_ENV
+            echo "NUTANIX_API_KEY=${{ secrets.NUTANIX_API_KEY }}" >> $GITHUB_ENV
             echo "NUTANIX_INSECURE=${{ secrets.NUTANIX_INSECURE }}" >> $GITHUB_ENV
             echo "NUTANIX_PORT=${{ secrets.NUTANIX_PORT }}" >> $GITHUB_ENV
             echo "NUTANIX_ENDPOINT=${{ secrets.NUTANIX_ENDPOINT }}" >> $GITHUB_ENV


### PR DESCRIPTION
## 🔐 Pipeline Support for API Key Authentication

### Summary

This PR extends [PR #1062](https://github.com/nutanix/terraform-provider-nutanix/pull/1062) by adding pipeline support for API key authentication in acceptance tests. The CI/CD workflow can now execute acceptance tests using API keys as an alternative to username/password authentication.

### Changes Made

**GitHub Actions Workflow** (`.github/workflows/acceptance-test.yml`)
- ✅ Added `NUTANIX_API_KEY` environment variable to the test execution environment (line 94)
- The API key is now available to all acceptance tests via the `NUTANIX_API_KEY` environment variable
- Tests can authenticate using API keys when the secret is configured in the repository

### Benefits

- 🔑 **Flexible Authentication**: Acceptance tests can use API key authentication alongside existing username/password credentials
- 🔒 **Enhanced Security**: API keys provide a more secure and manageable authentication method for CI/CD pipelines
- 🔄 **Backward Compatible**: Existing username/password authentication continues to work unchanged
- ✨ **Consistency**: Aligns the pipeline with the API key authentication feature introduced in PR #1062

### Usage

The pipeline will automatically use the API key when:
- The `NUTANIX_API_KEY` secret is configured in the GitHub repository secrets
- Tests are configured to use API key authentication (as supported by PR #1062)


**Type**: Enhancement  
**Impact**: Pipeline/CI-CD  
**Breaking Change**: No
