### PR TITLE
Cherry Pick: Refine VM hotplug power-cycle checks for memory, sockets…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2.3.5(May 4, 2026)
+[Full Changelog](https://github.com/nutanix/terraform-provider-nutanix/compare/v2.3.4...v2.3.5)
+
+- **Fixed Bugs:**
+   - Memory hot-plug increase causing VM power off when using `nutanix_virtual_machine_v2` resource. [#1105](https://github.com/nutanix/terraform-provider-nutanix/issues/1105)
+
 ## 2.3.4 (November 14, 2025)
 [Full Changelog](https://github.com/nutanix/terraform-provider-nutanix/compare/v2.3.3...v2.3.4)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Terraform provider plugin to integrate with Nutanix Cloud Platform.
 
-NOTE: The latest version of the Nutanix provider is [v2.3.4](https://github.com/nutanix/terraform-provider-nutanix/releases/tag/v2.3.4).
+NOTE: The latest version of the Nutanix provider is [v2.3.5](https://github.com/nutanix/terraform-provider-nutanix/releases/tag/v2.3.5).
 
 Modules based on Terraform Nutanix Provider can be found here : [Modules](https://github.com/nutanix/terraform-provider-nutanix/tree/master/modules)
 
@@ -22,30 +22,28 @@ Modules based on Terraform Nutanix Provider can be found here : [Modules](https:
 * [Go](https://golang.org/doc/install) 1.17+ (to build the provider plugin)
 * This provider uses [SDKv2](https://www.terraform.io/plugin/sdkv2/sdkv2-intro) from release 1.3.0
 
-## Introducing Nutanix Terraform Provider Version v2.3.4
+## Introducing Nutanix Terraform Provider Version v2.3.5
 
-We're excited to announce the release of Nutanix Terraform Provider Version 2.3.4!
+We're excited to announce the release of Nutanix Terraform Provider Version 2.3.5!
 
-### What's New in v2.3.4
-
-- **Enhancements:**
-  - Support for Ejecting ISO from CD-ROM [\#1006](https://github.com/nutanix/terraform-provider-nutanix/issues/1006)
+### What's New in v2.3.5
 
 - **Fixed Bugs:**
-   - Subnet entity is not saved in Terraform State due to plugin crash [\#894](https://github.com/nutanix/terraform-provider-nutanix/issues/894)
+   - Memory hot-plug increase causing VM power off when using `nutanix_virtual_machine_v2` resource. [#1105](https://github.com/nutanix/terraform-provider-nutanix/issues/1105)
 
 
 ### Software Requirements
-The provider is used to interact with the many resources and data sources supported by Nutanix, using Prism Central as the provider endpoint. To fully utilize the capabilities of version 2.3.0, ensure your Nutanix environment meets the following software requirements:
+The provider is used to interact with the many resources and data sources supported by Nutanix, using Prism Central as the provider endpoint. To fully utilize the capabilities of version 2.3.5, ensure your Nutanix environment meets the following software requirements:
 - Self Service version: 4.2.0 (Required only for running Self Service based resource and data source)
 - AOS Version: 7.3 or later
 - Prism Central Version: pc 7.3 or later
-- Nutanix Terraform Provider Version: 2.3.4
+- Nutanix Terraform Provider Version: 2.3.5
 
 
 ## Compatibility Matrix
 | Terraform Version |  AOS Version | PC version  | Other software versions | Supported |
 |  :--- |  :--- | :--- | :--- | :--- |
+| 2.3.5 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.4 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.3 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.2 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -1647,10 +1647,10 @@ func ResourceNutanixVirtualMachineV2Read(ctx context.Context, d *schema.Resource
 
 func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.Client).VmmAPI
-	// respImages := resp.Data.GetValue().(config.Vm)
-	// updateSpec := respImages
 
-	if checkForHotPlugChanges(d) && !isVMPowerOff(d, conn) {
+	// Power Off of VM is required for specific VM update operations.
+	isCpuHotplugEnabled := d.Get("is_cpu_hotplug_enabled").(bool)
+	if checkForHotPlugChanges(d) || (!isCpuHotplugEnabled && d.HasChange("num_sockets")) || checkMemoryAndSocketsDecreased(d) {
 		log.Printf("[DEBUG] callingForPowerOffVM func")
 		callForPowerOffVM(ctx, conn, d, meta)
 	}
@@ -2429,7 +2429,7 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 	}
 
 	// call for power on VM after updating
-	if checkForHotPlugChanges(d) {
+	if checkForHotPlugChanges(d) || (!isCpuHotplugEnabled && d.HasChange("num_sockets")) || checkMemoryAndSocketsDecreased(d) {
 		if power, ok := d.GetOk("power_state"); ok {
 			if power == "ON" {
 				callForPowerOnVM(ctx, conn, d, meta)
@@ -3509,12 +3509,30 @@ func diffConfig(oldValue []interface{}, newValue []interface{}) ([]interface{}, 
 
 // Check if VM is in power off state to perform update operations
 func checkForHotPlugChanges(d *schema.ResourceData) bool {
-	if d.HasChange(("num_sockets")) || d.HasChange(("num_cores_per_socket")) || d.HasChange(("memory_size_bytes")) ||
-		d.HasChange(("num_threads_per_core")) || d.HasChange(("cd_rom")) || d.HasChange(("num_numa_nodes")) ||
+	if d.HasChange("num_cores_per_socket") ||
+		d.HasChange("num_threads_per_core") || d.HasChange("cd_roms") || d.HasChange("num_numa_nodes") ||
 		d.HasChange("cluster") || d.HasChange("is_cpu_passthrough_enabled") || d.HasChange("enabled_cpu_features") ||
 		d.HasChange("is_vcpu_hard_pinning_enabled") || d.HasChange("guest_customization") || d.HasChange("guest_tools") ||
-		d.HasChange("serial_ports") || d.HasChange("gpus") || d.HasChange("boot_config") {
+		d.HasChange("serial_ports") || d.HasChange("gpus") || d.HasChange("boot_config") || d.HasChange("is_cpu_hotplug_enabled") {
 		return true
+	}
+	return false
+}
+
+func checkMemoryAndSocketsChange(d *schema.ResourceData) bool {
+	if d.HasChange("memory_size_bytes") || d.HasChange("num_sockets") {
+		return true
+	}
+	return false
+}
+
+func checkMemoryAndSocketsDecreased(d *schema.ResourceData) bool {
+	if checkMemoryAndSocketsChange(d) {
+		oldMemory, newMemory := d.GetChange("memory_size_bytes")
+		oldSockets, newSockets := d.GetChange("num_sockets")
+		if newMemory.(int) < oldMemory.(int) || newSockets.(int) < oldSockets.(int) {
+			return true
+		}
 	}
 	return false
 }

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -1649,8 +1649,8 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 	conn := meta.(*conns.Client).VmmAPI
 
 	// Power Off of VM is required for specific VM update operations.
-	isCpuHotplugEnabled := d.Get("is_cpu_hotplug_enabled").(bool)
-	if checkForHotPlugChanges(d) || (!isCpuHotplugEnabled && d.HasChange("num_sockets")) || checkMemoryAndSocketsDecreased(d) {
+	isCPUHotplugEnabled := d.Get("is_cpu_hotplug_enabled").(bool)
+	if checkForHotPlugChanges(d) || (!isCPUHotplugEnabled && d.HasChange("num_sockets")) || checkMemoryAndSocketsDecreased(d) {
 		log.Printf("[DEBUG] callingForPowerOffVM func")
 		callForPowerOffVM(ctx, conn, d, meta)
 	}
@@ -2429,7 +2429,7 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 	}
 
 	// call for power on VM after updating
-	if checkForHotPlugChanges(d) || (!isCpuHotplugEnabled && d.HasChange("num_sockets")) || checkMemoryAndSocketsDecreased(d) {
+	if checkForHotPlugChanges(d) || (!isCPUHotplugEnabled && d.HasChange("num_sockets")) || checkMemoryAndSocketsDecreased(d) {
 		if power, ok := d.GetOk("power_state"); ok {
 			if power == "ON" {
 				callForPowerOnVM(ctx, conn, d, meta)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -13,17 +13,14 @@ The provider is used to interact with the many resources and data sources suppor
 Use the navigation on the left to read about the available resources and data sources this provider can use.
 
 
-## Introducing Nutanix Terraform Provider Version v2.3.4
+## Introducing Nutanix Terraform Provider Version v2.3.5
 
-We're excited to announce the release of Nutanix Terraform Provider Version 2.3.4!
+We're excited to announce the release of Nutanix Terraform Provider Version 2.3.5!
 
-### What's New in v2.3.4
-
-- **Enhancements:**
-  - Support for Ejecting ISO from CD-ROM [\#1006](https://github.com/nutanix/terraform-provider-nutanix/issues/1006)
+### What's New in v2.3.5
 
 - **Fixed Bugs:**
-   - Subnet entity is not saved in Terraform State due to plugin crash [\#894](https://github.com/nutanix/terraform-provider-nutanix/issues/894)
+   - Memory hot-plug increase causing VM power off when using `nutanix_virtual_machine_v2` resource. [#1105](https://github.com/nutanix/terraform-provider-nutanix/issues/1105)
 
 
 ~> **Important Notice:** Upcoming Deprecation of Legacy Nutanix Terraform Provider Resources. Starting with the Nutanix Terraform Provider release planned for Q4-CY2026, legacy resources which are based on v0.8,v1,v2 and v3 APIs will be deprecated and no longer supported. For more information, visit [Legacy API Deprecation Announcement](https://portal.nutanix.com/page/documents/eol/list?type=announcement) [Legacy API Deprecation - FAQs](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA0VO0000005rgP0AQ). Nutanix strongly encourages you to migrate your scripts and applications to the latest v2 version of the Nutanix Terraform Provider resources, which are built on our v4 APIs/SDKs. By adopting the latest v2 version based on v4 APIs and SDKs, our users can leverage the enhanced capabilities and latest innovations from Nutanix. We understand that this transition may require some effort, and we are committed to supporting you throughout the process. Please refer to our documentation and support channels for guidance and assistance.
@@ -37,6 +34,7 @@ Customers not taking advantage of the  Advanced API/SDK Support Program will con
 ## Compatibility Matrix
 | Terraform Version |  AOS Version | PC version  | Other software versions | Supported |
 |  :--- |  :--- | :--- | :--- | :--- |
+| 2.3.5 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.4 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.3 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |
 | 2.3.2 | 7.3 | pc7.3 or later | Self Service  v4.2.0, v4.1.0 | yes |


### PR DESCRIPTION
Cherry pick of this commit to release/2.3.5: https://github.com/nutanix/terraform-provider-nutanix/pull/1117

## Summary
- Update `nutanix_virtual_machine_v2` update flow to make power-off decisions more explicit for CPU/memory hotplug scenarios.
- Remove unconditional power-off requirement for `memory_size_bytes` and `num_sockets` from `checkForHotPlugChanges`.
- Add dedicated helper checks to detect memory/socket changes and enforce power-off when values are decreased.
- Ensure socket updates still require power-off when `is_cpu_hotplug_enabled` is disabled.
- Treat `is_cpu_hotplug_enabled` updates themselves as power-off-required changes.
- Ensure Memory can be increased even with Power On.


# Testcases for Hotplug

### Testcase 1.1: Memory increase
VM is in already ON state
No power off required -- Update -- No Power on required -- Success

### Testcase 1.2: Memory decrease
VM is in already ON state
Power off required -- Update -- Power on -- Success

What if no power off happened before update?
Error should be returned
Error: error waiting for virtual machine (ZXJnb24=:714a47c8-1bf9-5f47-9d89-6df0bc0c8b1a) to update: error_detail: Failed to perform the operation on the VM with UUID '9f6a028b-9907-4a86-5eeb-437545205b41', because the current power state of the VM is 'kOn'., progress_message: 100 - error checks done

# Done
================================================================================
### Testcase 1.5: num_sockets increase, Hotplug enabled
VM is in already ON state ---
No power off required -- update -- No Power on required -- Success

### Testcase 1.6: num_sockets decrease, Hotplug enabled
Power off required -- Update -- Power on Required -- Success

What if no power off happened before update?

Error should be returned 
error waiting for virtual machine (ZXJnb24=:8cb6f847-2025-5367-8a7a-3af0a369f842) to update: error_detail: Failed to perform the operation on the VM with UUID '9f6a028b-9907-4a86-5eeb-437545205b41', because the current power state of the VM is 'kOn'., progress_message: 100 -- error checks done.

# Done
================================================================================

### Testcase 1.7: num_sockets increase, Hotplug disabled
VM is in already ON state ---
=============================================
Negative Case:
Hotplug is disabled
VM is not powered off
do update -- num_sockets increase
error message should be shown

Error: error waiting for virtual machine (ZXJnb24=:ec9d989d-30d7-5527-9306-d12ff4d4967a) to update: error_detail: Failed to perform the operation 'UpdateVm', as it is not supported., progress_message: 100
=============================================
Power off required -- Update -- Power on  -- Success - Done

### Testcase 1.8: num_sockets decrease, Hotplug disabled
Power off required -- Update -- Power on -- Success- Done

# Success Done.

# Cases when VM is powered OFF
1. Memory increase/descrease, CPU increase/decrease doesn't Power On the VM after update.