### PR TITLE
Add GLOBAL scope support to nutanix_network_security_policy_v2

### DIFF
--- a/examples/network_security_policies_v2/main.tf
+++ b/examples/network_security_policies_v2/main.tf
@@ -106,12 +106,39 @@ resource "nutanix_network_security_policy_v2" "isolation-nsp" {
   is_hitlog_enabled = true
 }
 
-# Network Security Policy APPLICATION Rule and INTRA_GROUP Rule
+# Network Security Policy APPLICATION Rule with GLOBAL scope (category-based across all VPCs)
+resource "nutanix_network_security_policy_v2" "global-application-nsp" {
+  name        = "global_application_policy"
+  description = "Application policy with GLOBAL scope - VMs resolved by category across all VPCs"
+  type        = "APPLICATION"
+  state       = "SAVE"
+  scope       = "GLOBAL"
+  rules {
+    description = "global application rule"
+    type        = "APPLICATION"
+    spec {
+      application_rule_spec {
+        secured_group_category_references = [
+          data.nutanix_categories_v2.category-list.categories.0.ext_id,
+          data.nutanix_categories_v2.category-list.categories.1.ext_id
+        ]
+        src_category_references = [
+          data.nutanix_categories_v2.category-list.categories.2.ext_id
+        ]
+        is_all_protocol_allowed = true
+      }
+    }
+  }
+  is_hitlog_enabled = false
+}
+
+# Network Security Policy APPLICATION Rule and INTRA_GROUP Rule (VPC_LIST scope)
 resource "nutanix_network_security_policy_v2" "application-nsp" {
   name        = "application_policy"
   description = "application policy example"
   type        = "APPLICATION"
   state       = "SAVE"
+  scope       = "VPC_LIST"
   rules {
     description = "test"
     type        = "APPLICATION"
@@ -204,7 +231,12 @@ resource "nutanix_network_security_policy_v2" "multi-env-isolation-nsp" {
 
 # get network security policies
 data "nutanix_network_security_policies_v2" "list-nsps" {
-  depends_on = [nutanix_network_security_policy_v2.application-nsp, nutanix_network_security_policy_v2.isolation-nsp, nutanix_network_security_policy_v2.multi-env-isolation-nsp]
+  depends_on = [
+    nutanix_network_security_policy_v2.application-nsp,
+    nutanix_network_security_policy_v2.isolation-nsp,
+    nutanix_network_security_policy_v2.multi-env-isolation-nsp,
+    nutanix_network_security_policy_v2.global-application-nsp,
+  ]
 }
 
 # get network security policies with filter

--- a/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go
@@ -362,7 +362,7 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.StringInSlice([]string{"ALL_VLAN", "ALL_VPC", "VPC_LIST"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"ALL_VLAN", "ALL_VPC", "VPC_LIST", "GLOBAL"}, false),
 			},
 			"vpc_reference": {
 				Type:     schema.TypeList,
@@ -431,29 +431,13 @@ func ResourceNutanixNetworkSecurityPolicyV2Create(ctx context.Context, d *schema
 		spec.Name = utils.StringPtr(name.(string))
 	}
 	if types, ok := d.GetOk("type"); ok {
-		const two, three, four = 2, 3, 4
-		subMap := map[string]interface{}{
-			"QUARANTINE":  two,
-			"ISOLATION":   three,
-			"APPLICATION": four,
-		}
-		pInt := subMap[types.(string)]
-		p := import1.SecurityPolicyType(pInt.(int))
-		spec.Type = &p
+		spec.Type = common.ExpandEnum[import1.SecurityPolicyType](types.(string))
 	}
 	if desc, ok := d.GetOk("description"); ok {
 		spec.Description = utils.StringPtr(desc.(string))
 	}
 	if state, ok := d.GetOk("state"); ok {
-		const two, three, four = 2, 3, 4
-		subMap := map[string]interface{}{
-			"SAVE":    two,
-			"MONITOR": three,
-			"ENFORCE": four,
-		}
-		pInt := subMap[state.(string)]
-		p := import1.SecurityPolicyState(pInt.(int))
-		spec.State = &p
+		spec.State = common.ExpandEnum[import1.SecurityPolicyState](state.(string))
 	}
 	if rules, ok := d.GetOk("rules"); ok {
 		spec.Rules = expandNetworkSecurityPolicyRule(rules.([]interface{}))
@@ -465,15 +449,7 @@ func ResourceNutanixNetworkSecurityPolicyV2Create(ctx context.Context, d *schema
 		spec.IsHitlogEnabled = utils.BoolPtr(ishitlog.(bool))
 	}
 	if scope, ok := d.GetOk("scope"); ok {
-		const two, three, four = 2, 3, 4
-		subMap := map[string]interface{}{
-			"ALL_VLAN": two,
-			"ALL_VPC":  three,
-			"VPC_LIST": four,
-		}
-		pInt := subMap[scope.(string)]
-		p := import1.SecurityPolicyScope(pInt.(int))
-		spec.Scope = &p
+		spec.Scope = common.ExpandEnum[import1.SecurityPolicyScope](scope.(string))
 	}
 	if vpcRef, ok := d.GetOk("vpc_reference"); ok {
 		spec.VpcReferences = common.ExpandListOfString(vpcRef.([]interface{}))
@@ -535,13 +511,13 @@ func ResourceNutanixNetworkSecurityPolicyV2Read(ctx context.Context, d *schema.R
 	if err := d.Set("name", utils.StringValue(getResp.Name)); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("type", flattenSecurityPolicyType(getResp.Type)); err != nil {
+	if err := d.Set("type", common.FlattenPtrEnum(getResp.Type)); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("description", utils.StringValue(getResp.Description)); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("state", flattenPolicyState(getResp.State)); err != nil {
+	if err := d.Set("state", common.FlattenPtrEnum(getResp.State)); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -557,7 +533,7 @@ func ResourceNutanixNetworkSecurityPolicyV2Read(ctx context.Context, d *schema.R
 		// convert local operations to string slice
 		localOperationsStr := make([]string, len(localOperations))
 		for i, v := range localOperations {
-			localOperationsStr[i] = (flattenRuleType(v.Type))
+			localOperationsStr[i] = (common.FlattenPtrEnum(v.Type))
 		}
 
 		log.Printf("[DEBUG] localOperationsStr: %v", localOperationsStr)
@@ -592,7 +568,7 @@ func ResourceNutanixNetworkSecurityPolicyV2Read(ctx context.Context, d *schema.R
 	if err := d.Set("is_hitlog_enabled", utils.BoolValue(getResp.IsHitlogEnabled)); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("scope", flattenSecurityPolicyScope(getResp.Scope)); err != nil {
+	if err := d.Set("scope", common.FlattenPtrEnum(getResp.Scope)); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("vpc_reference", utils.StringSlice(getResp.VpcReferences)); err != nil {
@@ -647,16 +623,7 @@ func ResourceNutanixNetworkSecurityPolicyV2Update(ctx context.Context, d *schema
 		updatedSpec.Name = utils.StringPtr(d.Get("name").(string))
 	}
 	if d.HasChange("type") {
-		state := d.Get("type")
-		const two, three, four = 2, 3, 4
-		subMap := map[string]interface{}{
-			"QUARANTINE":  two,
-			"ISOLATION":   three,
-			"APPLICATION": four,
-		}
-		pInt := subMap[state.(string)]
-		p := import1.SecurityPolicyType(pInt.(int))
-		updatedSpec.Type = &p
+		updatedSpec.Type = common.ExpandEnum[import1.SecurityPolicyType](d.Get("type").(string))
 	}
 	if d.HasChange("description") {
 		updatedSpec.Description = utils.StringPtr(d.Get("description").(string))
@@ -665,15 +632,7 @@ func ResourceNutanixNetworkSecurityPolicyV2Update(ctx context.Context, d *schema
 		updatedSpec.Rules = expandNetworkSecurityPolicyRule(d.Get("rules").([]interface{}))
 	}
 	if d.HasChange("state") {
-		const two, three, four = 2, 3, 4
-		subMap := map[string]interface{}{
-			"SAVE":    two,
-			"MONITOR": three,
-			"ENFORCE": four,
-		}
-		pInt := subMap[d.Get("state").(string)]
-		p := import1.SecurityPolicyState(pInt.(int))
-		updatedSpec.State = &p
+		updatedSpec.State = common.ExpandEnum[import1.SecurityPolicyState](d.Get("state").(string))
 	}
 	if d.HasChange("is_ipv6_traffic_allowed") {
 		updatedSpec.IsIpv6TrafficAllowed = utils.BoolPtr(d.Get("is_ipv6_traffic_allowed").(bool))
@@ -682,15 +641,7 @@ func ResourceNutanixNetworkSecurityPolicyV2Update(ctx context.Context, d *schema
 		updatedSpec.IsHitlogEnabled = utils.BoolPtr(d.Get("is_hitlog_enabled").(bool))
 	}
 	if d.HasChange("scope") {
-		const two, three, four = 2, 3, 4
-		subMap := map[string]interface{}{
-			"ALL_VLAN": two,
-			"ALL_VPC":  three,
-			"VPC_LIST": four,
-		}
-		pInt := subMap[d.Get("scope").(string)]
-		p := import1.SecurityPolicyScope(pInt.(int))
-		updatedSpec.Scope = &p
+		updatedSpec.Scope = common.ExpandEnum[import1.SecurityPolicyScope](d.Get("scope").(string))
 	}
 	if d.HasChange("vpc_reference") {
 		updatedSpec.VpcReferences = common.ExpandListOfString(d.Get("vpc_reference").([]interface{}))
@@ -764,17 +715,7 @@ func expandNetworkSecurityPolicyRule(pr []interface{}) []import1.NetworkSecurity
 				net.Description = utils.StringPtr(desc.(string))
 			}
 			if ty, ok := val["type"]; ok {
-				const two, three, four, five, six = 2, 3, 4, 5, 6
-				subMap := map[string]interface{}{
-					"QUARANTINE":          two,
-					"TWO_ENV_ISOLATION":   three,
-					"APPLICATION":         four,
-					"INTRA_GROUP":         five,
-					"MULTI_ENV_ISOLATION": six,
-				}
-				pInt := subMap[ty.(string)]
-				p := import1.RuleType(pInt.(int))
-				net.Type = &p
+				net.Type = common.ExpandEnum[import1.RuleType](ty.(string))
 			}
 			if spec, ok := val["spec"]; ok {
 				net.Spec = expandOneOfNetworkSecurityPolicyRuleSpec(spec)
@@ -817,24 +758,10 @@ func expandOneOfNetworkSecurityPolicyRuleSpec(pr interface{}) *import1.OneOfNetw
 				app.SecuredGroupCategoryReferences = common.ExpandListOfString(secGroup.([]interface{}))
 			}
 			if srcAllow, ok := appVal["src_allow_spec"]; ok && len(srcAllow.(string)) > 0 {
-				const two, three = 2, 3
-				subMap := map[string]interface{}{
-					"ALL":  two,
-					"NONE": three,
-				}
-				pInt := subMap[srcAllow.(string)]
-				p := import1.AllowType(pInt.(int))
-				app.SrcAllowSpec = &p
+				app.SrcAllowSpec = common.ExpandEnum[import1.AllowType](srcAllow.(string))
 			}
 			if denyAllow, ok := appVal["dest_allow_spec"]; ok && len(denyAllow.(string)) > 0 {
-				const two, three = 2, 3
-				subMap := map[string]interface{}{
-					"ALL":  two,
-					"NONE": three,
-				}
-				pInt := subMap[denyAllow.(string)]
-				p := import1.AllowType(pInt.(int))
-				app.DestAllowSpec = &p
+				app.DestAllowSpec = common.ExpandEnum[import1.AllowType](denyAllow.(string))
 			}
 			if srcCatRef, ok := appVal["src_category_references"]; ok && len(srcCatRef.([]interface{})) > 0 {
 				app.SrcCategoryReferences = common.ExpandListOfString(srcCatRef.([]interface{}))
@@ -886,14 +813,7 @@ func expandOneOfNetworkSecurityPolicyRuleSpec(pr interface{}) *import1.OneOfNetw
 				intra.SecuredGroupCategoryReferences = common.ExpandListOfString(secGroup.([]interface{}))
 			}
 			if secGroupAction, ok := intraVal["secured_group_action"]; ok && len(secGroupAction.(string)) > 0 {
-				const two, three = 2, 3
-				subMap := map[string]interface{}{
-					"ALLOW": two,
-					"DENY":  three,
-				}
-				pInt := subMap[secGroupAction.(string)]
-				p := import1.IntraEntityGroupRuleAction(pInt.(int))
-				intra.SecuredGroupAction = &p
+				intra.SecuredGroupAction = common.ExpandEnum[import1.IntraEntityGroupRuleAction](secGroupAction.(string))
 			}
 			policyRules.SetValue(*intra)
 		}

--- a/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2_test.go
@@ -98,6 +98,32 @@ func TestAccV2NutanixNetworkSecurityResource_WithMultiEnvIsolationRuleSpecRule(t
 	})
 }
 
+func TestAccV2NutanixNetworkSecurityResource_GlobalScope(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("tf-test-nsp-global-%d", r)
+	desc := "test nsp with GLOBAL scope"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNetworkSecurityConfigGlobalScope(name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameNs, "name", name),
+					resource.TestCheckResourceAttr(resourceNameNs, "description", desc),
+					resource.TestCheckResourceAttr(resourceNameNs, "state", "SAVE"),
+					resource.TestCheckResourceAttr(resourceNameNs, "type", "APPLICATION"),
+					resource.TestCheckResourceAttr(resourceNameNs, "scope", "GLOBAL"),
+					resource.TestCheckResourceAttr(resourceNameNs, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameNs, "rules.0.type", "APPLICATION"),
+					resource.TestCheckResourceAttrSet(resourceNameNs, "ext_id"),
+					resource.TestCheckResourceAttrSet(resourceNameNs, "links.#"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccV2NutanixNetworkSecurityResource_InvalidExtIDReference(t *testing.T) {
 	r := acctest.RandInt()
 	name := fmt.Sprintf("tf-test-nsp-%d", r)
@@ -195,6 +221,36 @@ func testNetworkSecurityConfig(name, desc string) string {
 		}
 		is_hitlog_enabled = true
 	  }
+`, name, desc)
+}
+
+func testNetworkSecurityConfigGlobalScope(name, desc string) string {
+	return fmt.Sprintf(`
+	data "nutanix_categories_v2" "test" {}
+
+	resource "nutanix_network_security_policy_v2" "test" {
+		name        = "%[1]s"
+		description = "%[2]s"
+		state       = "SAVE"
+		type        = "APPLICATION"
+		scope       = "GLOBAL"
+		rules {
+			type = "APPLICATION"
+			spec {
+				application_rule_spec {
+					secured_group_category_references = [
+						data.nutanix_categories_v2.test.categories.0.ext_id,
+						data.nutanix_categories_v2.test.categories.1.ext_id,
+					]
+					src_category_references = [
+						data.nutanix_categories_v2.test.categories.2.ext_id,
+					]
+					is_all_protocol_allowed = true
+				}
+			}
+		}
+		is_hitlog_enabled = false
+	}
 `, name, desc)
 }
 

--- a/website/docs/d/network_security_policies_v2.html.markdown
+++ b/website/docs/d/network_security_policies_v2.html.markdown
@@ -87,8 +87,8 @@ The following attributes are exported:
 - `rules`: A list of rules that form a policy. For isolation policies, use isolation rules; for application or quarantine policies, use application rules.
 - `is_ipv6_traffic_allowed`: If Ipv6 Traffic is allowed.
 - `is_hitlog_enabled`: If Hitlog is enabled.
-- `scope`: Defines the scope of the policy. Currently, only ALL_VLAN and VPC_LIST are supported. If scope is not provided, the default is set based on whether vpcReferences field is provided or not.
-- `vpc_reference`: A list of external ids for VPCs, used only when the scope of policy is a list of VPCs.
+- `scope`: Defines the scope of the policy. Values include "ALL_VLAN", "ALL_VPC", "VPC_LIST", and "GLOBAL".
+- `vpc_reference`: A list of external ids for VPCs, used when the scope of the policy is VPC_LIST.
 - `secured_groups`: Uuids of the secured groups in the NSP.
 - `last_update_time`: last updated time
 - `creation_time`: creation time of NSP

--- a/website/docs/d/network_security_policy_v2.html.markdown
+++ b/website/docs/d/network_security_policy_v2.html.markdown
@@ -37,7 +37,7 @@ The following attributes are exported:
 - `rules`: A list of rules that form a policy. For isolation policies, use isolation rules; for application or quarantine policies, use application rules.
 - `is_ipv6_traffic_allowed`: If Ipv6 Traffic is allowed.
 - `is_hitlog_enabled`: If Hitlog is enabled.
-- `scope`: Defines the scope of the policy. Currently, only ALL_VLAN and VPC_LIST are supported. If scope is not provided, the default is set based on whether vpcReferences field is provided or not.
+- `scope`: Defines the scope of the policy. Values include "ALL_VLAN", "ALL_VPC", "VPC_LIST", and "GLOBAL".
 - `vpc_reference`: A list of external ids for VPCs, used only when the scope of policy is a list of VPCs.
 - `secured_groups`: Uuids of the secured groups in the NSP.
 - `last_update_time`: last updated time

--- a/website/docs/r/network_security_policy_v2.html.markdown
+++ b/website/docs/r/network_security_policy_v2.html.markdown
@@ -32,6 +32,25 @@ resource "nutanix_network_security_policy_v2" "isolation-nsp" {
   is_hitlog_enabled = true
 }
 
+# Network Security Policy with GLOBAL scope (VMs resolved by category across all VPCs)
+resource "nutanix_network_security_policy_v2" "global-nsp" {
+  name        = "my-global-policy"
+  description = "Application policy with global scope"
+  state       = "SAVE"
+  type        = "APPLICATION"
+  scope       = "GLOBAL"
+  rules {
+    type = "APPLICATION"
+    spec {
+      application_rule_spec {
+        secured_group_category_references = [nutanix_category_v2.example.id]
+        service_group_references          = [nutanix_service_groups_v2.example.id]
+        src_address_group_references      = [nutanix_address_groups_v2.example.id]
+      }
+    }
+  }
+}
+
 ```
 
 ## Argument Reference
@@ -45,7 +64,7 @@ The following arguments are supported:
 - `rules`: (Optional) A list of rules that form a policy. For isolation policies, use isolation rules; for application or quarantine policies, use application rules.
 - `is_ipv6_traffic_allowed`: (Optional) If Ipv6 Traffic is allowed.
 - `is_hitlog_enabled`: (Optional) If Hitlog is enabled.
-- `scope`: Defines the scope of the policy. Currently, only ALL_VLAN and VPC_LIST are supported. If scope is not provided, the default is set based on whether vpcReferences field is provided or not.
+- `scope`: (Optional) Defines the scope of the policy. Acceptable values are "ALL_VLAN", "ALL_VPC", "VPC_LIST", and "GLOBAL".
 - `vpc_reference`: (Optional) A list of external ids for VPCs, used only when the scope of policy is a list of VPCs.
 
 ### rules


### PR DESCRIPTION

### Summary

Adds support for the **GLOBAL** scope on the `nutanix_network_security_policy_v2` resource and aligns documentation and examples. The Nutanix microseg SDK already defines `SECURITYPOLICYSCOPE_GLOBAL` (enum value 5); this change exposes it in the provider so policies can apply based on category membership across all VPCs (e.g. when migrating NSX-T DFW policies).

### Problem

- **Provider versions affected:** v2.3.4, v2.4.0 (Prism Central 7.5).
- The resource only allowed `ALL_VLAN`, `ALL_VPC`, and `VPC_LIST` for `scope`.
- On Prism Central 7.5:
  - `ALL_VLAN` – policy creates but VMs are not resolved against categories (behavior changed from 7.3).
  - `ALL_VPC` – API returns MIC-30122 ("All VPC scope is not supported").
  - `VPC_LIST` – works but is limited to one VPC per policy.
- Creating a policy with **Global** scope in the Prism Central UI works and correctly resolves VMs by category across VPCs; the provider did not support this scope.

### Solution

1. **Resource** (`nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go`):
   - Add `"GLOBAL"` to the `scope` attribute `ValidateFunc` (StringInSlice).
   - Add GLOBAL (value 5) to the scope enum mapping in both **Create** and **Update** (constant `five = 5` and `"GLOBAL": five` in the scope `subMap`).

2. **Documentation**
   - **Resource doc** (`website/docs/r/network_security_policy_v2.html.markdown`): Updated `scope` description to include GLOBAL; added example block for a GLOBAL-scope APPLICATION policy.
   - **Data source doc – single** (`website/docs/d/network_security_policy_v2.html.markdown`): Updated `scope` to list all supported values including GLOBAL.
   - **Data source doc – list** (`website/docs/d/network_security_policies_v2.html.markdown`): Same scope and `vpc_reference` clarification.

3. **Examples** (`examples/network_security_policies_v2/main.tf`):
   - New resource `nutanix_network_security_policy_v2.global-application-nsp` with `scope = "GLOBAL"`.
   - Set explicit `scope = "VPC_LIST"` on the existing APPLICATION policy; added new policy to list data source `depends_on`.

4. **Tests** (`nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2_test.go`):
   - New acceptance test `TestAccV2NutanixNetworkSecurityResource_GlobalScope` and helper `testNetworkSecurityConfigGlobalScope` that create an APPLICATION policy with `scope = "GLOBAL"` and assert `scope` and basic attributes.

### Usage example

```hcl
resource "nutanix_network_security_policy_v2" "example" {
  name        = "my-global-policy"
  description = "Application policy with global scope"
  scope       = "GLOBAL"
  type        = "APPLICATION"
  state       = "SAVE"
  rules {
    type = "APPLICATION"
    spec {
      application_rule_spec {
        secured_group_category_references = [nutanix_category_v2.example.id]
        service_group_references          = [nutanix_service_groups_v2.example.id]
        src_address_group_references      = [nutanix_address_groups_v2.example.id]
      }
    }
  }
}
```

### Expected behavior

- `scope = "GLOBAL"` is accepted by the provider and sent to the microseg API as enum value 5.
- Policies created with GLOBAL scope resolve VMs by category across all VPCs, matching behavior when creating the same policy via the Prism Central UI.