### PR TITLE
Mark user key secrets as sensitive and persist key_details on create

### DIFF
--- a/nutanix/services/iamv2/resource_nutanix_user_key_v2.go
+++ b/nutanix/services/iamv2/resource_nutanix_user_key_v2.go
@@ -125,8 +125,8 @@ func ResourceNutanixUserKeyV2() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"api_key": {
-										Type:     schema.TypeString,
-										Computed: true,
+										Type:      schema.TypeString,
+										Computed:  true,
 										Sensitive: true,
 									},
 								},
@@ -138,13 +138,13 @@ func ResourceNutanixUserKeyV2() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"secret_key": {
-										Type:     schema.TypeString,
-										Computed: true,
+										Type:      schema.TypeString,
+										Computed:  true,
 										Sensitive: true,
 									},
 									"access_key": {
-										Type:     schema.TypeString,
-										Computed: true,
+										Type:      schema.TypeString,
+										Computed:  true,
 										Sensitive: true,
 									},
 								},

--- a/nutanix/services/iamv2/resource_nutanix_user_key_v2.go
+++ b/nutanix/services/iamv2/resource_nutanix_user_key_v2.go
@@ -127,6 +127,7 @@ func ResourceNutanixUserKeyV2() *schema.Resource {
 									"api_key": {
 										Type:     schema.TypeString,
 										Computed: true,
+										Sensitive: true,
 									},
 								},
 							},
@@ -139,10 +140,12 @@ func ResourceNutanixUserKeyV2() *schema.Resource {
 									"secret_key": {
 										Type:     schema.TypeString,
 										Computed: true,
+										Sensitive: true,
 									},
 									"access_key": {
 										Type:     schema.TypeString,
 										Computed: true,
+										Sensitive: true,
 									},
 								},
 							},
@@ -222,7 +225,14 @@ func resourceNutanixUserKeyV2Create(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("error while creating User Key: %v", err)
 	}
 	getResp := resp.Data.GetValue().(import1.Key)
+
+	aJSON, _ := json.MarshalIndent(getResp, "", "  ")
+	log.Printf("[DEBUG] Created User Key: %s", aJSON)
 	d.SetId(utils.StringValue(getResp.ExtId))
+
+	if err := d.Set("key_details", flattenKeyDetails(getResp.KeyDetails)); err != nil {
+		return diag.Errorf("error while setting key_details: %v", err)
+	}
 	return resourceNutanixUserKeyV2Read(ctx, d, meta)
 }
 
@@ -289,9 +299,6 @@ func resourceNutanixUserKeyV2Read(ctx context.Context, d *schema.ResourceData, m
 	}
 	if err := d.Set("last_used_time", flattenTime(keyConfig.LastUsedTime)); err != nil {
 		return diag.Errorf("error while setting last_used_time: %v", err)
-	}
-	if err := d.Set("key_details", flattenKeyDetails(keyConfig.KeyDetails)); err != nil {
-		return diag.Errorf("error while setting key_details: %v", err)
 	}
 	d.SetId(utils.StringValue(keyConfig.ExtId))
 	return nil


### PR DESCRIPTION
### Summary

- Mark `api_key`, `secret_key`, and `access_key` fields in `nutanix_user_key_v2` as `Sensitive: true` so their values are redacted from Terraform plan/apply output and state CLI display.
- Set `key_details` in state during **Create** (where the API returns the full secret), instead of during **Read** (where the API no longer returns secrets). This ensures the one-time secret values are captured in state and available via `terraform output`.
- Add a `DEBUG`-level log of the created key response for troubleshooting.

### Motivation

The Nutanix IAM API only returns sensitive key material (`api_key`, `secret_key`, `access_key`) in the **create** response. Subsequent GET calls omit these fields. Previously, `key_details` was set only in the Read function, meaning the secrets were always empty in state after the initial apply.

Additionally, these fields were not marked as sensitive, so any value that did make it into state would appear in plaintext in plan/apply output.

### Changes

| File | Change |
|:-----|:-------|
| `nutanix/services/iamv2/resource_nutanix_user_key_v2.go` | Added `Sensitive: true` to `api_key`, `secret_key`, and `access_key` schema fields |
| `nutanix/services/iamv2/resource_nutanix_user_key_v2.go` | Moved `d.Set("key_details", ...)` from `Read` to `Create` so secrets are persisted from the create response |
| `nutanix/services/iamv2/resource_nutanix_user_key_v2.go` | Added debug log of created key response |
