### PR TITLE
Mark guest_customization as ForceNew on virtual_machine_v2

### DIFF
--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -1245,6 +1245,7 @@ func schemaForGuestCustomization() *schema.Schema {
 		Type:     schema.TypeList,
 		Optional: true,
 		Computed: true,
+		ForceNew: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"config": {


### PR DESCRIPTION
**Story**
Updating the cloud_init/Sysprep field does not have any effect on the VM. Although the update operation completes successfully without any errors or warnings, the changes are not applied.

This appears to be expected behavior, as cloud_init/Sysprep is typically a create-time only attribute across most platforms (including Nutanix, AWS, etc.):

It is consumed only during the first boot of the VM
It is not re-applied on updates
Any changes after creation are silently ignored

As a result, the current behavior is:
✅ Update succeeds without errors
❌ No actual changes are reflected on the VM

**Summary on Change**
This change sets ForceNew: true on the guest_customization block so that any change to guest customization triggers destroy/create instead of an in-place update.
- nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go: add ForceNew: true to the guest_customization schema (via schemaForGuestCustomization()).

**Testing**
- Sysprep (Windows GC): verified behavior when guest customization (Sysprep-related config) changes — Terraform plans replace the VM as expected.
- Cloud-init (Linux GC): verified the same for cloud-init–based guest customization — replacement on change behaves as expected.



