### PR TITLE
Fix: User Key recreate and Object Store issues

### DIFF
--- a/nutanix/services/iamv2/resource_nutanix_user_key_v2.go
+++ b/nutanix/services/iamv2/resource_nutanix_user_key_v2.go
@@ -63,7 +63,7 @@ func ResourceNutanixUserKeyV2() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{"API_KEY", "OBJECT_KEY"}, false),
-				ForceNew: true,
+				ForceNew:     true,
 			},
 			"created_time": {
 				Type:     schema.TypeString,

--- a/nutanix/services/iamv2/resource_nutanix_user_key_v2.go
+++ b/nutanix/services/iamv2/resource_nutanix_user_key_v2.go
@@ -51,16 +51,19 @@ func ResourceNutanixUserKeyV2() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"key_type": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{"API_KEY", "OBJECT_KEY"}, false),
+				ForceNew: true,
 			},
 			"created_time": {
 				Type:     schema.TypeString,
@@ -82,6 +85,7 @@ func ResourceNutanixUserKeyV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"status": {
 				Type:         schema.TypeString,
@@ -108,6 +112,7 @@ func ResourceNutanixUserKeyV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"key_details": {
 				Type:     schema.TypeList,
@@ -327,7 +332,7 @@ func flattenKeyDetails(oneOfKeyKeyDetails *import1.OneOfKeyKeyDetails) interface
 }
 
 func resourceNutanixUserKeyV2Update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	return resourceNutanixUserKeyV2Create(ctx, d, m)
+	return nil
 }
 
 func resourceNutanixUserKeyV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/nutanix/services/objectsv2/resource_nutanix_object_store_v2.go
+++ b/nutanix/services/objectsv2/resource_nutanix_object_store_v2.go
@@ -63,8 +63,9 @@ func ResourceNutanixObjectStoresV2() *schema.Resource {
 				},
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 16),
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/nutanix/services/objectsv2/resource_nutanix_object_store_v2.go
+++ b/nutanix/services/objectsv2/resource_nutanix_object_store_v2.go
@@ -65,7 +65,7 @@ func ResourceNutanixObjectStoresV2() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 50),
+				ValidateFunc: validation.StringLenBetween(1, 16),
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/nutanix/services/objectsv2/resource_nutanix_object_store_v2.go
+++ b/nutanix/services/objectsv2/resource_nutanix_object_store_v2.go
@@ -65,7 +65,7 @@ func ResourceNutanixObjectStoresV2() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 16),
+				ValidateFunc: validation.StringLenBetween(1, 50),
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/website/docs/r/object_store_v2.html.markdown
+++ b/website/docs/r/object_store_v2.html.markdown
@@ -13,7 +13,7 @@ Run the prechecks, create and start the deployment of an Object store on Prism C
 > ⚠️ **Warning:** Before deleting the Object Store, make sure to delete all buckets inside it manually.
 > Currently, the Terraform provider does not support the Delete Bucket API.
 
-> ⚠️ **Warning:** The Object Store **update** operation does **not** allow modification of any configuration parameters (including `name` and `description`). Apart from retrying a failed deployment, no other changes can be performed through update.
+> ⚠️ **Warning:** The Object Store **update** operation does **not** allow modification of any configuration parameters (including `name` and `description`). As per the API design, the update operation is supported exclusively for retrying a failed deployment. No other changes can be performed through update.
 > It should be used when the Object Store is in the `OBJECT_STORE_DEPLOYMENT_FAILED` state.
 > Triggering an update in this state will attempt to resume the deployment process.
 

--- a/website/docs/r/object_store_v2.html.markdown
+++ b/website/docs/r/object_store_v2.html.markdown
@@ -13,7 +13,7 @@ Run the prechecks, create and start the deployment of an Object store on Prism C
 > ⚠️ **Warning:** Before deleting the Object Store, make sure to delete all buckets inside it manually.
 > Currently, the Terraform provider does not support the Delete Bucket API.
 
