### PR TITLE
VMM v2: fix `nic_backing_info` / `nic_network_info`  and fix `is_connected` change detection

### DIFF
--- a/nutanix/common/common.go
+++ b/nutanix/common/common.go
@@ -80,9 +80,58 @@ func IsExplicitlySet(d *schema.ResourceData, key string) bool {
 	if !ok {
 		return false
 	}
-
-	log.Printf("[DEBUG] Key: %s, Value: %s", key, val)
+	aJSON, _ := json.MarshalIndent(val, "", "  ")
+	log.Printf("[DEBUG] Key: %s, Value: %s", key, string(aJSON))
 	return !val.IsNull() // Ensure key exists and isn't explicitly null
+}
+
+// IsNonEmptyBlockExplicitlySet returns true only when the key exists in raw config and has meaningful content
+// (e.g. at least one nested attribute or block set). Used to prefer legacy blocks when the user only set
+// legacy fields and the new block is present in config as an empty block (e.g. from schema default).
+func IsNonEmptyBlockExplicitlySet(d *schema.ResourceData, key string) bool {
+	rawConfig := d.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.IsKnown() {
+		return false
+	}
+	val, ok := getRawConfigValueAtPath(rawConfig, key)
+	if !ok || val.IsNull() || !val.IsKnown() {
+		return false
+	}
+	return ctyValueHasContent(val)
+}
+
+// ctyValueHasContent returns true if the cty value has at least one non-null, known nested value.
+func ctyValueHasContent(v cty.Value) bool {
+	if v.IsNull() || !v.IsKnown() {
+		return false
+	}
+	ty := v.Type()
+	if ty.IsListType() || ty.IsTupleType() {
+		l := v.Length()
+		if l.IsNull() || !l.IsKnown() {
+			return false
+		}
+		bf := l.AsBigFloat()
+		n, _ := bf.Int64()
+		if n == 0 {
+			return false
+		}
+		return ctyValueHasContent(v.Index(cty.NumberIntVal(0)))
+	}
+	if ty.IsObjectType() || ty.IsMapType() {
+		for _, v := range v.AsValueMap() {
+			if !v.IsNull() && v.IsKnown() {
+				if v.Type().IsPrimitiveType() || v.Type().IsCapsuleType() {
+					return true
+				}
+				if ctyValueHasContent(v) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	return true // primitive or other known type
 }
 
 func getRawConfigValueAtPath(root cty.Value, path string) (cty.Value, bool) {

--- a/nutanix/services/vmmv2/data_source_nutanix_ova_v2_test.go
+++ b/nutanix/services/vmmv2/data_source_nutanix_ova_v2_test.go
@@ -48,7 +48,7 @@ func TestAccV2NutanixOvaDatasource_GetOvaDetails(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceNameOva, "vm_config.0.disks.0.backing_info.0.vm_disk.0.disk_size_bytes", datasourceNameOva, "vm_config.0.disks.0.backing_info.0.vm_disk.0.disk_size_bytes"),
 					resource.TestCheckResourceAttrPair(resourceNameOva, "vm_config.0.disks.0.disk_address.0.bus_type", datasourceNameOva, "vm_config.0.disks.0.disk_address.0.bus_type"),
 					resource.TestCheckResourceAttrPair(resourceNameOva, "vm_config.0.nics.#", datasourceNameOva, "vm_config.0.nics.#"),
-					resource.TestCheckResourceAttrPair(resourceNameOva, "vm_config.0.nics.0.network_info.0.nic_type", datasourceNameOva, "vm_config.0.nics.0.network_info.0.nic_type"),
+					resource.TestCheckResourceAttrPair(resourceNameOva, "vm_config.0.nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", datasourceNameOva, "vm_config.0.nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type"),
 				),
 			},
 		},

--- a/nutanix/services/vmmv2/data_source_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/data_source_nutanix_virtual_machine_v2.go
@@ -2326,12 +2326,12 @@ func flattenNic(nic []config.Nic) []interface{} {
 				nics["nic_network_info"] = []interface{}{nicNetworkInfo}
 			}
 			if _, ok := nics["network_info"]; !ok && v.NetworkInfo != nil {
-				flattened := flattenNicNetworkInfo(v.NetworkInfo)
-				nics["network_info"] = flattened
+				flattened_nic_network_info := flattenNicNetworkInfo(v.NetworkInfo)
+				nics["network_info"] = flattened_nic_network_info
 				// Also set nic_network_info so vm_config matches VM state shape (e.g. OVA returns legacy only).
 				if _, ok := nics["nic_network_info"]; !ok {
 					nicNetworkInfo := make(map[string]interface{})
-					nicNetworkInfo["virtual_ethernet_nic_network_info"] = flattened
+					nicNetworkInfo["virtual_ethernet_nic_network_info"] = flattened_nic_network_info
 					nics["nic_network_info"] = []interface{}{nicNetworkInfo}
 				}
 			}

--- a/nutanix/services/vmmv2/data_source_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/data_source_nutanix_virtual_machine_v2.go
@@ -2326,7 +2326,14 @@ func flattenNic(nic []config.Nic) []interface{} {
 				nics["nic_network_info"] = []interface{}{nicNetworkInfo}
 			}
 			if _, ok := nics["network_info"]; !ok && v.NetworkInfo != nil {
-				nics["network_info"] = flattenNicNetworkInfo(v.NetworkInfo)
+				flattened := flattenNicNetworkInfo(v.NetworkInfo)
+				nics["network_info"] = flattened
+				// Also set nic_network_info so vm_config matches VM state shape (e.g. OVA returns legacy only).
+				if _, ok := nics["nic_network_info"]; !ok {
+					nicNetworkInfo := make(map[string]interface{})
+					nicNetworkInfo["virtual_ethernet_nic_network_info"] = flattened
+					nics["nic_network_info"] = []interface{}{nicNetworkInfo}
+				}
 			}
 
 			nicList[k] = nics
@@ -2413,22 +2420,7 @@ func flattenNicNetworkInfo(pr *config.NicNetworkInfo) []map[string]interface{} {
 }
 
 func flattenNicType(pr *config.NicType) string {
-	if pr != nil {
-		const two, three, four, five = 2, 3, 4, 5
-		if *pr == config.NicType(two) {
-			return "NORMAL_NIC"
-		}
-		if *pr == config.NicType(three) {
-			return "DIRECT_NIC"
-		}
-		if *pr == config.NicType(four) {
-			return "NETWORK_FUNCTION_NIC"
-		}
-		if *pr == config.NicType(five) {
-			return "SPAN_DESTINATION_NIC"
-		}
-	}
-	return "UNKNOWN"
+	return pr.GetName()
 }
 
 func flattenNetworkFunctionChainReference(ref *config.NetworkFunctionChainReference) []map[string]interface{} {

--- a/nutanix/services/vmmv2/data_source_nutanix_virtual_machine_v2_test.go
+++ b/nutanix/services/vmmv2/data_source_nutanix_virtual_machine_v2_test.go
@@ -58,10 +58,10 @@ func TestAccV2NutanixVmsDatasource_WithConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(datasourceNameVMs, "is_agent_vm", "false"),
 					resource.TestCheckResourceAttr(datasourceNameVMs, "machine_type", "PC"),
 					resource.TestCheckResourceAttrSet(datasourceNameVMs, "nics.#"),
-					resource.TestCheckResourceAttr(datasourceNameVMs, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
-					resource.TestCheckResourceAttr(datasourceNameVMs, "nics.0.network_info.0.vlan_mode", "ACCESS"),
-					resource.TestCheckResourceAttrSet(datasourceNameVMs, "nics.0.backing_info.#"),
-					resource.TestCheckResourceAttrSet(datasourceNameVMs, "nics.0.network_info.#"),
+					resource.TestCheckResourceAttr(datasourceNameVMs, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(datasourceNameVMs, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttrSet(datasourceNameVMs, "nics.0.nic_backing_info.#"),
+					resource.TestCheckResourceAttrSet(datasourceNameVMs, "nics.0.nic_network_info.#"),
 				),
 			},
 		},
@@ -89,10 +89,10 @@ func TestAccV2NutanixVmsDatasource_WithCdromConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(datasourceNameVMs, "is_agent_vm", "false"),
 					resource.TestCheckResourceAttr(datasourceNameVMs, "machine_type", "PC"),
 					resource.TestCheckResourceAttrSet(datasourceNameVMs, "nics.#"),
-					resource.TestCheckResourceAttr(datasourceNameVMs, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
-					resource.TestCheckResourceAttr(datasourceNameVMs, "nics.0.network_info.0.vlan_mode", "ACCESS"),
-					resource.TestCheckResourceAttrSet(datasourceNameVMs, "nics.0.backing_info.#"),
-					resource.TestCheckResourceAttrSet(datasourceNameVMs, "nics.0.network_info.#"),
+					resource.TestCheckResourceAttr(datasourceNameVMs, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(datasourceNameVMs, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttrSet(datasourceNameVMs, "nics.0.nic_backing_info.#"),
+					resource.TestCheckResourceAttrSet(datasourceNameVMs, "nics.0.nic_network_info.#"),
 					resource.TestCheckResourceAttrSet(datasourceNameVMs, "cd_roms.#"),
 					resource.TestCheckResourceAttr(datasourceNameVMs, "cd_roms.0.disk_address.0.bus_type", "SATA"),
 					resource.TestCheckResourceAttr(datasourceNameVMs, "cd_roms.0.disk_address.0.index", "0"),
@@ -123,10 +123,10 @@ func TestAccV2NutanixVmsDatasource_WithCdromBackingInfo(t *testing.T) {
 					resource.TestCheckResourceAttr(datasourceNameVMs, "is_agent_vm", "false"),
 					resource.TestCheckResourceAttr(datasourceNameVMs, "machine_type", "PC"),
 					resource.TestCheckResourceAttrSet(datasourceNameVMs, "nics.#"),
-					resource.TestCheckResourceAttr(datasourceNameVMs, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
-					resource.TestCheckResourceAttr(datasourceNameVMs, "nics.0.network_info.0.vlan_mode", "ACCESS"),
-					resource.TestCheckResourceAttrSet(datasourceNameVMs, "nics.0.backing_info.#"),
-					resource.TestCheckResourceAttrSet(datasourceNameVMs, "nics.0.network_info.#"),
+					resource.TestCheckResourceAttr(datasourceNameVMs, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(datasourceNameVMs, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttrSet(datasourceNameVMs, "nics.0.nic_backing_info.#"),
+					resource.TestCheckResourceAttrSet(datasourceNameVMs, "nics.0.nic_network_info.#"),
 					resource.TestCheckResourceAttrSet(datasourceNameVMs, "cd_roms.#"),
 					resource.TestCheckResourceAttr(datasourceNameVMs, "cd_roms.0.disk_address.0.bus_type", "IDE"),
 					resource.TestCheckResourceAttr(datasourceNameVMs, "cd_roms.0.disk_address.0.index", "0"),
@@ -190,12 +190,14 @@ func testAccVMDataSourceConfigV4WithNic(name, desc string) string {
 				ext_id = local.cluster0
 			}
 			nics{
-				network_info{
-					nic_type = "NORMAL_NIC"
-					subnet{
-						ext_id = data.nutanix_subnets_v2.subnets.subnets.0.ext_id
-					}	
-					vlan_mode = "ACCESS"
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets.0.ext_id
+						}	
+						vlan_mode = "ACCESS"
+					}
 				}
 			}
 		}
@@ -232,12 +234,14 @@ func testAccVMDataSourceConfigV4WithCdrom(name, desc string) string {
 				ext_id = local.cluster0
 			}
 			nics{
-				network_info{
-					nic_type = "NORMAL_NIC"
-					subnet{
-						ext_id = data.nutanix_subnets_v2.subnets.subnets.0.ext_id
-					}	
-					vlan_mode = "ACCESS"
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets.0.ext_id
+						}	
+						vlan_mode = "ACCESS"
+					}
 				}
 			}
 			boot_config{
@@ -320,12 +324,14 @@ func testAccVMDataSourceConfigV4WithCdromBackingInfo(name, desc string) string {
 				}
 			}
 			nics{
-				network_info{
-					nic_type = "NORMAL_NIC"
-					subnet{
-						ext_id = data.nutanix_subnets_v2.subnets.subnets.0.ext_id
-					}	
-					vlan_mode = "ACCESS"
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets.0.ext_id
+						}	
+						vlan_mode = "ACCESS"
+					}
 				}
 			}
 			cd_roms{

--- a/nutanix/services/vmmv2/resource_nutanix_ngt_installation_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_ngt_installation_v2_test.go
@@ -371,12 +371,14 @@ func testPreEnvConfig(vmName string, r int) string {
 		  }
 
 		  nics {
-			network_info {
-			  nic_type = "NORMAL_NIC"
-			  subnet {
-				ext_id = data.nutanix_subnets_v2.subnet.subnets[0].ext_id
+			nic_network_info {
+			  virtual_ethernet_nic_network_info {
+				nic_type = "NORMAL_NIC"
+				subnet {
+				  ext_id = data.nutanix_subnets_v2.subnet.subnets[0].ext_id
+				}
+				vlan_mode = "ACCESS"
 			  }
-			  vlan_mode = "ACCESS"
 			}
 		  }
 

--- a/nutanix/services/vmmv2/resource_nutanix_ova_download_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_ova_download_v2_test.go
@@ -43,9 +43,9 @@ func TestAccV2NutanixOvaDownloadResource_DownloadOvaFile(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceNameVMForOva, "disks.0.backing_info.0.vm_disk.0.storage_container.0.ext_id"),
 					resource.TestCheckResourceAttr(resourceNameVMForOva, "disks.0.disk_address.0.bus_type", "SCSI"),
 					resource.TestCheckResourceAttrSet(resourceNameVMForOva, "nics.0.ext_id"),
-					resource.TestCheckResourceAttr(resourceNameVMForOva, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
-					resource.TestCheckResourceAttrSet(resourceNameVMForOva, "nics.0.network_info.0.subnet.0.ext_id"),
-					resource.TestCheckResourceAttr(resourceNameVMForOva, "nics.0.network_info.0.vlan_mode", "TRUNK"),
+					resource.TestCheckResourceAttr(resourceNameVMForOva, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttrSet(resourceNameVMForOva, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.subnet.0.ext_id"),
+					resource.TestCheckResourceAttr(resourceNameVMForOva, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "TRUNK"),
 
 					// ova checks
 					resource.TestCheckResourceAttrSet(resourceNameOva, "ext_id"),
@@ -71,7 +71,7 @@ func TestAccV2NutanixOvaDownloadResource_DownloadOvaFile(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceNameOva, "vm_config.0.disks.0.backing_info.0.vm_disk.0.disk_size_bytes", resourceNameVMForOva, "disks.0.backing_info.0.vm_disk.0.disk_size_bytes"),
 					resource.TestCheckResourceAttrPair(resourceNameOva, "vm_config.0.disks.0.disk_address.0.bus_type", resourceNameVMForOva, "disks.0.disk_address.0.bus_type"),
 					resource.TestCheckResourceAttrPair(resourceNameOva, "vm_config.0.nics.#", resourceNameVMForOva, "nics.#"),
-					resource.TestCheckResourceAttrPair(resourceNameOva, "vm_config.0.nics.0.network_info.0.nic_type", resourceNameVMForOva, "nics.0.network_info.0.nic_type"),
+					resource.TestCheckResourceAttrPair(resourceNameOva, "vm_config.0.nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", resourceNameVMForOva, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type"),
 
 					// ova Download Checks
 					resource.TestCheckResourceAttrPair(resourceNameOvaDownload, "ova_ext_id", resourceNameOva, "ext_id"),
@@ -131,13 +131,15 @@ resource "nutanix_virtual_machine_v2" "ova-vm" {
     }
   }
   nics {
-    network_info {
-      nic_type = "NORMAL_NIC"
-      subnet {
-        ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+    nic_network_info {
+      virtual_ethernet_nic_network_info {
+        nic_type = "NORMAL_NIC"
+        subnet {
+          ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+        }
+        vlan_mode     = "TRUNK"
+        trunked_vlans = ["1"]
       }
-      vlan_mode     = "TRUNK"
-      trunked_vlans = ["1"]
     }
   }
   memory_size_bytes = 4 * 1024 * 1024 * 1024 # 4 GiB

--- a/nutanix/services/vmmv2/resource_nutanix_ova_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_ova_v2_test.go
@@ -46,9 +46,9 @@ func TestAccV2NutanixOvaResource_CreateOvaFromVM(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceNameVMForOva, "disks.0.backing_info.0.vm_disk.0.storage_container.0.ext_id"),
 					resource.TestCheckResourceAttr(resourceNameVMForOva, "disks.0.disk_address.0.bus_type", "SCSI"),
 					resource.TestCheckResourceAttrSet(resourceNameVMForOva, "nics.0.ext_id"),
-					resource.TestCheckResourceAttr(resourceNameVMForOva, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
-					resource.TestCheckResourceAttrSet(resourceNameVMForOva, "nics.0.network_info.0.subnet.0.ext_id"),
-					resource.TestCheckResourceAttr(resourceNameVMForOva, "nics.0.network_info.0.vlan_mode", "TRUNK"),
+					resource.TestCheckResourceAttr(resourceNameVMForOva, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttrSet(resourceNameVMForOva, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.subnet.0.ext_id"),
+					resource.TestCheckResourceAttr(resourceNameVMForOva, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "TRUNK"),
 
 					// ova checks
 					resource.TestCheckResourceAttrSet(resourceNameOva, "ext_id"),
@@ -74,7 +74,7 @@ func TestAccV2NutanixOvaResource_CreateOvaFromVM(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceNameOva, "vm_config.0.disks.0.backing_info.0.vm_disk.0.disk_size_bytes", resourceNameVMForOva, "disks.0.backing_info.0.vm_disk.0.disk_size_bytes"),
 					resource.TestCheckResourceAttrPair(resourceNameOva, "vm_config.0.disks.0.disk_address.0.bus_type", resourceNameVMForOva, "disks.0.disk_address.0.bus_type"),
 					resource.TestCheckResourceAttrPair(resourceNameOva, "vm_config.0.nics.#", resourceNameVMForOva, "nics.#"),
-					resource.TestCheckResourceAttrPair(resourceNameOva, "vm_config.0.nics.0.network_info.0.nic_type", resourceNameVMForOva, "nics.0.network_info.0.nic_type"),
+					resource.TestCheckResourceAttrPair(resourceNameOva, "vm_config.0.nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", resourceNameVMForOva, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type"),
 				),
 			},
 			// update ova
@@ -228,13 +228,15 @@ resource "nutanix_virtual_machine_v2" "ova-vm" {
     }
   }
   nics {
-    network_info {
-      nic_type = "NORMAL_NIC"
-      subnet {
-        ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+    nic_network_info {
+      virtual_ethernet_nic_network_info {
+        nic_type = "NORMAL_NIC"
+        subnet {
+          ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+        }
+        vlan_mode     = "TRUNK"
+        trunked_vlans = ["1"]
       }
-      vlan_mode     = "TRUNK"
-      trunked_vlans = ["1"]
     }
   }
   memory_size_bytes = 4 * 1024 * 1024 * 1024 # 4 GiB

--- a/nutanix/services/vmmv2/resource_nutanix_ova_vm_deploy_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_ova_vm_deploy_v2.go
@@ -482,7 +482,7 @@ func ResourceNutanixOvaVMDeploymentCreate(ctx context.Context, d *schema.Resourc
 				overrideSpec.Categories = expandCategoryReference(cats.([]interface{}))
 			}
 			if nics, ok := ovm["nics"]; ok {
-				overrideSpec.Nics = expandNic(nics.([]interface{}))
+				overrideSpec.Nics = expandNic(nics.([]interface{}), nil, "")
 			}
 			if cdroms, ok := ovm["cd_roms"]; ok {
 				overrideSpec.CdRoms = expandCdRom(cdroms.([]interface{}))

--- a/nutanix/services/vmmv2/resource_nutanix_ova_vm_deploy_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_ova_vm_deploy_v2_test.go
@@ -31,7 +31,7 @@ func TestAccV2NutanixOvaVmDeployResource_DeployVMFromOva(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameOvaVMDeploy, "override_vm_config.0.name", fmt.Sprintf("%s-from-ova", vmName)),
 					resource.TestCheckResourceAttr(resourceNameOvaVMDeploy, "override_vm_config.0.memory_size_bytes", strconv.Itoa(8*1024*1024*1024)), // 8GB
 					resource.TestCheckResourceAttr(resourceNameOvaVMDeploy, "override_vm_config.0.nics.#", "1"),
-					resource.TestCheckResourceAttr(resourceNameOvaVMDeploy, "override_vm_config.0.nics.0.network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(resourceNameOvaVMDeploy, "override_vm_config.0.nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
 
 					// vm data source checks
 					resource.TestCheckResourceAttr(datasourceVMFromOva, "vms.#", "1"),
@@ -42,7 +42,7 @@ func TestAccV2NutanixOvaVmDeployResource_DeployVMFromOva(t *testing.T) {
 					resource.TestCheckResourceAttr(datasourceVMFromOva, "vms.0.disks.#", "1"),
 					resource.TestCheckResourceAttr(datasourceVMFromOva, "vms.0.disks.0.disk_address.0.bus_type", "SCSI"),
 					resource.TestCheckResourceAttr(datasourceVMFromOva, "vms.0.nics.#", "1"),
-					resource.TestCheckResourceAttr(datasourceVMFromOva, "vms.0.nics.0.network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(datasourceVMFromOva, "vms.0.nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
 					resource.TestCheckResourceAttr(datasourceVMFromOva, "vms.0.num_cores_per_socket", "4"),
 					resource.TestCheckResourceAttr(datasourceVMFromOva, "vms.0.num_sockets", "2"),
 					resource.TestCheckResourceAttr(datasourceVMFromOva, "vms.0.num_threads_per_core", "2"),
@@ -225,15 +225,19 @@ resource "nutanix_ova_vm_deploy_v2" "test" {
     num_threads_per_core = 2
     power_state          = "OFF"
     nics {
-      backing_info {
-        is_connected = true
-      }
-      network_info {
-        nic_type = "NORMAL_NIC"
-        subnet {
-          ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+      nic_backing_info {
+        virtual_ethernet_nic {
+          is_connected = true
         }
-        vlan_mode     = "ACCESS"
+      }
+      nic_network_info {
+        virtual_ethernet_nic_network_info {
+          nic_type = "NORMAL_NIC"
+          subnet {
+            ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+          }
+          vlan_mode     = "ACCESS"
+        }
       }
     }
   }
@@ -273,15 +277,19 @@ resource "nutanix_ova_vm_deploy_v2" "test" {
     name              = "tf-test-vm-ova-from-ova"
     memory_size_bytes = 8 * 1024 * 1024 * 1024 # 8 GiB
     nics {
-      backing_info {
-        is_connected = true
-      }
-      network_info {
-        nic_type = "NORMAL_NIC"
-        subnet {
-          ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+      nic_backing_info {
+        virtual_ethernet_nic {
+          is_connected = true
         }
-        vlan_mode     = "ACCESS"
+      }
+      nic_network_info {
+        virtual_ethernet_nic_network_info {
+          nic_type = "NORMAL_NIC"
+          subnet {
+            ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+          }
+          vlan_mode     = "ACCESS"
+        }
       }
     }
   }
@@ -361,15 +369,19 @@ resource "nutanix_ova_vm_deploy_v2" "test" {
     num_threads_per_core = 1                       # updated
     power_state          = "ON"                    # updated
     nics {
-      backing_info {
-        is_connected = true
-      }
-      network_info {
-        nic_type = "NORMAL_NIC"
-        subnet {
-          ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+      nic_backing_info {
+        virtual_ethernet_nic {
+          is_connected = true
         }
-        vlan_mode     = "ACCESS"
+      }
+      nic_network_info {
+        virtual_ethernet_nic_network_info {
+          nic_type = "NORMAL_NIC"
+          subnet {
+            ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+          }
+          vlan_mode     = "ACCESS"
+        }
       }
     }
   }
@@ -453,15 +465,19 @@ resource "nutanix_ova_vm_deploy_v2" "test" {
     num_threads_per_core = 1                       # initial config
     power_state          = "OFF"                   # initial state
     nics {
-      backing_info {
-        is_connected = true
-      }
-      network_info {
-        nic_type = "NORMAL_NIC"
-        subnet {
-          ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+      nic_backing_info {
+        virtual_ethernet_nic {
+          is_connected = true
         }
-        vlan_mode     = "ACCESS"
+      }
+      nic_network_info {
+        virtual_ethernet_nic_network_info {
+          nic_type = "NORMAL_NIC"
+          subnet {
+            ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+          }
+          vlan_mode     = "ACCESS"
+        }
       }
     }
   }
@@ -539,15 +555,19 @@ resource "nutanix_ova_vm_deploy_v2" "test" {
     num_threads_per_core = 2                        # updated config
     power_state          = "ON"                     # updated state
     nics {
-      backing_info {
-        is_connected = true
-      }
-      network_info {
-        nic_type = "NORMAL_NIC"
-        subnet {
-          ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+      nic_backing_info {
+        virtual_ethernet_nic {
+          is_connected = true
         }
-        vlan_mode     = "ACCESS"
+      }
+      nic_network_info {
+        virtual_ethernet_nic_network_info {
+          nic_type = "NORMAL_NIC"
+          subnet {
+            ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+          }
+          vlan_mode     = "ACCESS"
+        }
       }
     }
   }
@@ -664,15 +684,19 @@ resource "nutanix_ova_vm_deploy_v2" "test" {
     num_threads_per_core = 2
     power_state          = "OFF"
     nics {
-      backing_info {
-        is_connected = true
-      }
-      network_info {
-        nic_type = "NORMAL_NIC"
-        subnet {
-          ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+      nic_backing_info {
+        virtual_ethernet_nic {
+          is_connected = true
         }
-        vlan_mode     = "ACCESS"
+      }
+      nic_network_info {
+        virtual_ethernet_nic_network_info {
+          nic_type = "NORMAL_NIC"
+          subnet {
+            ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+          }
+          vlan_mode     = "ACCESS"
+        }
       }
     }
     disks {

--- a/nutanix/services/vmmv2/resource_nutanix_ova_vm_deploy_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_ova_vm_deploy_v2_test.go
@@ -646,20 +646,20 @@ resource "nutanix_virtual_machine_v2" "ova-vm" {
   cluster {
     ext_id = local.cluster_ext_id
   }
-  disks {
-    disk_address {
-      bus_type = "SCSI"
-      index    = 0
-    }
-    backing_info {
-      vm_disk {
-        disk_size_bytes = 10 * 1024 * 1024 * 1024 # 10 GiB
-        storage_container {
-          ext_id = data.nutanix_storage_containers_v2.ngt-sc.storage_containers[0].ext_id
-        }
-      }
-    }
-  }
+  #disks {
+  #  disk_address {
+  #    bus_type = "SCSI"
+  #    index    = 0
+  #  }
+  #  backing_info {
+  #    vm_disk {
+  #      disk_size_bytes = 10 * 1024 * 1024 * 1024 # 10 GiB
+  #      storage_container {
+  #        ext_id = data.nutanix_storage_containers_v2.ngt-sc.storage_containers[0].ext_id
+  #      }
+  #    }
+  #  }
+  #}
   memory_size_bytes = 4 * 1024 * 1024 * 1024 # 4 GiB
   power_state = "OFF"
 }

--- a/nutanix/services/vmmv2/resource_nutanix_ova_vm_deploy_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_ova_vm_deploy_v2_test.go
@@ -646,20 +646,6 @@ resource "nutanix_virtual_machine_v2" "ova-vm" {
   cluster {
     ext_id = local.cluster_ext_id
   }
-  #disks {
-  #  disk_address {
-  #    bus_type = "SCSI"
-  #    index    = 0
-  #  }
-  #  backing_info {
-  #    vm_disk {
-  #      disk_size_bytes = 10 * 1024 * 1024 * 1024 # 10 GiB
-  #      storage_container {
-  #        ext_id = data.nutanix_storage_containers_v2.ngt-sc.storage_containers[0].ext_id
-  #      }
-  #    }
-  #  }
-  #}
   memory_size_bytes = 4 * 1024 * 1024 * 1024 # 4 GiB
   power_state = "OFF"
 }

--- a/nutanix/services/vmmv2/resource_nutanix_template_deploy_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_template_deploy_v2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -97,7 +98,7 @@ func ResourceNutanixTemplateDeployV2Create(ctx context.Context, d *schema.Resour
 		body.ClusterReference = utils.StringPtr(clsRef.(string))
 	}
 	if overrideCfg, ok := d.GetOk("override_vm_config_map"); ok {
-		body.OverrideVmConfigMap = expandVMConfigOverride(overrideCfg)
+		body.OverrideVmConfigMap = expandVMConfigOverride(overrideCfg, d)
 	}
 
 	resp, err := conn.TemplatesAPIInstance.DeployTemplate(utils.StringPtr(extID.(string)), body)
@@ -152,7 +153,7 @@ func ResourceNutanixTemplateDeployV2Delete(ctx context.Context, d *schema.Resour
 	return nil
 }
 
-func expandVMConfigOverride(pr interface{}) map[string]import5.VmConfigOverride {
+func expandVMConfigOverride(pr interface{}, d *schema.ResourceData) map[string]import5.VmConfigOverride {
 	if len(pr.([]interface{})) > 0 {
 		// vmcfg := import5.VmConfigOverride{}
 
@@ -179,7 +180,11 @@ func expandVMConfigOverride(pr interface{}) map[string]import5.VmConfigOverride 
 			vmConfig.MemorySizeBytes = utils.Int64Ptr(int64(mem.(int)))
 		}
 		if nics, ok := val["nics"]; ok {
-			vmConfig.Nics = expandNic(nics.([]interface{}))
+			nicBasePath := ""
+			if d != nil {
+				nicBasePath = "override_vm_config_map.0.nics"
+			}
+			vmConfig.Nics = expandNic(nics.([]interface{}), d, nicBasePath)
 		}
 		if guest, ok := val["guest_customization"]; ok {
 			vmConfig.GuestCustomization = expandTemplateGuestCustomizationParams(guest)
@@ -191,7 +196,7 @@ func expandVMConfigOverride(pr interface{}) map[string]import5.VmConfigOverride 
 	return nil
 }
 
-func expandNic(pr []interface{}) []config.Nic {
+func expandNic(pr []interface{}, d *schema.ResourceData, basePath string) []config.Nic {
 	if len(pr) > 0 {
 		nicList := make([]config.Nic, len(pr))
 
@@ -210,7 +215,21 @@ func expandNic(pr []interface{}) []config.Nic {
 				nicBackingInfo := config.NewOneOfNicNicBackingInfo()
 
 				if venRaw, ok := nbi["virtual_ethernet_nic"]; ok && venRaw != nil && len(venRaw.([]interface{})) > 0 {
-					ven := expandVirtualEthernetNic(venRaw)
+					var venOpts *VirtualEthernetNicExpandOpts
+					if d != nil && basePath != "" {
+						venPath := basePath + "." + strconv.Itoa(k) + ".nic_backing_info.0.virtual_ethernet_nic.0"
+						if common.IsExplicitlySet(d, venPath+".is_connected") {
+							venOpts = &VirtualEthernetNicExpandOpts{IsConnectedExplicitlySet: true}
+							if venList, ok := venRaw.([]interface{}); ok && len(venList) > 0 {
+								if venMap, ok := venList[0].(map[string]interface{}); ok {
+									if isConn, ok := venMap["is_connected"].(bool); ok {
+										venOpts.IsConnectedValue = isConn
+									}
+								}
+							}
+						}
+					}
+					ven := expandVirtualEthernetNic(venRaw, venOpts)
 					if err := nicBackingInfo.SetValue(ven); err != nil {
 						log.Printf("[ERROR] Error setting value for nic_backing_info.virtual_ethernet_nic: %v", err)
 						diag.Errorf("Error setting value for nic_backing_info.virtual_ethernet_nic: %v", err)
@@ -242,7 +261,21 @@ func expandNic(pr []interface{}) []config.Nic {
 			} else if backingInfo, ok := val["backing_info"]; ok && backingInfo != nil && len(backingInfo.([]interface{})) > 0 {
 				log.Printf("[DEBUG] Expanding legacy backing_info as nic_backing_info")
 				nicBackingInfo := config.NewOneOfNicNicBackingInfo()
-				ven := expandVirtualEthernetNic(backingInfo)
+				var venOpts *VirtualEthernetNicExpandOpts
+				if d != nil && basePath != "" {
+					venPath := basePath + "." + strconv.Itoa(k) + ".backing_info.0"
+					if common.IsExplicitlySet(d, venPath+".is_connected") {
+						venOpts = &VirtualEthernetNicExpandOpts{IsConnectedExplicitlySet: true}
+						if biList, ok := backingInfo.([]interface{}); ok && len(biList) > 0 {
+							if biMap, ok := biList[0].(map[string]interface{}); ok {
+								if isConn, ok := biMap["is_connected"].(bool); ok {
+									venOpts.IsConnectedValue = isConn
+								}
+							}
+						}
+					}
+				}
+				ven := expandVirtualEthernetNic(backingInfo, venOpts)
 				if ven != nil {
 					if err := nicBackingInfo.SetValue(ven); err != nil {
 						log.Printf("[ERROR] Error setting value for nic_backing_info from legacy backing_info: %v", err)
@@ -263,7 +296,7 @@ func expandNic(pr []interface{}) []config.Nic {
 				nni := nniRaw.([]interface{})[0].(map[string]interface{})
 				if venNI, ok := nni["virtual_ethernet_nic_network_info"]; ok && venNI != nil && len(venNI.([]interface{})) > 0 {
 					log.Printf("[DEBUG] Expanding new nic_network_info")
-					ven := expandVirtualEthernetNic(venNI)
+					ven := expandVirtualEthernetNic(venNI, nil)
 					if err := nic.SetNicNetworkInfo(ven); err != nil {
 						log.Printf("[ERROR] Error setting value for nic_network_info.virtual_ethernet_nic_network_info: %v", err)
 						diag.Errorf("Error setting value for nic_network_info.virtual_ethernet_nic_network_info: %v", err)
@@ -290,7 +323,7 @@ func expandNic(pr []interface{}) []config.Nic {
 				log.Printf("[DEBUG] Expanding legacy network_info")
 				// SetNicNetworkInfo expects VirtualEthernetNicNetworkInfo (or other oneof types), not *config.NicNetworkInfo.
 				// expandVirtualEthernetNic maps legacy network_info fields to VirtualEthernetNicNetworkInfo.
-				venNI := expandVirtualEthernetNic(ntwkInfo)
+				venNI := expandVirtualEthernetNic(ntwkInfo, nil)
 				if venNI == nil {
 					log.Printf("[ERROR] Failed to expand legacy network_info")
 					continue

--- a/nutanix/services/vmmv2/resource_nutanix_template_deploy_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_template_deploy_v2.go
@@ -196,6 +196,16 @@ func expandVMConfigOverride(pr interface{}, d *schema.ResourceData) map[string]i
 	return nil
 }
 
+// hasNonEmptyBlock returns true if m[key] is a non-empty list (e.g. one block set).
+func hasNonEmptyBlock(m map[string]interface{}, key string) bool {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return false
+	}
+	list, ok := v.([]interface{})
+	return ok && len(list) > 0
+}
+
 func expandNic(pr []interface{}, d *schema.ResourceData, basePath string) []config.Nic {
 	if len(pr) > 0 {
 		nicList := make([]config.Nic, len(pr))
@@ -208,18 +218,21 @@ func expandNic(pr []interface{}, d *schema.ResourceData, basePath string) []conf
 			if extID, ok := val["ext_id"]; ok && len(extID.(string)) > 0 {
 				nic.ExtId = utils.StringPtr(extID.(string))
 			}
-			// nicPath: when expanding a single nic, basePath may be the full path (e.g. "nics.0"); otherwise basePath is the list path and we append index.
+			// When expanding a single nic (e.g. update path), basePath is already "nics.0"
 			nicPath := ""
 			if basePath != "" {
 				if len(pr) == 1 {
-					nicPath = basePath
+					nicPath = basePath // nicPath = "nics.0"
 				} else {
-					nicPath = basePath + "." + strconv.Itoa(k)
+					nicPath = basePath + "." + strconv.Itoa(k) // nicPath = "nics.1"
 				}
 			}
-			// Prefer new nic_backing_info (v2.4.1+). If not present, fall back to legacy backing_info and
-			// treat it as nic_backing_info.virtual_ethernet_nic to keep old configs working.
-			if nbiRaw, ok := val["nic_backing_info"]; ok && nbiRaw != nil && len(nbiRaw.([]interface{})) > 0 {
+			
+			// Backing: Use the block that the user set in config. When only legacy is set, val's legacy block has desired values; when only new is set, val's new block has them.
+			// Use IsNonEmptyBlockExplicitlySet so that an empty nic_backing_info block in config (e.g. from state merge) does not override legacy backing_info.
+			newBackingSet := d != nil && common.IsNonEmptyBlockExplicitlySet(d, nicPath+".nic_backing_info")
+			useNewBacking := hasNonEmptyBlock(val, "nic_backing_info") && (d == nil || newBackingSet)
+			if nbiRaw, ok := val["nic_backing_info"]; ok && useNewBacking && nbiRaw != nil && len(nbiRaw.([]interface{})) > 0 {
 				nbi := nbiRaw.([]interface{})[0].(map[string]interface{})
 				nicBackingInfo := config.NewOneOfNicNicBackingInfo()
 
@@ -312,9 +325,11 @@ func expandNic(pr []interface{}, d *schema.ResourceData, basePath string) []conf
 					}
 				}
 			}
-			// Prefer new nic_network_info (v2.4.1+). If not present, fall back to legacy network_info and
-			// treat it as nic_network_info.virtual_ethernet_nic_network_info to keep old configs working.
-			if nniRaw, ok := val["nic_network_info"]; ok && nniRaw != nil && len(nniRaw.([]interface{})) > 0 {
+			// Network: Use the block that the user set in config. When only legacy is set, val's legacy block has desired values; when only new is set, val's new block has them.
+			// Use IsNonEmptyBlockExplicitlySet so that an empty nic_network_info block in config (e.g. from state merge) does not override legacy network_info.
+			newNetworkSet := d != nil && common.IsNonEmptyBlockExplicitlySet(d, nicPath+".nic_network_info")
+			useNewNetwork := hasNonEmptyBlock(val, "nic_network_info") && (d == nil || newNetworkSet)
+			if nniRaw, ok := val["nic_network_info"]; ok && useNewNetwork && nniRaw != nil && len(nniRaw.([]interface{})) > 0 {
 				nni := nniRaw.([]interface{})[0].(map[string]interface{})
 				if venNI, ok := nni["virtual_ethernet_nic_network_info"]; ok && venNI != nil && len(venNI.([]interface{})) > 0 {
 					log.Printf("[DEBUG] Expanding new nic_network_info")
@@ -340,6 +355,7 @@ func expandNic(pr []interface{}, d *schema.ResourceData, basePath string) []conf
 						diag.Errorf("Error setting value for nic_network_info.dp_offload_nic_network_info: %v", err)
 						continue
 					}
+					
 				}
 			} else if ntwkInfo, ok := val["network_info"]; ok && ntwkInfo != nil && len(ntwkInfo.([]interface{})) > 0 {
 				log.Printf("[DEBUG] Expanding legacy network_info")
@@ -355,6 +371,7 @@ func expandNic(pr []interface{}, d *schema.ResourceData, basePath string) []conf
 					diag.Errorf("Error setting value for network_info: %v", err)
 					continue
 				}
+				log.Printf("[DEBUG] Network info set successfully")
 			}
 
 			nicList[k] = *nic

--- a/nutanix/services/vmmv2/resource_nutanix_template_deploy_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_template_deploy_v2.go
@@ -231,7 +231,7 @@ func expandNic(pr []interface{}, d *schema.ResourceData, basePath string) []conf
 					nicPath = basePath + suffix
 				}
 			}
-			
+
 			// Backing: Use the block that the user set in config. When only legacy is set, val's legacy block has desired values; when only new is set, val's new block has them.
 			// Use IsNonEmptyBlockExplicitlySet so that an empty nic_backing_info block in config (e.g. from state merge) does not override legacy backing_info.
 			newBackingSet := d != nil && common.IsNonEmptyBlockExplicitlySet(d, nicPath+".nic_backing_info")
@@ -359,7 +359,7 @@ func expandNic(pr []interface{}, d *schema.ResourceData, basePath string) []conf
 						diag.Errorf("Error setting value for nic_network_info.dp_offload_nic_network_info: %v", err)
 						continue
 					}
-					
+
 				}
 			} else if ntwkInfo, ok := val["network_info"]; ok && ntwkInfo != nil && len(ntwkInfo.([]interface{})) > 0 {
 				log.Printf("[DEBUG] Expanding legacy network_info")

--- a/nutanix/services/vmmv2/resource_nutanix_template_deploy_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_template_deploy_v2.go
@@ -208,6 +208,15 @@ func expandNic(pr []interface{}, d *schema.ResourceData, basePath string) []conf
 			if extID, ok := val["ext_id"]; ok && len(extID.(string)) > 0 {
 				nic.ExtId = utils.StringPtr(extID.(string))
 			}
+			// nicPath: when expanding a single nic, basePath may be the full path (e.g. "nics.0"); otherwise basePath is the list path and we append index.
+			nicPath := ""
+			if basePath != "" {
+				if len(pr) == 1 {
+					nicPath = basePath
+				} else {
+					nicPath = basePath + "." + strconv.Itoa(k)
+				}
+			}
 			// Prefer new nic_backing_info (v2.4.1+). If not present, fall back to legacy backing_info and
 			// treat it as nic_backing_info.virtual_ethernet_nic to keep old configs working.
 			if nbiRaw, ok := val["nic_backing_info"]; ok && nbiRaw != nil && len(nbiRaw.([]interface{})) > 0 {
@@ -216,14 +225,27 @@ func expandNic(pr []interface{}, d *schema.ResourceData, basePath string) []conf
 
 				if venRaw, ok := nbi["virtual_ethernet_nic"]; ok && venRaw != nil && len(venRaw.([]interface{})) > 0 {
 					var venOpts *VirtualEthernetNicExpandOpts
-					if d != nil && basePath != "" {
-						venPath := basePath + "." + strconv.Itoa(k) + ".nic_backing_info.0.virtual_ethernet_nic.0"
+					if d != nil && nicPath != "" {
+						venPath := nicPath + ".nic_backing_info.0.virtual_ethernet_nic.0"
+						legacyPath := nicPath + ".backing_info.0"
 						if common.IsExplicitlySet(d, venPath+".is_connected") {
 							venOpts = &VirtualEthernetNicExpandOpts{IsConnectedExplicitlySet: true}
 							if venList, ok := venRaw.([]interface{}); ok && len(venList) > 0 {
 								if venMap, ok := venList[0].(map[string]interface{}); ok {
 									if isConn, ok := venMap["is_connected"].(bool); ok {
 										venOpts.IsConnectedValue = isConn
+									}
+								}
+							}
+						} else if common.IsExplicitlySet(d, legacyPath+".is_connected") {
+							// User may set is_connected only in legacy backing_info; merged config can still have nic_backing_info from state.
+							venOpts = &VirtualEthernetNicExpandOpts{IsConnectedExplicitlySet: true}
+							if biRaw, ok := val["backing_info"]; ok && biRaw != nil {
+								if biList, ok := biRaw.([]interface{}); ok && len(biList) > 0 {
+									if biMap, ok := biList[0].(map[string]interface{}); ok {
+										if isConn, ok := biMap["is_connected"].(bool); ok {
+											venOpts.IsConnectedValue = isConn
+										}
 									}
 								}
 							}
@@ -262,8 +284,8 @@ func expandNic(pr []interface{}, d *schema.ResourceData, basePath string) []conf
 				log.Printf("[DEBUG] Expanding legacy backing_info as nic_backing_info")
 				nicBackingInfo := config.NewOneOfNicNicBackingInfo()
 				var venOpts *VirtualEthernetNicExpandOpts
-				if d != nil && basePath != "" {
-					venPath := basePath + "." + strconv.Itoa(k) + ".backing_info.0"
+				if d != nil && nicPath != "" {
+					venPath := nicPath + ".backing_info.0"
 					if common.IsExplicitlySet(d, venPath+".is_connected") {
 						venOpts = &VirtualEthernetNicExpandOpts{IsConnectedExplicitlySet: true}
 						if biList, ok := backingInfo.([]interface{}); ok && len(biList) > 0 {

--- a/nutanix/services/vmmv2/resource_nutanix_template_deploy_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_template_deploy_v2.go
@@ -101,6 +101,8 @@ func ResourceNutanixTemplateDeployV2Create(ctx context.Context, d *schema.Resour
 		body.OverrideVmConfigMap = expandVMConfigOverride(overrideCfg, d)
 	}
 
+	aJSON, _ := json.MarshalIndent(body, "", "  ")
+	log.Printf("[DEBUG] Payload to deploy template: %s", string(aJSON))
 	resp, err := conn.TemplatesAPIInstance.DeployTemplate(utils.StringPtr(extID.(string)), body)
 	if err != nil {
 		return diag.Errorf("error while deploying template : %v", err)
@@ -129,7 +131,7 @@ func ResourceNutanixTemplateDeployV2Create(ctx context.Context, d *schema.Resour
 	}
 	taskDetails := taskResp.Data.GetValue().(import2.Task)
 
-	aJSON, _ := json.MarshalIndent(taskDetails, "", " ")
+	aJSON, _ = json.MarshalIndent(taskDetails, "", " ")
 	log.Printf("[DEBUG] Template Deploy Task Details: %s", string(aJSON))
 
 	uuid, err := common.ExtractEntityUUIDFromTask(taskDetails, utils.RelEntityTypeVM, "VM")
@@ -167,8 +169,8 @@ func expandVMConfigOverride(pr interface{}, d *schema.ResourceData) map[string]i
 		if name, ok := val["name"]; ok {
 			vmConfig.Name = utils.StringPtr(name.(string))
 		}
-		if sockets, ok := val["sockets"]; ok {
-			vmConfig.NumSockets = utils.IntPtr(sockets.(int))
+		if numSockets, ok := val["num_sockets"]; ok {
+			vmConfig.NumSockets = utils.IntPtr(numSockets.(int))
 		}
 		if cores, ok := val["num_cores_per_socket"]; ok {
 			vmConfig.NumCoresPerSocket = utils.IntPtr(cores.(int))
@@ -218,13 +220,15 @@ func expandNic(pr []interface{}, d *schema.ResourceData, basePath string) []conf
 			if extID, ok := val["ext_id"]; ok && len(extID.(string)) > 0 {
 				nic.ExtId = utils.StringPtr(extID.(string))
 			}
-			// When expanding a single nic (e.g. update path), basePath is already "nics.0"
+			// Path to this NIC in config: either basePath is the list path (e.g. "override_vm_config_map.0.nics")
+			// and we append the index, or basePath is already the path to this nic (e.g. "nics.0" from VM update).
 			nicPath := ""
 			if basePath != "" {
-				if len(pr) == 1 {
-					nicPath = basePath // nicPath = "nics.0"
+				suffix := "." + strconv.Itoa(k)
+				if len(basePath) >= len(suffix) && basePath[len(basePath)-len(suffix):] == suffix {
+					nicPath = basePath
 				} else {
-					nicPath = basePath + "." + strconv.Itoa(k) // nicPath = "nics.1"
+					nicPath = basePath + suffix
 				}
 			}
 			

--- a/nutanix/services/vmmv2/resource_nutanix_template_deploy_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_template_deploy_v2_test.go
@@ -93,17 +93,21 @@ func testTemplateDeployV2Config(name, desc, tempName, tempDesc string) string {
 			  num_cores_per_socket=1
 			  num_threads_per_core=1
 			  nics{
-				backing_info{
-				  is_connected = true
-				  model = "VIRTIO"
-				}
-				network_info {
-				  nic_type = "NORMAL_NIC"
-				  subnet {
-					ext_id = data.nutanix_subnets_v2.subnets.subnets.0.ext_id
+				nic_backing_info{
+				  virtual_ethernet_nic {
+					is_connected = true
+					model = "VIRTIO"
 				  }
-				  vlan_mode = "ACCESS"
-				  should_allow_unknown_macs = false
+				}
+				nic_network_info {
+				  virtual_ethernet_nic_network_info {
+					nic_type = "NORMAL_NIC"
+					subnet {
+					  ext_id = data.nutanix_subnets_v2.subnets.subnets.0.ext_id
+					}
+					vlan_mode = "ACCESS"
+					should_allow_unknown_macs = false
+				  }
 				}
 			  }
 			}

--- a/nutanix/services/vmmv2/resource_nutanix_template_guest_os_actions_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_template_guest_os_actions_v2_test.go
@@ -59,12 +59,14 @@ func testTemplateActionsV2Config(name, desc, tempName, tempDesc string) string {
 				ext_id = local.cluster0
 			}
 			nics{
-				network_info{
-					nic_type = "NORMAL_NIC"
-					subnet{
-						ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
-					}	
-					vlan_mode = "ACCESS"
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+						}	
+						vlan_mode = "ACCESS"
+					}
 				}
 			}
 			power_state = "ON"

--- a/nutanix/services/vmmv2/resource_nutanix_template_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_template_v2.go
@@ -2126,7 +2126,7 @@ func expandTemplateVMSpec(vmSpec interface{}) *vmmConfig.Vm {
 			vm.CdRoms = expandCdRom(cdRoms.([]interface{}))
 		}
 		if nics, ok := vmVal["nics"]; ok {
-			vm.Nics = expandNic(nics.([]interface{}))
+			vm.Nics = expandNic(nics.([]interface{}), nil, "")
 		}
 		if gpus, ok := vmVal["gpus"]; ok {
 			vm.Gpus = expandGpu(gpus.([]interface{}))
@@ -2489,7 +2489,7 @@ func expandVMConfigOverrideTemplate(pr interface{}) *vmmContent.VmConfigOverride
 			cfg.MemorySizeBytes = utils.Int64Ptr(int64(memorySizeBytes.(int)))
 		}
 		if nics, ok := val["nics"]; ok && len(nics.([]interface{})) > 0 {
-			cfg.Nics = expandNic(nics.([]interface{}))
+			cfg.Nics = expandNic(nics.([]interface{}), nil, "")
 		}
 		if guest, ok := val["guest_customization"]; ok && len(guest.([]interface{})) > 0 {
 			cfg.GuestCustomization = expandTemplateGuestCustomizationParams(guest)

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -1844,8 +1845,24 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 			}
 		}
 		if len(updatedNic) > 0 {
+			newNicList := common.InterfaceToSlice(newNic)
 			for _, nic := range updatedNic {
-				nicInput := expandNic([]interface{}{nic}, nil, "")[0]
+				nicMap, _ := nic.(map[string]interface{})
+				extID, _ := nicMap["ext_id"].(string)
+				nicIndex := -1
+				for i, n := range newNicList {
+					if m, ok := n.(map[string]interface{}); ok {
+						if e, _ := m["ext_id"].(string); e == extID {
+							nicIndex = i
+							break
+						}
+					}
+				}
+				basePath := ""
+				if nicIndex >= 0 {
+					basePath = "nics." + strconv.Itoa(nicIndex)
+				}
+				nicInput := expandNic([]interface{}{nic}, d, basePath)[0]
 
 				nicExtID := nicInput.ExtId
 

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -1809,7 +1809,7 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 
 		if len(oldDeletedNic) > 0 {
 			for _, nic := range oldDeletedNic {
-				nicInput := expandNic([]interface{}{nic})[0]
+				nicInput := expandNic([]interface{}{nic}, nil, "")[0]
 
 				nicExtID := nicInput.ExtId
 
@@ -1845,7 +1845,7 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 		}
 		if len(updatedNic) > 0 {
 			for _, nic := range updatedNic {
-				nicInput := expandNic([]interface{}{nic})[0]
+				nicInput := expandNic([]interface{}{nic}, nil, "")[0]
 
 				nicExtID := nicInput.ExtId
 
@@ -1885,7 +1885,7 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 		}
 		if len(newAddedNic) > 0 {
 			for _, nic := range newAddedNic {
-				nicInput := expandNic([]interface{}{nic})[0]
+				nicInput := expandNic([]interface{}{nic}, nil, "")[0]
 
 				ReadVMResp, err := conn.VMAPIInstance.GetVmById(utils.StringPtr(d.Id()))
 				if err != nil {
@@ -3713,7 +3713,7 @@ func prepareVMConfigFromMap(m map[string]interface{}) *config.Vm {
 		body.CdRoms = expandCdRom(cdroms.([]interface{}))
 	}
 	if nics, ok := m["nics"]; ok {
-		body.Nics = expandNic(nics.([]interface{}))
+		body.Nics = expandNic(nics.([]interface{}), nil, "")
 	}
 	if gpus, ok := m["gpus"]; ok {
 		body.Gpus = expandGpu(gpus.([]interface{}))

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
@@ -850,15 +850,16 @@ func testVmsV4Config(name, desc string) string {
 
 func testVmsV4ConfigWithDisk(r int, desc string) string {
 	return fmt.Sprintf(`
-		data "nutanix_clusters_v2" "clusters" {}
+		data "nutanix_clusters_v2" "clusters" {
+			filter = "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"		
+		}
 
-		data "nutanix_subnets_v2" "subnets" {}
+		data "nutanix_subnets_v2" "subnets" {
+			filter = "name eq '${local.vmm.subnet_name}'"
+		}
 
 		locals {
-			cluster0 = [
-			for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
-			cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
-		  ][0]
+			cluster0 = data.nutanix_clusters_v2.clusters.cluster_entities[0].ext_id
 			subnetExtId = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
 			config = jsondecode(file("%[3]s"))
 			vmm = local.config.vmm

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
@@ -165,8 +165,8 @@ func TestAccV2NutanixVmsResource_WithNic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameVms, "disks.0.disk_address.0.bus_type", "SCSI"),
 					resource.TestCheckResourceAttr(resourceNameVms, "disks.0.disk_address.0.index", "0"),
 					resource.TestCheckResourceAttrSet(resourceNameVms, "nics.#"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
 				),
 			},
 		},
@@ -196,9 +196,9 @@ func TestAccV2NutanixVmsResource_WithNicTrunk(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameVms, "disks.0.disk_address.0.bus_type", "SCSI"),
 					resource.TestCheckResourceAttr(resourceNameVms, "disks.0.disk_address.0.index", "0"),
 					resource.TestCheckResourceAttrSet(resourceNameVms, "nics.#"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "TRUNK"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.trunked_vlans.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "TRUNK"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.trunked_vlans.#", "1"),
 				),
 			},
 		},
@@ -226,8 +226,8 @@ func TestAccV2NutanixVmsResource_NicAddRemove(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameVms, "name", name),
 					resource.TestCheckResourceAttr(resourceNameVms, "description", desc),
 					resource.TestCheckResourceAttr(resourceNameVms, "nics.#", "1"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
 				),
 			},
 			// Step 2: Add a second NIC
@@ -237,10 +237,10 @@ func TestAccV2NutanixVmsResource_NicAddRemove(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameVms, "name", name),
 					resource.TestCheckResourceAttr(resourceNameVms, "description", desc),
 					resource.TestCheckResourceAttr(resourceNameVms, "nics.#", "2"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.1.network_info.0.nic_type", "NORMAL_NIC"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.1.network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.1.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.1.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
 				),
 			},
 			// Step 3: Remove the second NIC (back to one NIC)
@@ -251,8 +251,8 @@ func TestAccV2NutanixVmsResource_NicAddRemove(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameVms, "name", name),
 					resource.TestCheckResourceAttr(resourceNameVms, "description", desc),
 					resource.TestCheckResourceAttr(resourceNameVms, "nics.#", "1"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
 				),
 			},
 		},
@@ -474,8 +474,8 @@ func TestAccV2NutanixVmsResource_WithCloudInit(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameVms, "disks.0.disk_address.0.bus_type", "SCSI"),
 					resource.TestCheckResourceAttr(resourceNameVms, "disks.0.disk_address.0.index", "0"),
 					resource.TestCheckResourceAttrSet(resourceNameVms, "nics.#"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
 				),
 			},
 		},
@@ -505,8 +505,8 @@ func TestAccV2NutanixVmsResource_WithSysprep(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameVms, "disks.0.disk_address.0.bus_type", "SCSI"),
 					resource.TestCheckResourceAttr(resourceNameVms, "disks.0.disk_address.0.index", "0"),
 					resource.TestCheckResourceAttrSet(resourceNameVms, "nics.#"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
 					resource.TestCheckResourceAttrSet(resourceNameVms, "cd_roms.#"),
 					resource.TestCheckResourceAttr(resourceNameVms, "cd_roms.0.iso_type", "GUEST_CUSTOMIZATION"),
 				),
@@ -539,8 +539,8 @@ func TestAccV2NutanixVmsResource_WithCloudInitWithCustomKeys(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameVms, "disks.0.disk_address.0.bus_type", "SCSI"),
 					resource.TestCheckResourceAttr(resourceNameVms, "disks.0.disk_address.0.index", "0"),
 					resource.TestCheckResourceAttrSet(resourceNameVms, "nics.#"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
 				),
 			},
 		},
@@ -573,8 +573,8 @@ func TestAccV2NutanixVmsResource_UpdateDiskNics(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameVms, "disks.0.disk_address.0.bus_type", "SCSI"),
 					resource.TestCheckResourceAttr(resourceNameVms, "disks.0.disk_address.0.index", "0"),
 					resource.TestCheckResourceAttr(resourceNameVms, "nics.#", "1"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
 				),
 			},
 			{
@@ -595,8 +595,8 @@ func TestAccV2NutanixVmsResource_UpdateDiskNics(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNameVms, "disks.1.disk_address.0.bus_type", "SCSI"),
 					resource.TestCheckResourceAttr(resourceNameVms, "disks.1.disk_address.0.index", "1"),
 					resource.TestCheckResourceAttr(resourceNameVms, "nics.#", "2"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.nic_type", "NORMAL_NIC"),
-					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
 				),
 			},
 		},
@@ -903,12 +903,14 @@ func testVmsV4ConfigWithDisk(r int, desc string) string {
 				}
 			}
 			nics{
-				network_info{
-					nic_type = "NORMAL_NIC"
-					subnet{
-						ext_id = local.subnetExtId
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = local.subnetExtId
+						}
+						vlan_mode = "ACCESS"
 					}
-					vlan_mode = "ACCESS"
 				}
 			}
 		}
@@ -1050,12 +1052,14 @@ func testVmsV4ConfigWithNic(r int, desc string) string {
 				}
 			}
 			nics{
-				network_info{
-					nic_type = "NORMAL_NIC"
-					subnet{
-						ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+						}
+						vlan_mode = "ACCESS"
 					}
-					vlan_mode = "ACCESS"
 				}
 			}
 			power_state = "ON"
@@ -1108,13 +1112,15 @@ func testVmsV4ConfigWithNicWithTrunkVlan(r int, desc string) string {
 				}
 			}
 			nics{
-				network_info{
-					nic_type = "NORMAL_NIC"
-					subnet{
-						ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+						}
+						vlan_mode = "TRUNK"
+						trunked_vlans = ["1"]
 					}
-					vlan_mode = "TRUNK"
-					trunked_vlans = ["1"]
 				}
 			}
 			power_state = "ON"
@@ -1510,12 +1516,14 @@ func testVmsV4ConfigWithCloudInit(r int, desc string) string {
 				}
 			}
 			nics{
-				network_info{
-					nic_type = "NORMAL_NIC"
-					subnet{
-						ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+						}
+						vlan_mode = "ACCESS"
 					}
-					vlan_mode = "ACCESS"
 				}
 			}
 			guest_customization{
@@ -1584,12 +1592,14 @@ resource "nutanix_virtual_machine_v2" "test"{
 		}
 	}
 	nics{
-		network_info{
-			nic_type = "NORMAL_NIC"
-			subnet{
-				ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+		nic_network_info{
+			virtual_ethernet_nic_network_info{
+				nic_type = "NORMAL_NIC"
+				subnet{
+					ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+				}
+				vlan_mode = "ACCESS"
 			}
-			vlan_mode = "ACCESS"
 		}
 	}
 	guest_customization {
@@ -1660,12 +1670,14 @@ func testVmsV4ConfigWithCloudInitWithCustomKeys(r int, desc string) string {
 				}
 			}
 			nics{
-				network_info{
-					nic_type = "NORMAL_NIC"
-					subnet{
-						ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+						}
+						vlan_mode = "ACCESS"
 					}
-					vlan_mode = "ACCESS"
 				}
 			}
 			guest_customization {
@@ -1738,12 +1750,14 @@ func testVmsV4ConfigWithDiskNic(name string, desc string) string {
 				}
 			}
 			nics{
-				network_info{
-					nic_type = "NORMAL_NIC"
-					subnet{
-						ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+						}
+						vlan_mode = "ACCESS"
 					}
-					vlan_mode = "ACCESS"
 				}
 			}
 			power_state = "ON"
@@ -1810,21 +1824,25 @@ func testVmsV4ConfigWitUpdatedDiskNic(name, desc string) string {
 				}
 			}
 			nics{
-				network_info{
-					nic_type = "NORMAL_NIC"
-					subnet{
-						ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+						}
+						vlan_mode = "ACCESS"
 					}
-					vlan_mode = "ACCESS"
 				}
 			}
 			nics{
-				network_info{
-					nic_type = "NORMAL_NIC"
-					subnet{
-						ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+						}
+						vlan_mode = "ACCESS"
 					}
-					vlan_mode = "ACCESS"
 				}
 			}
 			power_state = "ON"
@@ -1860,12 +1878,14 @@ func testVmsCategoriesV4Config(name, desc string) string {
 				ext_id = local.cluster0
 			}
 			nics{
-				network_info{
-					nic_type = "NORMAL_NIC"
-					subnet{
-						ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+						}
+						vlan_mode = "ACCESS"
 					}
-					vlan_mode = "ACCESS"
 				}
 			}
 			categories{
@@ -1910,12 +1930,14 @@ func testVmsCategoriesV4ConfigUpdate(name, desc string) string {
 				ext_id = local.cluster0
 			}
 			nics{
-				network_info{
-					nic_type = "NORMAL_NIC"
-					subnet{
-						ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+						}
+						vlan_mode = "ACCESS"
 					}
-					vlan_mode = "ACCESS"
 				}
 			}
 			categories{
@@ -2018,12 +2040,14 @@ func testVmsConfigWithSerialPorts(name, desc string, isconn bool) string {
 				ext_id = local.cluster0
 			}
 			nics{
-				network_info{
-					nic_type = "NORMAL_NIC"
-					subnet{
-						ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+						}
+						vlan_mode = "ACCESS"
 					}
-					vlan_mode = "ACCESS"
 				}
 			}
 			serial_ports{
@@ -2100,11 +2124,13 @@ func testVmsV4ConfigWithSingleNic(name, desc string, r int) string {
 				}
 			}
 			nics {
-				network_info {
-					nic_type  = "NORMAL_NIC"
-					vlan_mode = "ACCESS"
-					subnet {
-						ext_id = data.nutanix_subnets_v2.subnet1.subnets[0].ext_id
+				nic_network_info {
+					virtual_ethernet_nic_network_info {
+						nic_type  = "NORMAL_NIC"
+						vlan_mode = "ACCESS"
+						subnet {
+							ext_id = data.nutanix_subnets_v2.subnet1.subnets[0].ext_id
+						}
 					}
 				}
 			}
@@ -2191,11 +2217,13 @@ func testVmsV4ConfigWithSingleNicKeepSubnet(name, desc string, r int) string {
 			}
 			# Only one NIC - removed the second NIC
 			nics {
-				network_info {
-					nic_type  = "NORMAL_NIC"
-					vlan_mode = "ACCESS"
-					subnet {
-						ext_id = data.nutanix_subnets_v2.subnet1.subnets[0].ext_id
+				nic_network_info {
+					virtual_ethernet_nic_network_info {
+						nic_type  = "NORMAL_NIC"
+						vlan_mode = "ACCESS"
+						subnet {
+							ext_id = data.nutanix_subnets_v2.subnet1.subnets[0].ext_id
+						}
 					}
 				}
 			}
@@ -2280,21 +2308,25 @@ func testVmsV4ConfigWithTwoNics(name, desc string, r int) string {
 			}
 			# First NIC - existing subnet
 			nics {
-				network_info {
-					nic_type  = "NORMAL_NIC"
-					vlan_mode = "ACCESS"
-					subnet {
-						ext_id = data.nutanix_subnets_v2.subnet1.subnets[0].ext_id
+				nic_network_info {
+					virtual_ethernet_nic_network_info {
+						nic_type  = "NORMAL_NIC"
+						vlan_mode = "ACCESS"
+						subnet {
+							ext_id = data.nutanix_subnets_v2.subnet1.subnets[0].ext_id
+						}
 					}
 				}
 			}
 			# Second NIC - new test subnet
 			nics {
-				network_info {
-					nic_type  = "NORMAL_NIC"
-					vlan_mode = "ACCESS"
-					subnet {
-						ext_id = nutanix_subnet_v2.test_subnet.ext_id
+				nic_network_info {
+					virtual_ethernet_nic_network_info {
+						nic_type  = "NORMAL_NIC"
+						vlan_mode = "ACCESS"
+						subnet {
+							ext_id = nutanix_subnet_v2.test_subnet.ext_id
+						}
 					}
 				}
 			}

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
@@ -150,7 +150,7 @@ func TestAccV2NutanixVmsResource_WithNic(t *testing.T) {
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testVmsV4ConfigWithNic(r, desc),
+				Config: testVmsV4ConfigWithNic(r, desc, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceNameVms, "name", fmt.Sprintf("tf-test-vm-%d", r)),
 					resource.TestCheckResourceAttr(resourceNameVms, "num_cores_per_socket", "1"),
@@ -167,6 +167,17 @@ func TestAccV2NutanixVmsResource_WithNic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceNameVms, "nics.#"),
 					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
 					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+			{
+				Config: testVmsV4ConfigWithNic(r, desc, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "name", fmt.Sprintf("tf-test-vm-%d", r)),
+					resource.TestCheckResourceAttr(resourceNameVms, "num_cores_per_socket", "1"),
+					resource.TestCheckResourceAttr(resourceNameVms, "description", desc),
+					resource.TestCheckResourceAttr(resourceNameVms, "num_sockets", "1"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "false"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.model", "VIRTIO"),
 				),
 			},
 		},
@@ -1007,7 +1018,7 @@ func testVmsV4ConfigWithDiskWithDatasource(name string, desc string) string {
 `, name, desc, filepath)
 }
 
-func testVmsV4ConfigWithNic(r int, desc string) string {
+func testVmsV4ConfigWithNic(r int, desc string, isConnected bool) string {
 	return fmt.Sprintf(`
 		data "nutanix_clusters_v2" "clusters" {}
 
@@ -1061,10 +1072,16 @@ func testVmsV4ConfigWithNic(r int, desc string) string {
 						vlan_mode = "ACCESS"
 					}
 				}
+				nic_backing_info{
+					virtual_ethernet_nic{
+						is_connected = %[4]t
+						model = "VIRTIO"
+					}
+				}
 			}
 			power_state = "ON"
 		}
-`, r, desc, filepath)
+`, r, desc, filepath, isConnected)
 }
 
 func testVmsV4ConfigWithNicWithTrunkVlan(r int, desc string) string {

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
@@ -344,7 +344,7 @@ func TestAccV2NutanixVmsResource_NicScenariosVlanModeAndIsConnected(t *testing.T
 			},
 			// Step 7: Update with new and old fields having different values -> new fields win
 			{
-				Config: testVmsV4ConfigNicScenariosStep4DifferentValues(r, name, desc),
+				Config:             testVmsV4ConfigNicScenariosStep4DifferentValues(r, name, desc),
 				ExpectNonEmptyPlan: true, // since the new fields are updated and the state is updated with new values for both blocks (expected behavior)
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
@@ -444,7 +444,7 @@ func TestAccV2NutanixVmsResource_NicScenariosCreateWithSameValuesThenUpdates(t *
 			},
 			// 7: Update with new and old different values -> new fields win, state updated for both blocks
 			{
-				Config: testVmsV4ConfigNicScenariosStep4DifferentValues(r, name, desc),
+				Config:             testVmsV4ConfigNicScenariosStep4DifferentValues(r, name, desc),
 				ExpectNonEmptyPlan: true, // since the new fields are updated and the state is updated with new values for both blocks (expected behavior)
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
@@ -1441,7 +1441,6 @@ func testVmsV4ConfigWithNicWithTrunkVlan(r int, desc string) string {
 		}
 `, r, desc, filepath)
 }
-
 
 // testVmsV4ConfigNicScenariosStep1Create: VM with both nic_* and legacy blocks, same values (is_connected=false, vlan_mode=TRUNK).
 func testVmsV4ConfigNicScenariosStep1Create(r int, name, desc string) string {

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
@@ -270,6 +270,302 @@ func TestAccV2NutanixVmsResource_NicAddRemove(t *testing.T) {
 	})
 }
 
+// TestAccV2NutanixVmsResource_NicScenariosVlanModeAndIsConnected covers:
+// 1. Create VM with new fields (nic_backing_info, nic_network_info) and legacy (backing_info, network_info) same values -> plan no changes
+// 2. Update VM with new fields (vlan_mode, is_connected) -> plan no changes
+// 3. Update VM with old fields (vlan_mode, is_connected) -> plan no changes
+// 4. Update VM with new and old fields having different values -> new fields win, state updated for both blocks
+// 5. Update VM with new and old fields with same values -> plan no changes
+// 6. Destroy VM (CheckDestroy)
+func TestAccV2NutanixVmsResource_NicScenariosVlanModeAndIsConnected(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("tf-test-vm-nic-scenarios-%d", r)
+	desc := "test vm for NIC vlan_mode and is_connected scenarios"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckNutanixVmsResourceDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create VM with both new and legacy NIC blocks, same values (is_connected=false, vlan_mode=TRUNK)
+			{
+				Config: testVmsV4ConfigNicScenariosStep1Create(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "name", name),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.model", "VIRTIO"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "false"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type", "NORMAL_NIC"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "TRUNK"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.backing_info.0.is_connected", "false"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "TRUNK"),
+				),
+			},
+			// Idempotent: same config, no change
+			{
+				Config: testVmsV4ConfigNicScenariosStep1Create(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "false"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "TRUNK"),
+				),
+			},
+			// Step 3: Update VM with new fields only (is_connected=true, vlan_mode=ACCESS)
+			{
+				Config: testVmsV4ConfigNicScenariosStep2UpdateNewFields(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+			// Idempotent after update with new fields
+			{
+				Config: testVmsV4ConfigNicScenariosStep2UpdateNewFields(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+			// Step 5: Update VM with old fields only (same values is_connected=true, vlan_mode=ACCESS) -> plan no changes
+			{
+				Config: testVmsV4ConfigNicScenariosStep3UpdateOldFields(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.backing_info.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+			// Idempotent after update with old fields
+			{
+				Config: testVmsV4ConfigNicScenariosStep3UpdateOldFields(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.backing_info.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+			// Step 7: Update with new and old fields having different values -> new fields win
+			{
+				Config: testVmsV4ConfigNicScenariosStep4DifferentValues(r, name, desc),
+				ExpectNonEmptyPlan: true, // since the new fields are updated and the state is updated with new values for both blocks (expected behavior)
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.backing_info.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+			// Step 8: Update with new and old fields same values -> plan no changes
+			{
+				Config: testVmsV4ConfigNicScenariosStep5SameValues(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.backing_info.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+			// Idempotent: same config
+			{
+				Config: testVmsV4ConfigNicScenariosStep5SameValues(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccV2NutanixVmsResource_NicScenariosCreateWithSameValuesThenUpdates covers:
+// 13. Create the vm with new fields and old fields with same values -> new fields values -> terraform plan no changes
+// 14. Update the vm with new fields -> terraform plan no changes
+// 15. Update the vm with old fields -> terraform plan no changes
+// 16. Update the vm with new fields and old fields with different values -> taking new fields values -> state updated for both blocks (expected behavior)
+// 17. Update the vm with new fields and old fields with same values -> new fields values -> terraform plan no changes
+// 18. Delete the vm -> terraform destroy (CheckDestroy)
+func TestAccV2NutanixVmsResource_NicScenariosCreateWithSameValuesThenUpdates(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("tf-test-vm-nic-same-then-updates-%d", r)
+	desc := "test vm for NIC scenarios 13-18 (create with same values then updates)"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckNutanixVmsResourceDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create VM with new fields and old fields with same values -> plan no changes
+			{
+				Config: testVmsV4ConfigNicScenariosStep1Create(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "name", name),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "false"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "TRUNK"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.backing_info.0.is_connected", "false"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "TRUNK"),
+				),
+			},
+			{
+				Config: testVmsV4ConfigNicScenariosStep1Create(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "false"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "TRUNK"),
+				),
+			},
+			// Step 3: Update the vm with new fields -> plan no changes
+			{
+				Config: testVmsV4ConfigNicScenariosStep2UpdateNewFields(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+			{
+				Config: testVmsV4ConfigNicScenariosStep2UpdateNewFields(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+			// Step 5: Update the vm with old fields -> plan no changes
+			{
+				Config: testVmsV4ConfigNicScenariosStep3UpdateOldFields(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.backing_info.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+			{
+				Config: testVmsV4ConfigNicScenariosStep3UpdateOldFields(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.backing_info.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+			// 7: Update with new and old different values -> new fields win, state updated for both blocks
+			{
+				Config: testVmsV4ConfigNicScenariosStep4DifferentValues(r, name, desc),
+				ExpectNonEmptyPlan: true, // since the new fields are updated and the state is updated with new values for both blocks (expected behavior)
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.backing_info.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+			// Step 8: Update with new and old same values -> plan no changes
+			{
+				Config: testVmsV4ConfigNicScenariosStep5SameValues(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.backing_info.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+			{
+				Config: testVmsV4ConfigNicScenariosStep5SameValues(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccV2NutanixVmsResource_NicScenariosCreateWithDifferentValuesThenUpdates covers (main.tf scenarios 19-23):
+// 19. Create the vm with new fields and old fields with different values -> taking new fields values -> state updated with new values for both blocks (expected behavior)
+// 20. Update the vm with new fields -> terraform plan no changes
+// 21. Update the vm with old fields -> terraform plan no changes
+// 22. Update the vm with new fields and old fields with same values -> new fields values -> terraform plan no changes
+// 23. Update the vm with new fields and old fields with different values -> taking new fields values -> state updated (expected behavior)
+func TestAccV2NutanixVmsResource_NicScenariosCreateWithDifferentValuesThenUpdates(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("tf-test-vm-nic-diff-then-updates-%d", r)
+	desc := "test vm for NIC scenarios 19-23 (create with different values then updates)"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckNutanixVmsResourceDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create VM with new and old fields having different values -> new wins, state updated for both blocks
+			{
+				Config:             testVmsV4ConfigNicScenariosStep4DifferentValues(r, name, desc),
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "name", name),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.backing_info.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+			// Step 2: Update the vm with new fields -> plan no changes
+			{
+				Config: testVmsV4ConfigNicScenariosStep1Create(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "false"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "TRUNK"),
+				),
+			},
+			{
+				Config: testVmsV4ConfigNicScenariosStep1Create(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "false"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "TRUNK"),
+				),
+			},
+			// Step 4: Update the vm with old fields -> plan no changes
+			{
+				Config: testVmsV4ConfigNicScenariosLegacyOnly(r, name, desc, false, "TRUNK"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.backing_info.0.is_connected", "false"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "TRUNK"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "false"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "TRUNK"),
+				),
+			},
+			{
+				Config: testVmsV4ConfigNicScenariosLegacyOnly(r, name, desc, false, "TRUNK"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.backing_info.0.is_connected", "false"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "TRUNK"),
+				),
+			},
+			// Step 6: Update with new and old same values -> plan no changes
+			{
+				Config: testVmsV4ConfigNicScenariosStep5SameValues(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.backing_info.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+			{
+				Config: testVmsV4ConfigNicScenariosStep5SameValues(r, name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+			// Step 8: Update with new and old different values -> new wins, state updated
+			{
+				Config:             testVmsV4ConfigNicScenariosStep4DifferentValues(r, name, desc),
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_backing_info.0.virtual_ethernet_nic.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.vlan_mode", "ACCESS"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.backing_info.0.is_connected", "true"),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.network_info.0.vlan_mode", "ACCESS"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccV2NutanixVmsResource_WithLegacyBootOrder(t *testing.T) {
 	r := acctest.RandInt()
 	name := fmt.Sprintf("tf-test-vm-%d", r)
@@ -1144,6 +1440,142 @@ func testVmsV4ConfigWithNicWithTrunkVlan(r int, desc string) string {
 			power_state = "ON"
 		}
 `, r, desc, filepath)
+}
+
+
+// testVmsV4ConfigNicScenariosStep1Create: VM with both nic_* and legacy blocks, same values (is_connected=false, vlan_mode=TRUNK).
+func testVmsV4ConfigNicScenariosStep1Create(r int, name, desc string) string {
+	return testVmsV4ConfigNicScenariosWithParams(r, name, desc, false, "TRUNK", false, "TRUNK")
+}
+
+// testVmsV4ConfigNicScenariosStep2UpdateNewFields: update using new fields (is_connected=true, vlan_mode=ACCESS); both blocks same.
+func testVmsV4ConfigNicScenariosStep2UpdateNewFields(r int, name, desc string) string {
+	return testVmsV4ConfigNicScenariosWithParams(r, name, desc, true, "ACCESS", true, "ACCESS")
+}
+
+// testVmsV4ConfigNicScenariosStep3UpdateOldFields: config with only legacy blocks (is_connected=true, vlan_mode=ACCESS).
+func testVmsV4ConfigNicScenariosStep3UpdateOldFields(r int, name, desc string) string {
+	return testVmsV4ConfigNicScenariosLegacyOnly(r, name, desc, true, "ACCESS")
+}
+
+// testVmsV4ConfigNicScenariosStep4DifferentValues: new fields is_connected=true, vlan_mode=ACCESS; legacy is_connected=false, vlan_mode=TRUNK. New wins.
+func testVmsV4ConfigNicScenariosStep4DifferentValues(r int, name, desc string) string {
+	return testVmsV4ConfigNicScenariosWithParams(r, name, desc, true, "ACCESS", false, "TRUNK")
+}
+
+// testVmsV4ConfigNicScenariosStep5SameValues: both blocks same (is_connected=true, vlan_mode=ACCESS).
+func testVmsV4ConfigNicScenariosStep5SameValues(r int, name, desc string) string {
+	return testVmsV4ConfigNicScenariosWithParams(r, name, desc, true, "ACCESS", true, "ACCESS")
+}
+
+// testVmsV4ConfigNicScenariosBase returns shared VM config (data sources, cluster, disks) with the given nics block injected.
+func testVmsV4ConfigNicScenariosBase(name, desc, nicsBlock string) string {
+	return fmt.Sprintf(`
+		data "nutanix_clusters_v2" "clusters" {}
+
+		locals {
+			cluster0 = [
+				for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+				cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+			][0]
+			config = jsondecode(file("%[3]s"))
+			vmm = local.config.vmm
+		}
+
+		data "nutanix_subnets_v2" "subnets" {
+			filter = "name eq '${local.vmm.subnet_name}'"
+		}
+
+		data "nutanix_storage_containers_v2" "ngt-sc" {
+			filter = "clusterExtId eq '${local.cluster0}'"
+			limit  = 1
+		}
+
+		resource "nutanix_virtual_machine_v2" "test" {
+			name                 = "%[1]s"
+			description          = "%[2]s"
+			num_cores_per_socket  = 1
+			num_sockets           = 1
+			cluster {
+				ext_id = local.cluster0
+			}
+			disks {
+				disk_address {
+					bus_type = "SCSI"
+					index    = 0
+				}
+				backing_info {
+					vm_disk {
+						disk_size_bytes = "1073741824"
+						storage_container {
+							ext_id = data.nutanix_storage_containers_v2.ngt-sc.storage_containers[0].ext_id
+						}
+					}
+				}
+			}
+			%[4]s
+			power_state = "OFF"
+		}
+`, name, desc, filepath, nicsBlock)
+}
+
+// testVmsV4ConfigNicScenariosNicsBlock returns the nics block for both nic_* and legacy (same structure as main.tf).
+func testVmsV4ConfigNicScenariosNicsBlock(newIsConnected bool, newVlanMode string, legacyIsConnected bool, legacyVlanMode string) string {
+	return fmt.Sprintf(`nics {
+				nic_backing_info {
+					virtual_ethernet_nic {
+						model        = "VIRTIO"
+						is_connected = %[1]t
+					}
+				}
+				nic_network_info {
+					virtual_ethernet_nic_network_info {
+						nic_type = "NORMAL_NIC"
+						subnet {
+							ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+						}
+						vlan_mode = "%[2]s"
+					}
+				}
+				backing_info {
+					model        = "VIRTIO"
+					is_connected = %[3]t
+				}
+				network_info {
+					nic_type = "NORMAL_NIC"
+					subnet {
+						ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+					}
+					vlan_mode = "%[4]s"
+				}
+			}`, newIsConnected, newVlanMode, legacyIsConnected, legacyVlanMode)
+}
+
+// testVmsV4ConfigNicScenariosNicsBlockLegacyOnly returns the nics block with only legacy backing_info and network_info.
+func testVmsV4ConfigNicScenariosNicsBlockLegacyOnly(isConnected bool, vlanMode string) string {
+	return fmt.Sprintf(`nics {
+				backing_info {
+					model        = "VIRTIO"
+					is_connected = %[1]t
+				}
+				network_info {
+					nic_type = "NORMAL_NIC"
+					subnet {
+						ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+					}
+					vlan_mode = "%[2]s"
+				}
+			}`, isConnected, vlanMode)
+}
+
+// testVmsV4ConfigNicScenariosWithParams: VM with both nic_* and legacy blocks; newIsConnected/newVlanMode for nic_*, legacyIsConnected/legacyVlanMode for legacy.
+func testVmsV4ConfigNicScenariosWithParams(r int, name, desc string, newIsConnected bool, newVlanMode string, legacyIsConnected bool, legacyVlanMode string) string {
+	return testVmsV4ConfigNicScenariosBase(name, desc, testVmsV4ConfigNicScenariosNicsBlock(newIsConnected, newVlanMode, legacyIsConnected, legacyVlanMode))
+}
+
+// testVmsV4ConfigNicScenariosLegacyOnly: VM with only legacy backing_info and network_info (for "update with old fields" scenario).
+func testVmsV4ConfigNicScenariosLegacyOnly(r int, name, desc string, isConnected bool, vlanMode string) string {
+	return testVmsV4ConfigNicScenariosBase(name, desc, testVmsV4ConfigNicScenariosNicsBlockLegacyOnly(isConnected, vlanMode))
 }
 
 func testVmsV4ConfigWithLegacyBoot(name, desc string) string {

--- a/nutanix/services/vmmv2/resource_nutanix_vms_clone_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vms_clone_v2_test.go
@@ -139,12 +139,14 @@ func testVmsCloneV2Config(name, desc string) string {
 				}
 			}
 			nics {
-				network_info {
-				  nic_type = "NORMAL_NIC"
-				  subnet {
-					ext_id = data.nutanix_subnets_v2.subnet.subnets[0].ext_id
+				nic_network_info {
+				  virtual_ethernet_nic_network_info {
+					nic_type = "NORMAL_NIC"
+					subnet {
+					  ext_id = data.nutanix_subnets_v2.subnet.subnets[0].ext_id
+					}
+					vlan_mode = "ACCESS"
 				  }
-				  vlan_mode = "ACCESS"
 				}
 		    }
 			// guest_customization{
@@ -264,12 +266,14 @@ func testVmsCloneV2WithGuestCustomizationConfig(name, desc string) string {
 		  }
 
 		  nics {
-			network_info {
-			  nic_type = "NORMAL_NIC"
-			  subnet {
-				ext_id = data.nutanix_subnets_v2.subnet.subnets[0].ext_id
+			nic_network_info {
+			  virtual_ethernet_nic_network_info {
+				nic_type = "NORMAL_NIC"
+				subnet {
+				  ext_id = data.nutanix_subnets_v2.subnet.subnets[0].ext_id
+				}
+				vlan_mode = "ACCESS"
 			  }
-			  vlan_mode = "ACCESS"
 			}
 		  }
 		  power_state = "OFF"

--- a/nutanix/services/vmmv2/resource_nutanix_vms_network_device_assign_ip_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vms_network_device_assign_ip_v2_test.go
@@ -126,12 +126,14 @@ func testVMWithNicAndDiskConfig(vmName string) string {
 		  }
        
           nics {
-			network_info {
-			  nic_type = "DIRECT_NIC"
-			  subnet {
-				ext_id = nutanix_subnet_v2.subnet.ext_id
+			nic_network_info {
+			  virtual_ethernet_nic_network_info {
+				nic_type = "DIRECT_NIC"
+				subnet {
+				  ext_id = nutanix_subnet_v2.subnet.ext_id
+				}
+				vlan_mode = "ACCESS"
 			  }
-			  vlan_mode = "ACCESS"
 			}
 		  }	  
 				  

--- a/nutanix/services/vmmv2/resource_nutanix_vms_shutdown_actions_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vms_shutdown_actions_v2_test.go
@@ -261,12 +261,14 @@ func testVMV2Config(name, desc, powerState string) string {
 			}
 			
 			nics {
-				network_info {
-				  nic_type = "NORMAL_NIC"
-				  subnet {
-					ext_id = data.nutanix_subnets_v2.subnet.subnets[0].ext_id
+				nic_network_info {
+				  virtual_ethernet_nic_network_info {
+					nic_type = "NORMAL_NIC"
+					subnet {
+					  ext_id = data.nutanix_subnets_v2.subnet.subnets[0].ext_id
+					}
+					vlan_mode = "ACCESS"
 				  }
-				  vlan_mode = "ACCESS"
 				}
 			}
 			
@@ -346,12 +348,14 @@ func testVmsShutdownV4ConfigWithError(name, desc, state string) string {
 				ext_id = local.cluster0
 			}
 			nics{
-				network_info{
-					nic_type = "NORMAL_NIC"
-					subnet{
-						ext_id = data.nutanix_subnets_v2.subnets.subnets.0.ext_id
-					}	
-					vlan_mode = "ACCESS"
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets.0.ext_id
+						}	
+						vlan_mode = "ACCESS"
+					}
 				}
 			}
 			disks{

--- a/nutanix/services/vmmv2/vmm_helper.go
+++ b/nutanix/services/vmmv2/vmm_helper.go
@@ -6,13 +6,21 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/utils"
 )
 
+// VirtualEthernetNicExpandOpts carries optional expansion hints from the Terraform config (e.g. whether is_connected was explicitly set).
+// Used so that updating is_connected from true to false is detected via common.IsExplicitlySet instead of relying on the config map alone.
+type VirtualEthernetNicExpandOpts struct {
+	IsConnectedExplicitlySet bool
+	IsConnectedValue         bool
+}
+
 // Expand helper functions for VMM v2
 // expandVirtualEthernetNic expands either:
 // - nic_backing_info.virtual_ethernet_nic (VirtualEthernetNic), OR
 // - nic_network_info.virtual_ethernet_nic_network_info (VirtualEthernetNicNetworkInfo).
 //
 // It returns the concrete (non-pointer) SDK object to satisfy OneOf setters, or nil if empty.
-func expandVirtualEthernetNic(pr interface{}) interface{} {
+// When opts is non-nil and IsConnectedExplicitlySet is true, is_connected is taken from opts (so false is applied correctly).
+func expandVirtualEthernetNic(pr interface{}, opts *VirtualEthernetNicExpandOpts) interface{} {
 	if pr == nil {
 		return nil
 	}
@@ -35,8 +43,12 @@ func expandVirtualEthernetNic(pr interface{}) interface{} {
 		if mac, ok := val["mac_address"]; ok && mac != nil && mac.(string) != "" {
 			ven.MacAddress = utils.StringPtr(mac.(string))
 		}
-		if isConn, ok := val["is_connected"]; ok && isConn != nil {
-			ven.IsConnected = utils.BoolPtr(isConn.(bool))
+		if opts != nil && opts.IsConnectedExplicitlySet {
+			ven.IsConnected = utils.BoolPtr(opts.IsConnectedValue)
+		} else if opts == nil {
+			if isConn, ok := val["is_connected"]; ok && isConn != nil {
+				ven.IsConnected = utils.BoolPtr(isConn.(bool))
+			}
 		}
 		if nq, ok := val["num_queues"]; ok && nq != nil {
 			ven.NumQueues = utils.IntPtr(nq.(int))

--- a/nutanix/services/vmmv2/vmm_schema.go
+++ b/nutanix/services/vmmv2/vmm_schema.go
@@ -17,7 +17,7 @@ func nicsElemSchemaV2() *schema.Resource {
 				Type:       schema.TypeList,
 				Optional:   true,
 				Computed:   true,
-				Deprecated: "The `backing_info` block is deprecated. Use `nic_backing_info` instead. This field will be removed in a future release.",
+				Deprecated: "The `backing_info` attribute is deprecated. Use `nic_backing_info` instead. This field will be removed in a future release.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"model": {
@@ -48,7 +48,7 @@ func nicsElemSchemaV2() *schema.Resource {
 				Type:       schema.TypeList,
 				Optional:   true,
 				Computed:   true,
-				Deprecated: "The `network_info` block is deprecated. Use `nic_network_info` instead. This field will be removed in a future release.",
+				Deprecated: "The `network_info` attribute is deprecated. Use `nic_network_info` instead. This field will be removed in a future release.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"nic_type": {

--- a/nutanix/services/vmmv2/vmm_schema.go
+++ b/nutanix/services/vmmv2/vmm_schema.go
@@ -48,7 +48,7 @@ func nicsElemSchemaV2() *schema.Resource {
 				Type:       schema.TypeList,
 				Optional:   true,
 				Computed:   true,
-				Deprecated: "Use `nic_backing_info` instead. This field will be removed in a future release.",
+				Deprecated: "Use `nic_network_info` instead. This field will be removed in a future release.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"nic_type": {

--- a/nutanix/services/vmmv2/vmm_schema.go
+++ b/nutanix/services/vmmv2/vmm_schema.go
@@ -17,7 +17,7 @@ func nicsElemSchemaV2() *schema.Resource {
 				Type:       schema.TypeList,
 				Optional:   true,
 				Computed:   true,
-				Deprecated: "Use `nic_backing_info` instead. This field will be removed in a future release.",
+				Deprecated: "The `backing_info` block is deprecated. Use `nic_backing_info` instead. This field will be removed in a future release.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"model": {
@@ -48,7 +48,7 @@ func nicsElemSchemaV2() *schema.Resource {
 				Type:       schema.TypeList,
 				Optional:   true,
 				Computed:   true,
-				Deprecated: "Use `nic_network_info` instead. This field will be removed in a future release.",
+				Deprecated: "The `network_info` block is deprecated. Use `nic_network_info` instead. This field will be removed in a future release.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"nic_type": {

--- a/website/docs/r/ova_vm_deploy_v2.html.markdown
+++ b/website/docs/r/ova_vm_deploy_v2.html.markdown
@@ -23,16 +23,20 @@ resource "nutanix_ova_vm_deploy_v2" "test" {
     name              = "vm-from-ova"
     memory_size_bytes = 8 * 1024 * 1024 * 1024 # 8 GiB
     nics {
-      backing_info {
-        is_connected = true
-      }
-      network_info {
-        nic_type = "NORMAL_NIC"
-        subnet {
-          ext_id = "9bd6cbc2-a592-4728-ab89-473612f46b99"
+      nic_backing_info {
+        virtual_ethernet_nic {
+          is_connected = true
         }
-        vlan_mode     = "TRUNK"
-        trunked_vlans = ["1"]
+      }
+      nic_network_info {
+        virtual_ethernet_nic_network_info {
+          nic_type = "NORMAL_NIC"
+          subnet {
+            ext_id = "9bd6cbc2-a592-4728-ab89-473612f46b99"
+          }
+          vlan_mode     = "TRUNK"
+          trunked_vlans = ["1"]
+        }
       }
     }
     disks {

--- a/website/docs/r/virtual_machine_v2.html.markdown
+++ b/website/docs/r/virtual_machine_v2.html.markdown
@@ -131,12 +131,14 @@ resource "nutanix_virtual_machine_v2" "vm-3" {
   }
 
   nics {
-    network_info {
+    nic_network_info {
+      virtual_ethernet_nic_network_info {
       nic_type = "NORMAL_NIC"
-      subnet {
-        ext_id = "7f66e20f-67f4-473f-96bb-c4fcfd487f16"
+        subnet {
+          ext_id = "7f66e20f-67f4-473f-96bb-c4fcfd487f16"
+        }
+        vlan_mode = "ACCESS"
       }
-      vlan_mode = "ACCESS"
     }
   }
 


### PR DESCRIPTION

## Summary

This PR updates the VMM v2 resources and tests to use the preferred NIC attributes and nested block structure, and fixes detection of explicit `is_connected` changes (e.g. from `true` to `false`) .

## Changes

### 1. Prefer `nic_backing_info` and `nic_network_info` (deprecate `backing_info` / `network_info`)

- **Schema (`vmm_schema.go`):** Corrected deprecation message for `network_info` to direct users to `nic_network_info`.
- **Tests:** All VMM v2 tests now use:
  - `nic_backing_info` with nested `virtual_ethernet_nic` (instead of flat or legacy `backing_info`).
  - `nic_network_info` with nested `virtual_ethernet_nic_network_info` (instead of flat or legacy `network_info`).
- **Assertions:** `TestCheckResourceAttr` paths updated to the new schema, e.g. `nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.nic_type`.

### 2. Fix `is_connected` change detection (true → false)

- **Issue:** Updating `is_connected` from `true` to `false` in config was not always reflected in the plan/apply because the expand logic relied on the config map, which can omit or mishandle explicit `false`.
- **Fix:** Use `common.IsExplicitlySet()` when expanding NIC backing info so that an explicitly set `is_connected` (including `false`) is applied.
- **Implementation:**
  - **`vmm_helper.go`:** Introduced `VirtualEthernetNicExpandOpts` and extended `expandVirtualEthernetNic(pr, opts)`. When `opts != nil` and `IsConnectedExplicitlySet` is true, `is_connected` is taken from opts; otherwise legacy behavior is preserved when `opts == nil`.
  - **`resource_nutanix_template_deploy_v2.go`:** `expandVMConfigOverride` and `expandNic` now accept `*schema.ResourceData` and a base path. For each NIC with `nic_backing_info.virtual_ethernet_nic` (or legacy `backing_info`), the code checks `IsExplicitlySet(d, path+".is_connected")` and, when set, passes the value via opts into `expandVirtualEthernetNic`.
- **Call sites:** All other callers of `expandNic` (virtual_machine_v2, ova_vm_deploy_v2, template_v2) pass `nil` for `d`/basePath so behavior is unchanged.

### 3. Test updates (nutanix/services/vmmv2)

- **HCL configs:** Every nics block now uses:
  - `nic_backing_info { virtual_ethernet_nic { ... } }` (replacing `backing_info` or flat `nic_backing_info`).
  - `nic_network_info { virtual_ethernet_nic_network_info { ... } }` (replacing `network_info` or flat `nic_network_info`).
- **Assertion paths:** All NIC-related `TestCheckResourceAttr` / `TestCheckResourceAttrPair` paths updated to the nested structure (e.g. `nic_network_info.0.virtual_ethernet_nic_network_info.0.*`, `nic_backing_info.#` where applicable).
- **Files touched:**  
  `resource_nutanix_ova_vm_deploy_v2_test.go`, `resource_nutanix_virtual_machine_v2_test.go`, `resource_nutanix_vms_shutdown_actions_v2_test.go`, `resource_nutanix_vms_network_device_assign_ip_v2_test.go`, `resource_nutanix_vms_clone_v2_test.go`, `resource_nutanix_template_deploy_v2_test.go`, `resource_nutanix_template_guest_os_actions_v2_test.go`, `resource_nutanix_ngt_installation_v2_test.go`, `resource_nutanix_ova_v2_test.go`, `resource_nutanix_ova_download_v2_test.go`, `data_source_nutanix_virtual_machine_v2_test.go`, `data_source_nutanix_ova_v2_test.go`.

### 4. Documentation

- **`website/docs/r/ova_vm_deploy_v2.html.markdown`** and **`website/docs/r/virtual_machine_v2.html.markdown`:** Updated to show `nic_backing_info` / `nic_network_info` with the nested `virtual_ethernet_nic` and `virtual_ethernet_nic_network_info` structure where relevant.

### 5. Resource / provider code

- **`resource_nutanix_ova_vm_deploy_v2.go`:** `expandNic` call updated to pass the new parameters (`nil`, `""`).
- **`resource_nutanix_virtual_machine_v2.go`:** All `expandNic` and single-NIC expand call sites updated to pass the new parameters (`nil`, `""`).
- **`resource_nutanix_template_v2.go`:** `expandNic` call sites updated to pass the new parameters (`nil`, `""`).

## Backward compatibility

- Legacy attributes `backing_info` and `network_info` remain in the schema (deprecated). Existing configs using them continue to work; tests now use the preferred nested `nic_backing_info` / `nic_network_info` structure.
- When `expandNic` is called without `ResourceData` (e.g. from virtual_machine_v2, ova_vm_deploy_v2), behavior is unchanged; the `is_connected` fix applies only where we have config and `ResourceData` (template deploy).

## Testing

- `go build ./nutanix/services/vmmv2/...` succeeds.
- Acceptance tests can be run with `TF_ACC` set; they use the new NIC attribute structure and assertion paths.
