### PR TITLE
Refine VM hotplug power-cycle checks for memory, sockets

### DIFF
--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -3401,7 +3401,7 @@ func diffConfig(oldValue []interface{}, newValue []interface{}) ([]interface{}, 
 // Check if VM is in power off state to perform update operations
 func checkForHotPlugChanges(d *schema.ResourceData) bool {
 	if d.HasChange("num_cores_per_socket") ||
-		d.HasChange("num_threads_per_core") || d.HasChange("cd_rom") || d.HasChange("num_numa_nodes") ||
+		d.HasChange("num_threads_per_core") || d.HasChange("cd_roms") || d.HasChange("num_numa_nodes") ||
 		d.HasChange("cluster") || d.HasChange("is_cpu_passthrough_enabled") || d.HasChange("enabled_cpu_features") ||
 		d.HasChange("is_vcpu_hard_pinning_enabled") || d.HasChange("guest_customization") || d.HasChange("guest_tools") ||
 		d.HasChange("serial_ports") || d.HasChange("gpus") || d.HasChange("boot_config") || d.HasChange("is_cpu_hotplug_enabled") {

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -1464,10 +1464,10 @@ func ResourceNutanixVirtualMachineV2Read(ctx context.Context, d *schema.Resource
 
 func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.Client).VmmAPI
-	// respImages := resp.Data.GetValue().(config.Vm)
-	// updateSpec := respImages
 
-	if checkForHotPlugChanges(d) && !isVMPowerOff(d, conn) {
+	// Power Off of VM is required for specific VM update operations.
+	isCpuHotplugEnabled := d.Get("is_cpu_hotplug_enabled").(bool)
+	if checkForHotPlugChanges(d)|| (!isCpuHotplugEnabled && d.HasChange("num_sockets")) || checkMemoryAndSocketsDecreased(d){
 		log.Printf("[DEBUG] callingForPowerOffVM func")
 		callForPowerOffVM(ctx, conn, d, meta)
 	}
@@ -2155,7 +2155,7 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 	}
 
 	// call for power on VM after updating
-	if checkForHotPlugChanges(d) {
+	if checkForHotPlugChanges(d)|| (!isCpuHotplugEnabled && d.HasChange("num_sockets")) || checkMemoryAndSocketsDecreased(d) {
 		if power, ok := d.GetOk("power_state"); ok {
 			if power == "ON" {
 				callForPowerOnVM(ctx, conn, d, meta)
@@ -3400,12 +3400,30 @@ func diffConfig(oldValue []interface{}, newValue []interface{}) ([]interface{}, 
 
 // Check if VM is in power off state to perform update operations
 func checkForHotPlugChanges(d *schema.ResourceData) bool {
-	if d.HasChange("num_sockets") || d.HasChange("num_cores_per_socket") || d.HasChange("memory_size_bytes") ||
+	if d.HasChange("num_cores_per_socket") ||
 		d.HasChange("num_threads_per_core") || d.HasChange("cd_rom") || d.HasChange("num_numa_nodes") ||
 		d.HasChange("cluster") || d.HasChange("is_cpu_passthrough_enabled") || d.HasChange("enabled_cpu_features") ||
 		d.HasChange("is_vcpu_hard_pinning_enabled") || d.HasChange("guest_customization") || d.HasChange("guest_tools") ||
-		d.HasChange("serial_ports") || d.HasChange("gpus") || d.HasChange("boot_config") {
+		d.HasChange("serial_ports") || d.HasChange("gpus") || d.HasChange("boot_config") || d.HasChange("is_cpu_hotplug_enabled") {
 		return true
+	}
+	return false
+}
+
+func checkMemoryAndSocketsChange(d *schema.ResourceData) bool {
+	if d.HasChange("memory_size_bytes") || d.HasChange("num_sockets") {
+		return true
+	}
+	return false
+}
+
+func checkMemoryAndSocketsDecreased(d *schema.ResourceData) bool {
+	if checkMemoryAndSocketsChange(d) {
+		oldMemory, newMemory := d.GetChange("memory_size_bytes")
+		oldSockets, newSockets := d.GetChange("num_sockets")
+		if newMemory.(int) < oldMemory.(int) || newSockets.(int) < oldSockets.(int) {
+			return true
+		}
 	}
 	return false
 }

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -1467,7 +1467,7 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 
 	// Power Off of VM is required for specific VM update operations.
 	isCpuHotplugEnabled := d.Get("is_cpu_hotplug_enabled").(bool)
-	if checkForHotPlugChanges(d)|| (!isCpuHotplugEnabled && d.HasChange("num_sockets")) || checkMemoryAndSocketsDecreased(d){
+	if checkForHotPlugChanges(d) || (!isCpuHotplugEnabled && d.HasChange("num_sockets")) || checkMemoryAndSocketsDecreased(d) {
 		log.Printf("[DEBUG] callingForPowerOffVM func")
 		callForPowerOffVM(ctx, conn, d, meta)
 	}
@@ -2155,7 +2155,7 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 	}
 
 	// call for power on VM after updating
-	if checkForHotPlugChanges(d)|| (!isCpuHotplugEnabled && d.HasChange("num_sockets")) || checkMemoryAndSocketsDecreased(d) {
+	if checkForHotPlugChanges(d) || (!isCpuHotplugEnabled && d.HasChange("num_sockets")) || checkMemoryAndSocketsDecreased(d) {
 		if power, ok := d.GetOk("power_state"); ok {
 			if power == "ON" {
 				callForPowerOnVM(ctx, conn, d, meta)

--- a/nutanix/services/vmmv2/resource_nutanix_vms_shutdown_actions_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vms_shutdown_actions_v2_test.go
@@ -47,9 +47,11 @@ func TestAccV2NutanixVmsShutdownResource_Basic(t *testing.T) {
 			},
 			// 3. create a vm shutdown action
 			{
-				Config: testVMV2Config(name, desc, "ON") + testNGTConfig() + testVmsShutdownV2Config("shutdown"),
+				Config:             testVMV2Config(name, desc, "ON") + testNGTConfig() + testVmsShutdownV2Config("shutdown"),
+				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("nutanix_virtual_machine_v2.rtest", "id"),
+					resource.TestCheckResourceAttr("nutanix_vm_shutdown_action_v2.vmShuts", "action", "shutdown"),
 				),
 			},
 			// 4. check the power state of the vm
@@ -123,7 +125,8 @@ func TestAccV2NutanixVmsShutdownResource_Basic(t *testing.T) {
 			},
 			// 11. guest_shutdown the vm
 			{
-				Config: testVMV2Config(name, desc, "ON") + testNGTConfig() + testVmsShutdownV2Config("guest_shutdown"),
+				Config:             testVMV2Config(name, desc, "ON") + testNGTConfig() + testVmsShutdownV2Config("guest_shutdown"),
+				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("nutanix_virtual_machine_v2.rtest", "id"),
 				),

--- a/nutanix/services/vmmv2/resource_nutanix_vms_shutdown_actions_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vms_shutdown_actions_v2_test.go
@@ -47,11 +47,9 @@ func TestAccV2NutanixVmsShutdownResource_Basic(t *testing.T) {
 			},
 			// 3. create a vm shutdown action
 			{
-				Config:             testVMV2Config(name, desc, "ON") + testNGTConfig() + testVmsShutdownV2Config("shutdown"),
-				ExpectNonEmptyPlan: true,
+				Config: testVMV2Config(name, desc, "ON") + testNGTConfig() + testVmsShutdownV2Config("shutdown"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("nutanix_virtual_machine_v2.rtest", "id"),
-					resource.TestCheckResourceAttr("nutanix_vm_shutdown_action_v2.vmShuts", "action", "shutdown"),
 				),
 			},
 			// 4. check the power state of the vm
@@ -125,8 +123,7 @@ func TestAccV2NutanixVmsShutdownResource_Basic(t *testing.T) {
 			},
 			// 11. guest_shutdown the vm
 			{
-				Config:             testVMV2Config(name, desc, "ON") + testNGTConfig() + testVmsShutdownV2Config("guest_shutdown"),
-				ExpectNonEmptyPlan: true,
+				Config: testVMV2Config(name, desc, "ON") + testNGTConfig() + testVmsShutdownV2Config("guest_shutdown"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("nutanix_virtual_machine_v2.rtest", "id"),
 				),


### PR DESCRIPTION
## Summary
- Update `nutanix_virtual_machine_v2` update flow to make power-off decisions more explicit for CPU/memory hotplug scenarios.
- Remove unconditional power-off requirement for `memory_size_bytes` and `num_sockets` from `checkForHotPlugChanges`.
- Add dedicated helper checks to detect memory/socket changes and enforce power-off when values are decreased.
- Ensure socket updates still require power-off when `is_cpu_hotplug_enabled` is disabled.
- Treat `is_cpu_hotplug_enabled` updates themselves as power-off-required changes.
- Ensure Memory can be increased even with Power On.


# Testcases for Hotplug

### Testcase 1.1: Memory increase
VM is in already ON state
No power off required -- Update -- No Power on required -- Success

### Testcase 1.2: Memory decrease
VM is in already ON state
Power off required -- Update -- Power on -- Success

What if no power off happened before update?
Error should be returned
Error: error waiting for virtual machine (ZXJnb24=:714a47c8-1bf9-5f47-9d89-6df0bc0c8b1a) to update: error_detail: Failed to perform the operation on the VM with UUID '9f6a028b-9907-4a86-5eeb-437545205b41', because the current power state of the VM is 'kOn'., progress_message: 100 - error checks done

# Done
================================================================================
### Testcase 1.5: num_sockets increase, Hotplug enabled
VM is in already ON state ---
No power off required -- update -- No Power on required -- Success

### Testcase 1.6: num_sockets decrease, Hotplug enabled
Power off required -- Update -- Power on Required -- Success

What if no power off happened before update?

Error should be returned 
error waiting for virtual machine (ZXJnb24=:8cb6f847-2025-5367-8a7a-3af0a369f842) to update: error_detail: Failed to perform the operation on the VM with UUID '9f6a028b-9907-4a86-5eeb-437545205b41', because the current power state of the VM is 'kOn'., progress_message: 100 -- error checks done.

# Done
================================================================================

### Testcase 1.7: num_sockets increase, Hotplug disabled
VM is in already ON state ---
=============================================
Negative Case:
Hotplug is disabled
VM is not powered off
do update -- num_sockets increase
error message should be shown

Error: error waiting for virtual machine (ZXJnb24=:ec9d989d-30d7-5527-9306-d12ff4d4967a) to update: error_detail: Failed to perform the operation 'UpdateVm', as it is not supported., progress_message: 100
=============================================
Power off required -- Update -- Power on  -- Success - Done

### Testcase 1.8: num_sockets decrease, Hotplug disabled
Power off required -- Update -- Power on -- Success- Done

# Success Done.

# Cases when VM is powered OFF
1. Memory increase/descrease, CPU increase/decrease doesn't Power On the VM after update.