-> ⚠️ **Warning:** The Object Store **update** operation is intended **only** to resume a failed deployment.
+> ⚠️ **Warning:** The Object Store **update** operation does **not** allow modification of any configuration parameters (including `name` and `description`). Apart from retrying a failed deployment, no other changes can be performed through update.
 > It should be used when the Object Store is in the `OBJECT_STORE_DEPLOYMENT_FAILED` state.
 > Triggering an update in this state will attempt to resume the deployment process.
 

--- a/website/docs/r/user_key_v2.html.markdown
+++ b/website/docs/r/user_key_v2.html.markdown
@@ -23,6 +23,26 @@ resource "nutanix_user_key_v2" "create_key" {
 }
 ```
 
+## Lifecycle Behavior
+
+~> Important: The nutanix_user_key_v2 resource does not support in-place updates.
+
+Changes to the following arguments will force the resource to be replaced:
+
+- name
+
+- description
+
+- key_type
+
+- expiry_time
+
+- assigned_to
+
+When any of these arguments are modified, Terraform will destroy the existing user key and create a new one. This results in a new key being generated.
+
+~> Note: Replacing the resource invalidates the previously generated key. Ensure that any dependent systems are updated before applying the changes.
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
This PR solves 3 issues
https://github.com/nutanix/terraform-provider-nutanix/issues/1094: (P1): Objects: Basic update functionality is not provided, so the ask is to add a support for updating the details of already deployed Objects Store.

## Overview
Object store once deployed the configuration details cannot be updated,.

## Changes made
 Updated docs to clarify object store update limitations 

======================================================================================
https://github.com/nutanix/terraform-provider-nutanix/issues/1093: (P1) Objects: From Terraform side, if user send a long name for Object store we show everything went fine but in Objects Store GUI it shows Predeploy checks failed : Cluster name tf-my-obj-store-longname is greater than the allowed Maximum length 16. Ask is to add some validations around the name, make sure Terraform shows the failure.

Add validation around name field, only 16 characters should be allowed
https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Objects-v5_3:top-os-naming-conventions-c.html
======================================================================================
https://github.com/nutanix/terraform-provider-nutanix/issues/1092: (P2) For User Keys, we don’t support Update(Product itself doesn’t support). Any changes made to the config calling out create context leads to failure. So, the ask is to if any updates have been made to the user key it should destroy and recreate the User Key.


## Overview

Updated the `nutanix_user_key_v2` resource to enforce resource recreation (instead of in-place updates) when certain immutable fields are modified. Added `ForceNew: true` to immutable fields and updated documentation to clearly explain the lifecycle behavior.

## Changes Made

### 1. Code Changes (`nutanix/services/iamv2/resource_nutanix_user_key_v2.go`)

- **Added `ForceNew: true`** to the following schema fields:
  - `name` (line 54)
  - `description` (line 60)
  - `key_type` (line 66)
  - `expiry_time` (line 88)
  - `assigned_to` (line 115)

- **Updated `resourceNutanixUserKeyV2Update` function** (line 335):
  - Changed from calling `resourceNutanixUserKeyV2Create` to returning `nil`
  - Prevents update attempts and relies on Terraform's recreation mechanism

### 2. Documentation Changes (`website/docs/r/user_key_v2.html.markdown`)

- **Added new "Lifecycle Behavior" section** (lines 26-44) that documents:
  - Resource does not support in-place updates
  - List of fields that force resource replacement
  - Warning about key invalidation when resource is replaced
  - Note about updating dependent systems

## Impact

- **User Experience**: Users are now clearly informed that modifying `name`, `description`, `key_type`, `expiry_time`, or `assigned_to` will recreate the resource
- **Resource Lifecycle**: Terraform will properly destroy and recreate the user key when these fields change
- **Key Management**: New keys are generated on recreation, invalidating previous keys
- **Error Prevention**: Prevents incorrect update behavior that could cause API errors

## Rationale

The Nutanix User Key API does not support updating these fields in-place. By marking them with `ForceNew: true`, Terraform will properly recreate the resource when these fields change, aligning with the API's actual behavior and preventing update failures.