### PR TITLE
code-gen(monitoring/cluster): terraform v2 provider code

### DIFF
--- a/examples/monitoring_v2/cluster_config/main.tf
+++ b/examples/monitoring_v2/cluster_config/main.tf
@@ -1,0 +1,44 @@
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = ">=1.0.0"
+    }
+  }
+}
+
+provider "nutanix" {
+  username = var.nutanix_username
+  password = var.nutanix_password
+  endpoint = var.nutanix_endpoint
+  port     = var.nutanix_port
+  insecure = true
+}
+
+# Data source: List all cluster configs for a System-Defined Alert Policy
+data "nutanix_sda_cluster_configs_v2" "all" {
+  system_defined_policy_ext_id = var.system_defined_policy_ext_id
+}
+
+# Data source: Get a specific cluster config
+data "nutanix_sda_cluster_config_v2" "example" {
+  system_defined_policy_ext_id = var.system_defined_policy_ext_id
+  ext_id                       = var.cluster_ext_id
+}
+
+# Resource: Manage a cluster config for a System-Defined Alert Policy
+resource "nutanix_sda_cluster_config_v2" "example" {
+  system_defined_policy_ext_id = var.system_defined_policy_ext_id
+  ext_id                       = var.cluster_ext_id
+  is_enabled                   = true
+}
+
+# Output the list of cluster configs
+output "cluster_configs" {
+  value = data.nutanix_sda_cluster_configs_v2.all.cluster_configs
+}
+
+# Output the specific cluster config
+output "cluster_config" {
+  value = data.nutanix_sda_cluster_config_v2.example
+}

--- a/examples/monitoring_v2/cluster_config/variables.tf
+++ b/examples/monitoring_v2/cluster_config/variables.tf
@@ -1,0 +1,27 @@
+variable "nutanix_username" {
+  type = string
+}
+
+variable "nutanix_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "nutanix_endpoint" {
+  type = string
+}
+
+variable "nutanix_port" {
+  type    = string
+  default = "9440"
+}
+
+variable "system_defined_policy_ext_id" {
+  type        = string
+  description = "Unique ID of the System-Defined Alert Policy."
+}
+
+variable "cluster_ext_id" {
+  type        = string
+  description = "Cluster UUID."
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4 v4.1.2-beta.2
 	github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2
 	github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2
+	github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2
 	github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1
 	github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4 v4.0.3
 	github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4 v4.3.1

--- a/go.sum
+++ b/go.sum
@@ -467,6 +467,8 @@ github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2 h1:ms+a
 github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2/go.mod h1:X3TsJoGBbkQzz6OP8Be7XvGhH4CwKkF9t35OmJpPY0w=
 github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2 h1:dE0zUP3ExJBnMUaGDAIZGN7/UZ0a85IWzHygMGcUDMc=
 github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2/go.mod h1:vo3VMB097Zd9cw4hLDbnpyBVcBZkpFmcQ2nNgpOpo7U=
+github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2 h1:dXFgnBHMd6MipSXkQE5cRysjKX96MeYeIFIkZDvye60=
+github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2/go.mod h1:msvlZou4z7vn5pHFhJ65OtAbh99z1ISsqCzfehdcWfw=
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1 h1:VWxK8mY6kOag/ocDBttDViktEi8bcjbAvm3i9laDyCA=
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1/go.mod h1:4fUdP3zeL4UFS/UVaii5EdS2v+KlM4gI07KcnS+wDuY=
 github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4 v4.0.3 h1:TE/G5GHrnvBGPI8MC0fSMSAaeD6HcdtezIgEmn8V/Yo=

--- a/nutanix/config.go
+++ b/nutanix/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/iam"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/lcm"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/microseg"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/monitoring"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/networking"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/objectstores"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/prism"
@@ -140,6 +141,10 @@ func (c *Config) Client() (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	monitoringClient, err := monitoring.NewMonitoringClient(configCreds)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Client{
 		WaitTimeout:         c.WaitTimeout,
@@ -161,6 +166,7 @@ func (c *Config) Client() (*Client, error) {
 		CalmAPI:             calmClient,
 		ObjectStoreAPI:      ObjectStoreClient,
 		SecurityAPI:         SecurityClient,
+		MonitoringAPI:       monitoringClient,
 	}, nil
 }
 
@@ -185,4 +191,5 @@ type Client struct {
 	CalmAPI             *selfservice.Client
 	ObjectStoreAPI      *objectstores.Client
 	SecurityAPI         *security.Client
+	MonitoringAPI       *monitoring.Client
 }

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/iamv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/lcmv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/microsegv2"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/monitoringv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/ndb"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/networking"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/networkingv2"
@@ -370,6 +371,8 @@ func Provider() *schema.Provider {
 			"nutanix_stigs_v2":                                securityv2.DatasourceNutanixStigsControlsV2(),
 			"nutanix_entity_group_v2":                         microsegv2.DatasourceNutanixEntityGroupV2(),
 			"nutanix_entity_groups_v2":                        microsegv2.DatasourceNutanixEntityGroupsV2(),
+			"nutanix_sda_cluster_config_v2":                   monitoringv2.DatasourceNutanixSdaClusterConfigV2(),
+			"nutanix_sda_cluster_configs_v2":                  monitoringv2.DatasourceNutanixSdaClusterConfigsV2(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"nutanix_virtual_machine":                         vmm.ResourceNutanixVirtualMachine(),
@@ -501,6 +504,7 @@ func Provider() *schema.Provider {
 			"nutanix_object_store_certificate_v2":             objectstoresv2.ResourceNutanixObjectStoreCertificateV2(),
 			"nutanix_key_management_server_v2":                securityv2.ResourceNutanixKeyManagementServerV2(),
 			"nutanix_entity_group_v2":                         microsegv2.ResourceNutanixEntityGroupV2(),
+			"nutanix_sda_cluster_config_v2":                   monitoringv2.ResourceNutanixSdaClusterConfigV2(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}

--- a/nutanix/sdks/v4/monitoring/monitoring.go
+++ b/nutanix/sdks/v4/monitoring/monitoring.go
@@ -1,0 +1,33 @@
+package monitoring
+
+import (
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/api"
+	monitoringClient "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
+)
+
+type Client struct {
+	SystemDefinedPoliciesAPI *api.SystemDefinedPoliciesApi
+	APIClientInstance        *monitoringClient.ApiClient
+}
+
+func NewMonitoringClient(credentials client.Credentials) (*Client, error) {
+	var baseClient *monitoringClient.ApiClient
+
+	pcClient := monitoringClient.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
+		baseClient = pcClient
+	}
+
+	return &Client{
+		SystemDefinedPoliciesAPI: api.NewSystemDefinedPoliciesApi(baseClient),
+		APIClientInstance:        baseClient,
+	}, nil
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_config_v2.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_config_v2.go
@@ -52,7 +52,7 @@ func DatasourceNutanixSdaClusterConfigV2() *schema.Resource {
 				Computed:    true,
 				Description: "Interval in seconds for periodically executing the SDA policy. This will not be set for policies with the type NOT_SCHEDULED & EVENT_DRIVEN.",
 			},
-			"alert_config": schemaForAlertConfig(),
+			"alert_config":            schemaForAlertConfig(),
 			"configurable_parameters": schemaForConfigurableParameters(),
 		},
 	}

--- a/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_config_v2.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_config_v2.go
@@ -1,0 +1,87 @@
+package monitoringv2
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	monitoringModel "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixSdaClusterConfigV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceNutanixSdaClusterConfigV2Read,
+		Schema: map[string]*schema.Schema{
+			"system_defined_policy_ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Unique ID of the System-Defined Alert Policy.",
+			},
+			"ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Cluster UUID.",
+			},
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A globally unique identifier that represents the tenant that owns this entity. The system automatically assigns it, and it and is immutable from an API consumer perspective (some use cases may cause this ID to change - For instance, a use case may require the transfer of ownership of the entity, but these cases are handled automatically on the server).",
+			},
+			"links": schemaForLinks(),
+			"is_enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates whether the SDA policy is enabled or not on the cluster.",
+			},
+			"last_modified_by_user": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Name of the user who made the latest update to this policy. Its value will be Nutanix if the last update is due to an upgrade event.",
+			},
+			"last_modified_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Time in ISO 8601 format when the SDA policy was last modified. It gets automatically updated by the Nutanix service from the user context during an update event.",
+			},
+			"schedule_interval_seconds": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Interval in seconds for periodically executing the SDA policy. This will not be set for policies with the type NOT_SCHEDULED & EVENT_DRIVEN.",
+			},
+			"alert_config": schemaForAlertConfig(),
+			"configurable_parameters": schemaForConfigurableParameters(),
+		},
+	}
+}
+
+func datasourceNutanixSdaClusterConfigV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	sdaPolicyExtID := d.Get("system_defined_policy_ext_id").(string)
+	extID := d.Get("ext_id").(string)
+
+	resp, err := conn.SystemDefinedPoliciesAPI.GetClusterConfigById(
+		utils.StringPtr(sdaPolicyExtID),
+		utils.StringPtr(extID),
+	)
+	if err != nil {
+		return diag.Errorf("error while reading SDA cluster config: %v", err)
+	}
+	if resp == nil || resp.Data == nil {
+		return diag.Errorf("no SDA cluster config found for system_defined_policy_ext_id: %s, ext_id: %s", sdaPolicyExtID, extID)
+	}
+
+	body := resp.Data.GetValue().(monitoringModel.ClusterConfig)
+	aJSON, _ := json.MarshalIndent(body, "", "  ")
+	log.Printf("[DEBUG] Get SDA Cluster Config Response: %s", string(aJSON))
+
+	if err := flattenClusterConfigToState(d, body); err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(extID)
+	return nil
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_config_v2_test.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_config_v2_test.go
@@ -1,0 +1,52 @@
+package monitoringv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const datasourceNameClusterConfig = "data.nutanix_sda_cluster_config_v2.test"
+
+func TestAccV2NutanixSdaClusterConfigDatasource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSdaClusterConfigDatasourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameClusterConfig, "ext_id"),
+					resource.TestCheckResourceAttrSet(datasourceNameClusterConfig, "system_defined_policy_ext_id"),
+					resource.TestCheckResourceAttrSet(datasourceNameClusterConfig, "is_enabled"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSdaClusterConfigDatasourceConfig() string {
+	return `
+		data "nutanix_sda_cluster_configs_v2" "policies" {
+			system_defined_policy_ext_id = data.nutanix_sda_cluster_configs_v2.list.cluster_configs.0.system_defined_policy_ext_id
+		}
+
+		data "nutanix_sda_cluster_configs_v2" "list" {
+			system_defined_policy_ext_id = local.sda_policy_ext_id
+		}
+
+		locals {
+			sda_policy_ext_id = data.nutanix_sda_cluster_configs_v2.all.cluster_configs.0.system_defined_policy_ext_id
+		}
+
+		data "nutanix_sda_cluster_configs_v2" "all" {
+			system_defined_policy_ext_id = "` + testVars.SystemDefinedPolicyExtID + `"
+		}
+
+		data "nutanix_sda_cluster_config_v2" "test" {
+			system_defined_policy_ext_id = "` + testVars.SystemDefinedPolicyExtID + `"
+			ext_id                       = "` + testVars.ClusterExtID + `"
+		}
+	`
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_configs_v2.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_configs_v2.go
@@ -1,0 +1,96 @@
+package monitoringv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	monitoringModel "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixSdaClusterConfigsV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceNutanixSdaClusterConfigsV2Read,
+		Schema: map[string]*schema.Schema{
+			"system_defined_policy_ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Unique ID of the System-Defined Alert Policy.",
+			},
+			"page": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"limit": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"order_by": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"select": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cluster_configs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     DatasourceNutanixSdaClusterConfigV2(),
+			},
+		},
+	}
+}
+
+func datasourceNutanixSdaClusterConfigsV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	sdaPolicyExtID := d.Get("system_defined_policy_ext_id").(string)
+
+	var filter, orderBy, selects *string
+	var page, limit *int
+
+	if pagef, ok := d.GetOk("page"); ok {
+		page = utils.IntPtr(pagef.(int))
+	}
+	if limitf, ok := d.GetOk("limit"); ok {
+		limit = utils.IntPtr(limitf.(int))
+	}
+	if filterf, ok := d.GetOk("filter"); ok {
+		filter = utils.StringPtr(filterf.(string))
+	}
+	if order, ok := d.GetOk("order_by"); ok {
+		orderBy = utils.StringPtr(order.(string))
+	}
+	if selectf, ok := d.GetOk("select"); ok {
+		selects = utils.StringPtr(selectf.(string))
+	}
+
+	resp, err := conn.SystemDefinedPoliciesAPI.ListClusterConfigsBySdaId(
+		utils.StringPtr(sdaPolicyExtID),
+		page, limit, filter, orderBy, selects,
+	)
+	if err != nil {
+		return diag.Errorf("error while fetching SDA cluster configs: %v", err)
+	}
+	if resp.Data == nil {
+		if err := d.Set("cluster_configs", []map[string]interface{}{}); err != nil {
+			return diag.FromErr(err)
+		}
+		d.SetId(utils.GenUUID())
+		return nil
+	}
+
+	configs := resp.Data.GetValue().([]monitoringModel.ClusterConfig)
+	if err := d.Set("cluster_configs", flattenClusterConfigs(configs)); err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(utils.GenUUID())
+	return nil
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_configs_v2_test.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_configs_v2_test.go
@@ -1,0 +1,34 @@
+package monitoringv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const datasourceNameClusterConfigs = "data.nutanix_sda_cluster_configs_v2.test"
+
+func TestAccV2NutanixSdaClusterConfigsDatasource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSdaClusterConfigsDatasourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameClusterConfigs, "cluster_configs.#"),
+					resource.TestCheckResourceAttrSet(datasourceNameClusterConfigs, "system_defined_policy_ext_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSdaClusterConfigsDatasourceConfig() string {
+	return `
+		data "nutanix_sda_cluster_configs_v2" "test" {
+			system_defined_policy_ext_id = "` + testVars.SystemDefinedPolicyExtID + `"
+		}
+	`
+}

--- a/nutanix/services/monitoringv2/helpers.go
+++ b/nutanix/services/monitoringv2/helpers.go
@@ -1,0 +1,725 @@
+package monitoringv2
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	import2 "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/common/v1/response"
+	monitoringModel "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func schemaForLinks() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"rel": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "A name that identifies the relationship of the link to the object that is returned by the URL. The unique value of \"self\" identifies the URL for the object.",
+				},
+				"href": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The URL at which the entity described by the link can be accessed.",
+				},
+			},
+		},
+	}
+}
+
+func schemaForParamValue() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"int_value": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"current_int_value": {
+								Type:        schema.TypeInt,
+								Computed:    true,
+								Description: "Captures the current value of the parameter.",
+							},
+							"default_int_value": {
+								Type:        schema.TypeInt,
+								Computed:    true,
+								Description: "Captures the default value of the parameter.",
+							},
+						},
+					},
+				},
+				"float_value": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"current_float_value": {
+								Type:        schema.TypeFloat,
+								Computed:    true,
+								Description: "Captures the current value of the parameter.",
+							},
+							"default_float_value": {
+								Type:        schema.TypeFloat,
+								Computed:    true,
+								Description: "Captures the default value of the parameter.",
+							},
+						},
+					},
+				},
+				"bool_value": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"current_bool_value": {
+								Type:        schema.TypeBool,
+								Computed:    true,
+								Description: "Captures the current value of the parameter.",
+							},
+							"default_bool_value": {
+								Type:        schema.TypeBool,
+								Computed:    true,
+								Description: "Captures the default value of the parameter.",
+							},
+						},
+					},
+				},
+				"string_value": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"current_str_value": {
+								Type:        schema.TypeString,
+								Computed:    true,
+								Description: "Captures the current value of the parameter.",
+							},
+							"default_str_value": {
+								Type:        schema.TypeString,
+								Computed:    true,
+								Description: "Captures the default value of the parameter.",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemaForParamValueResource() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"int_value": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"current_int_value": {
+								Type:        schema.TypeInt,
+								Optional:    true,
+								Description: "Captures the current value of the parameter.",
+							},
+							"default_int_value": {
+								Type:        schema.TypeInt,
+								Computed:    true,
+								Description: "Captures the default value of the parameter.",
+							},
+						},
+					},
+				},
+				"float_value": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"current_float_value": {
+								Type:        schema.TypeFloat,
+								Optional:    true,
+								Description: "Captures the current value of the parameter.",
+							},
+							"default_float_value": {
+								Type:        schema.TypeFloat,
+								Computed:    true,
+								Description: "Captures the default value of the parameter.",
+							},
+						},
+					},
+				},
+				"bool_value": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"current_bool_value": {
+								Type:        schema.TypeBool,
+								Optional:    true,
+								Description: "Captures the current value of the parameter.",
+							},
+							"default_bool_value": {
+								Type:        schema.TypeBool,
+								Computed:    true,
+								Description: "Captures the default value of the parameter.",
+							},
+						},
+					},
+				},
+				"string_value": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"current_str_value": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "Captures the current value of the parameter.",
+							},
+							"default_str_value": {
+								Type:        schema.TypeString,
+								Computed:    true,
+								Description: "Captures the default value of the parameter.",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemaForThresholdParameters() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Computed:    true,
+		Description: "Captures alert-related thresholds that correspond to a particular severity.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"display_name": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Equivalent name for the parameter used to display it on Prism UI.",
+				},
+				"name": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Unique identifier name for the parameter.",
+				},
+				"param_value": schemaForParamValue(),
+				"unit": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Unit for the parameter. For example, sec, %, MB, GB, and so on.",
+				},
+			},
+		},
+	}
+}
+
+func schemaForThresholdParametersResource() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		Computed:    true,
+		Description: "Captures alert-related thresholds that correspond to a particular severity.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"display_name": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Equivalent name for the parameter used to display it on Prism UI.",
+				},
+				"name": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Computed:    true,
+					Description: "Unique identifier name for the parameter.",
+				},
+				"param_value": schemaForParamValueResource(),
+				"unit": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Unit for the parameter. For example, sec, %, MB, GB, and so on.",
+				},
+			},
+		},
+	}
+}
+
+func schemaForSeverityConfig() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"state": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"threshold_parameters": schemaForThresholdParameters(),
+			},
+		},
+	}
+}
+
+func schemaForSeverityConfigResource() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"state": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"threshold_parameters": schemaForThresholdParametersResource(),
+			},
+		},
+	}
+}
+
+func schemaForAlertConfig() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"auto_resolve": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"critical_severity":  schemaForSeverityConfig(),
+				"info_severity":      schemaForSeverityConfig(),
+				"warning_severity":   schemaForSeverityConfig(),
+			},
+		},
+	}
+}
+
+func schemaForAlertConfigResource() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"auto_resolve": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"critical_severity":  schemaForSeverityConfigResource(),
+				"info_severity":      schemaForSeverityConfigResource(),
+				"warning_severity":   schemaForSeverityConfigResource(),
+			},
+		},
+	}
+}
+
+func schemaForConfigurableParameters() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Computed:    true,
+		Description: "Parameters of the SDA that are configurable by a user.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"display_name": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Equivalent name for the parameter used to display it on Prism UI.",
+				},
+				"name": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Unique identifier name for the parameter.",
+				},
+				"param_value": schemaForParamValue(),
+				"unit": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Unit for the parameter. For example, sec, %, MB, GB, and so on.",
+				},
+			},
+		},
+	}
+}
+
+func schemaForConfigurableParametersResource() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		Computed:    true,
+		Description: "Parameters of the SDA that are configurable by a user.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"display_name": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Equivalent name for the parameter used to display it on Prism UI.",
+				},
+				"name": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Computed:    true,
+					Description: "Unique identifier name for the parameter.",
+				},
+				"param_value": schemaForParamValueResource(),
+				"unit": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Unit for the parameter. For example, sec, %, MB, GB, and so on.",
+				},
+			},
+		},
+	}
+}
+
+// Flatten functions
+
+func flattenLinks(links []import2.ApiLink) []map[string]interface{} {
+	if len(links) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(links))
+	for i, link := range links {
+		result[i] = map[string]interface{}{
+			"rel":  utils.StringValue(link.Rel),
+			"href": utils.StringValue(link.Href),
+		}
+	}
+	return result
+}
+
+func flattenClusterConfigToState(d *schema.ResourceData, config monitoringModel.ClusterConfig) error {
+	if config.ExtId != nil {
+		if err := d.Set("ext_id", utils.StringValue(config.ExtId)); err != nil {
+			return err
+		}
+	}
+	if config.TenantId != nil {
+		if err := d.Set("tenant_id", utils.StringValue(config.TenantId)); err != nil {
+			return err
+		}
+	}
+	if config.IsEnabled != nil {
+		if err := d.Set("is_enabled", utils.BoolValue(config.IsEnabled)); err != nil {
+			return err
+		}
+	}
+	if config.LastModifiedByUser != nil {
+		if err := d.Set("last_modified_by_user", utils.StringValue(config.LastModifiedByUser)); err != nil {
+			return err
+		}
+	}
+	if config.LastModifiedTime != nil {
+		if err := d.Set("last_modified_time", config.LastModifiedTime.String()); err != nil {
+			return err
+		}
+	}
+	if config.ScheduleIntervalSeconds != nil {
+		if err := d.Set("schedule_interval_seconds", *config.ScheduleIntervalSeconds); err != nil {
+			return err
+		}
+	}
+	if config.Links != nil {
+		if err := d.Set("links", flattenLinks(config.Links)); err != nil {
+			return err
+		}
+	}
+	if config.AlertConfig != nil {
+		if err := d.Set("alert_config", flattenAlertConfig(config.AlertConfig)); err != nil {
+			return err
+		}
+	}
+	if config.ConfigurableParameters != nil {
+		if err := d.Set("configurable_parameters", flattenConfigurableParams(config.ConfigurableParameters)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func flattenClusterConfigs(configs []monitoringModel.ClusterConfig) []map[string]interface{} {
+	if len(configs) == 0 {
+		return []map[string]interface{}{}
+	}
+	result := make([]map[string]interface{}, len(configs))
+	for i, config := range configs {
+		result[i] = flattenClusterConfig(config)
+	}
+	return result
+}
+
+func flattenClusterConfig(config monitoringModel.ClusterConfig) map[string]interface{} {
+	m := map[string]interface{}{
+		"ext_id":                     utils.StringValue(config.ExtId),
+		"tenant_id":                  utils.StringValue(config.TenantId),
+		"is_enabled":                 utils.BoolValue(config.IsEnabled),
+		"last_modified_by_user":      utils.StringValue(config.LastModifiedByUser),
+		"schedule_interval_seconds":  0,
+		"links":                      flattenLinks(config.Links),
+		"alert_config":               flattenAlertConfig(config.AlertConfig),
+		"configurable_parameters":    flattenConfigurableParams(config.ConfigurableParameters),
+		"system_defined_policy_ext_id": "",
+	}
+	if config.LastModifiedTime != nil {
+		m["last_modified_time"] = config.LastModifiedTime.String()
+	} else {
+		m["last_modified_time"] = ""
+	}
+	if config.ScheduleIntervalSeconds != nil {
+		m["schedule_interval_seconds"] = *config.ScheduleIntervalSeconds
+	}
+	return m
+}
+
+func flattenAlertConfig(ac *monitoringModel.AlertConfig) []interface{} {
+	if ac == nil {
+		return []interface{}{}
+	}
+	m := map[string]interface{}{
+		"critical_severity": flattenSeverityConfig(ac.CriticalSeverity),
+		"info_severity":     flattenSeverityConfig(ac.InfoSeverity),
+		"warning_severity":  flattenSeverityConfig(ac.WarningSeverity),
+	}
+	if ac.AutoResolve != nil {
+		m["auto_resolve"] = ac.AutoResolve.GetName()
+	} else {
+		m["auto_resolve"] = ""
+	}
+	return []interface{}{m}
+}
+
+func flattenSeverityConfig(sc *monitoringModel.SeverityConfig) []interface{} {
+	if sc == nil {
+		return []interface{}{}
+	}
+	m := map[string]interface{}{
+		"threshold_parameters": flattenConfigurableParams(sc.ThresholdParameters),
+	}
+	if sc.State != nil {
+		m["state"] = sc.State.GetName()
+	} else {
+		m["state"] = ""
+	}
+	return []interface{}{m}
+}
+
+func flattenConfigurableParams(params []monitoringModel.AlertPolicyConfigurableParameter) []interface{} {
+	if len(params) == 0 {
+		return []interface{}{}
+	}
+	result := make([]interface{}, len(params))
+	for i, param := range params {
+		m := map[string]interface{}{
+			"display_name": utils.StringValue(param.DisplayName),
+			"name":         utils.StringValue(param.Name),
+			"unit":         utils.StringValue(param.Unit),
+			"param_value":  flattenParamValue(param.ParamValue),
+		}
+		result[i] = m
+	}
+	return result
+}
+
+func flattenParamValue(pv *monitoringModel.OneOfAlertPolicyConfigurableParameterParamValue) []interface{} {
+	if pv == nil {
+		return []interface{}{}
+	}
+	value := pv.GetValue()
+	if value == nil {
+		return []interface{}{}
+	}
+
+	m := map[string]interface{}{
+		"int_value":    []interface{}{},
+		"float_value":  []interface{}{},
+		"bool_value":   []interface{}{},
+		"string_value": []interface{}{},
+	}
+
+	switch v := value.(type) {
+	case monitoringModel.IntConfigurableParamValue:
+		intMap := map[string]interface{}{}
+		if v.CurrentIntValue != nil {
+			intMap["current_int_value"] = int(*v.CurrentIntValue)
+		}
+		if v.DefaultIntValue != nil {
+			intMap["default_int_value"] = int(*v.DefaultIntValue)
+		}
+		m["int_value"] = []interface{}{intMap}
+	case monitoringModel.FloatConfigurableParamValue:
+		floatMap := map[string]interface{}{}
+		if v.CurrentFloatValue != nil {
+			floatMap["current_float_value"] = float64(*v.CurrentFloatValue)
+		}
+		if v.DefaultFloatValue != nil {
+			floatMap["default_float_value"] = float64(*v.DefaultFloatValue)
+		}
+		m["float_value"] = []interface{}{floatMap}
+	case monitoringModel.BooleanConfigurableParamValue:
+		boolMap := map[string]interface{}{}
+		if v.CurrentBoolValue != nil {
+			boolMap["current_bool_value"] = *v.CurrentBoolValue
+		}
+		if v.DefaultBoolValue != nil {
+			boolMap["default_bool_value"] = *v.DefaultBoolValue
+		}
+		m["bool_value"] = []interface{}{boolMap}
+	case monitoringModel.StringConfigurableParamValue:
+		strMap := map[string]interface{}{}
+		if v.CurrentStrValue != nil {
+			strMap["current_str_value"] = *v.CurrentStrValue
+		}
+		if v.DefaultStrValue != nil {
+			strMap["default_str_value"] = *v.DefaultStrValue
+		}
+		m["string_value"] = []interface{}{strMap}
+	}
+
+	return []interface{}{m}
+}
+
+// Expand functions
+
+func expandAlertConfig(m map[string]interface{}) *monitoringModel.AlertConfig {
+	ac := &monitoringModel.AlertConfig{}
+	if v, ok := m["auto_resolve"]; ok && v.(string) != "" {
+		var ars monitoringModel.AutoResolveState
+		err := ars.UnmarshalJSON([]byte(fmt.Sprintf(`"%s"`, v.(string))))
+		if err == nil {
+			ac.AutoResolve = ars.Ref()
+		}
+	}
+	if v, ok := m["critical_severity"]; ok {
+		list := v.([]interface{})
+		if len(list) > 0 && list[0] != nil {
+			ac.CriticalSeverity = expandSeverityConfig(list[0].(map[string]interface{}))
+		}
+	}
+	if v, ok := m["info_severity"]; ok {
+		list := v.([]interface{})
+		if len(list) > 0 && list[0] != nil {
+			ac.InfoSeverity = expandSeverityConfig(list[0].(map[string]interface{}))
+		}
+	}
+	if v, ok := m["warning_severity"]; ok {
+		list := v.([]interface{})
+		if len(list) > 0 && list[0] != nil {
+			ac.WarningSeverity = expandSeverityConfig(list[0].(map[string]interface{}))
+		}
+	}
+	return ac
+}
+
+func expandSeverityConfig(m map[string]interface{}) *monitoringModel.SeverityConfig {
+	sc := &monitoringModel.SeverityConfig{}
+	if v, ok := m["state"]; ok && v.(string) != "" {
+		var ps monitoringModel.PropertyState
+		err := ps.UnmarshalJSON([]byte(fmt.Sprintf(`"%s"`, v.(string))))
+		if err == nil {
+			sc.State = ps.Ref()
+		}
+	}
+	if v, ok := m["threshold_parameters"]; ok {
+		sc.ThresholdParameters = expandConfigurableParameters(v.([]interface{}))
+	}
+	return sc
+}
+
+func expandConfigurableParameters(params []interface{}) []monitoringModel.AlertPolicyConfigurableParameter {
+	if len(params) == 0 {
+		return nil
+	}
+	result := make([]monitoringModel.AlertPolicyConfigurableParameter, len(params))
+	for i, p := range params {
+		pm := p.(map[string]interface{})
+		param := monitoringModel.AlertPolicyConfigurableParameter{}
+		if v, ok := pm["name"]; ok && v.(string) != "" {
+			param.Name = utils.StringPtr(v.(string))
+		}
+		if v, ok := pm["param_value"]; ok {
+			paramValueList := v.([]interface{})
+			if len(paramValueList) > 0 && paramValueList[0] != nil {
+				param.ParamValue = expandParamValue(paramValueList[0].(map[string]interface{}))
+			}
+		}
+		result[i] = param
+	}
+	return result
+}
+
+func expandParamValue(m map[string]interface{}) *monitoringModel.OneOfAlertPolicyConfigurableParameterParamValue {
+	pv := monitoringModel.NewOneOfAlertPolicyConfigurableParameterParamValue()
+
+	if v, ok := m["int_value"]; ok {
+		list := v.([]interface{})
+		if len(list) > 0 && list[0] != nil {
+			intMap := list[0].(map[string]interface{})
+			intVal := monitoringModel.IntConfigurableParamValue{}
+			if cv, exists := intMap["current_int_value"]; exists {
+				val := int64(cv.(int))
+				intVal.CurrentIntValue = &val
+			}
+			pv.SetValue(intVal)
+			return pv
+		}
+	}
+	if v, ok := m["float_value"]; ok {
+		list := v.([]interface{})
+		if len(list) > 0 && list[0] != nil {
+			floatMap := list[0].(map[string]interface{})
+			floatVal := monitoringModel.FloatConfigurableParamValue{}
+			if cv, exists := floatMap["current_float_value"]; exists {
+				val := float32(cv.(float64))
+				floatVal.CurrentFloatValue = &val
+			}
+			pv.SetValue(floatVal)
+			return pv
+		}
+	}
+	if v, ok := m["bool_value"]; ok {
+		list := v.([]interface{})
+		if len(list) > 0 && list[0] != nil {
+			boolMap := list[0].(map[string]interface{})
+			boolVal := monitoringModel.BooleanConfigurableParamValue{}
+			if cv, exists := boolMap["current_bool_value"]; exists {
+				val := cv.(bool)
+				boolVal.CurrentBoolValue = &val
+			}
+			pv.SetValue(boolVal)
+			return pv
+		}
+	}
+	if v, ok := m["string_value"]; ok {
+		list := v.([]interface{})
+		if len(list) > 0 && list[0] != nil {
+			strMap := list[0].(map[string]interface{})
+			strVal := monitoringModel.StringConfigurableParamValue{}
+			if cv, exists := strMap["current_str_value"]; exists {
+				strVal.CurrentStrValue = utils.StringPtr(cv.(string))
+			}
+			pv.SetValue(strVal)
+			return pv
+		}
+	}
+	return nil
+}

--- a/nutanix/services/monitoringv2/helpers.go
+++ b/nutanix/services/monitoringv2/helpers.go
@@ -305,9 +305,9 @@ func schemaForAlertConfig() *schema.Schema {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"critical_severity":  schemaForSeverityConfig(),
-				"info_severity":      schemaForSeverityConfig(),
-				"warning_severity":   schemaForSeverityConfig(),
+				"critical_severity": schemaForSeverityConfig(),
+				"info_severity":     schemaForSeverityConfig(),
+				"warning_severity":  schemaForSeverityConfig(),
 			},
 		},
 	}
@@ -326,9 +326,9 @@ func schemaForAlertConfigResource() *schema.Schema {
 					Optional: true,
 					Computed: true,
 				},
-				"critical_severity":  schemaForSeverityConfigResource(),
-				"info_severity":      schemaForSeverityConfigResource(),
-				"warning_severity":   schemaForSeverityConfigResource(),
+				"critical_severity": schemaForSeverityConfigResource(),
+				"info_severity":     schemaForSeverityConfigResource(),
+				"warning_severity":  schemaForSeverityConfigResource(),
 			},
 		},
 	}
@@ -470,14 +470,14 @@ func flattenClusterConfigs(configs []monitoringModel.ClusterConfig) []map[string
 
 func flattenClusterConfig(config monitoringModel.ClusterConfig) map[string]interface{} {
 	m := map[string]interface{}{
-		"ext_id":                     utils.StringValue(config.ExtId),
-		"tenant_id":                  utils.StringValue(config.TenantId),
-		"is_enabled":                 utils.BoolValue(config.IsEnabled),
-		"last_modified_by_user":      utils.StringValue(config.LastModifiedByUser),
-		"schedule_interval_seconds":  0,
-		"links":                      flattenLinks(config.Links),
-		"alert_config":               flattenAlertConfig(config.AlertConfig),
-		"configurable_parameters":    flattenConfigurableParams(config.ConfigurableParameters),
+		"ext_id":                       utils.StringValue(config.ExtId),
+		"tenant_id":                    utils.StringValue(config.TenantId),
+		"is_enabled":                   utils.BoolValue(config.IsEnabled),
+		"last_modified_by_user":        utils.StringValue(config.LastModifiedByUser),
+		"schedule_interval_seconds":    0,
+		"links":                        flattenLinks(config.Links),
+		"alert_config":                 flattenAlertConfig(config.AlertConfig),
+		"configurable_parameters":      flattenConfigurableParams(config.ConfigurableParameters),
 		"system_defined_policy_ext_id": "",
 	}
 	if config.LastModifiedTime != nil {

--- a/nutanix/services/monitoringv2/main_test.go
+++ b/nutanix/services/monitoringv2/main_test.go
@@ -1,0 +1,40 @@
+package monitoringv2_test
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"testing"
+)
+
+type TestConfig struct {
+	SystemDefinedPolicyExtID string `json:"system_defined_policy_ext_id"`
+	ClusterExtID             string `json:"cluster_ext_id"`
+}
+
+var testVars TestConfig
+
+var (
+	path, _  = os.Getwd()
+	filepath = path + "/../../../test_config_v2.json"
+)
+
+func loadVars(filepath string, varStruct interface{}) {
+	configData, err := os.ReadFile(filepath)
+	if err != nil {
+		log.Printf("Got this error while reading config.json: %s", err.Error())
+		os.Exit(1)
+	}
+
+	err = json.Unmarshal(configData, varStruct)
+	if err != nil {
+		log.Printf("Got this error while unmarshalling config.json: %s", err.Error())
+		os.Exit(1)
+	}
+}
+
+func TestMain(m *testing.M) {
+	log.Println("Setting up monitoringv2 tests")
+	loadVars("../../../test_config_v2.json", &testVars)
+	os.Exit(m.Run())
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_sda_cluster_config_v2.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_sda_cluster_config_v2.go
@@ -1,0 +1,239 @@
+package monitoringv2
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	monitoringModel "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	taskRef "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/prism/v4/config"
+	prismConfig "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/prism/v4/config"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/common"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func ResourceNutanixSdaClusterConfigV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNutanixSdaClusterConfigV2Create,
+		ReadContext:   resourceNutanixSdaClusterConfigV2Read,
+		UpdateContext: resourceNutanixSdaClusterConfigV2Update,
+		DeleteContext: resourceNutanixSdaClusterConfigV2Delete,
+		Schema: map[string]*schema.Schema{
+			"system_defined_policy_ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Unique ID of the System-Defined Alert Policy.",
+			},
+			"ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Cluster UUID.",
+			},
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A globally unique identifier that represents the tenant that owns this entity. The system automatically assigns it, and it and is immutable from an API consumer perspective (some use cases may cause this ID to change - For instance, a use case may require the transfer of ownership of the entity, but these cases are handled automatically on the server).",
+			},
+			"links": schemaForLinks(),
+			"is_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Indicates whether the SDA policy is enabled or not on the cluster.",
+			},
+			"last_modified_by_user": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Name of the user who made the latest update to this policy. Its value will be Nutanix if the last update is due to an upgrade event.",
+			},
+			"last_modified_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Time in ISO 8601 format when the SDA policy was last modified. It gets automatically updated by the Nutanix service from the user context during an update event.",
+			},
+			"schedule_interval_seconds": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "Interval in seconds for periodically executing the SDA policy. This will not be set for policies with the type NOT_SCHEDULED & EVENT_DRIVEN.",
+			},
+			"alert_config":              schemaForAlertConfigResource(),
+			"configurable_parameters":   schemaForConfigurableParametersResource(),
+		},
+	}
+}
+
+func resourceNutanixSdaClusterConfigV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	sdaPolicyExtID := d.Get("system_defined_policy_ext_id").(string)
+	extID := d.Get("ext_id").(string)
+
+	readResp, err := conn.SystemDefinedPoliciesAPI.GetClusterConfigById(
+		utils.StringPtr(sdaPolicyExtID),
+		utils.StringPtr(extID),
+	)
+	if err != nil {
+		return diag.Errorf("error while fetching SDA cluster config for create: %v", err)
+	}
+
+	etagValue := conn.SystemDefinedPoliciesAPI.ApiClient.GetEtag(readResp)
+	args := make(map[string]interface{})
+	args["If-Match"] = utils.StringPtr(etagValue)
+
+	body := readResp.Data.GetValue().(monitoringModel.ClusterConfig)
+
+	if v, ok := d.GetOk("is_enabled"); ok {
+		body.IsEnabled = utils.BoolPtr(v.(bool))
+	}
+	if v, ok := d.GetOk("alert_config"); ok {
+		alertConfigList := v.([]interface{})
+		if len(alertConfigList) > 0 && alertConfigList[0] != nil {
+			body.AlertConfig = expandAlertConfig(alertConfigList[0].(map[string]interface{}))
+		}
+	}
+	if v, ok := d.GetOk("configurable_parameters"); ok {
+		body.ConfigurableParameters = expandConfigurableParameters(v.([]interface{}))
+	}
+
+	aJSON, _ := json.MarshalIndent(body, "", "  ")
+	log.Printf("[DEBUG] Update SDA Cluster Config (Create) Payload: %s", string(aJSON))
+
+	resp, err := conn.SystemDefinedPoliciesAPI.UpdateClusterConfigById(
+		utils.StringPtr(sdaPolicyExtID),
+		utils.StringPtr(extID),
+		&body,
+		args,
+	)
+	if err != nil {
+		return diag.Errorf("error while updating SDA cluster config: %v", err)
+	}
+
+	TaskRefVal := resp.Data.GetValue().(taskRef.TaskReference)
+	taskUUID := TaskRefVal.ExtId
+
+	taskconn := meta.(*conns.Client).PrismAPI
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"QUEUED", "RUNNING", "PENDING"},
+		Target:  []string{"SUCCEEDED"},
+		Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, taskconn, utils.StringValue(taskUUID)),
+		Timeout: d.Timeout(schema.TimeoutCreate),
+	}
+
+	if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
+		return diag.Errorf("error waiting for SDA cluster config (%s) to update: %s", utils.StringValue(taskUUID), errWaitTask)
+	}
+
+	taskResp, err := taskconn.TaskRefAPI.GetTaskById(taskUUID, nil)
+	if err != nil {
+		return diag.Errorf("error while fetching SDA cluster config update task: %v", err)
+	}
+	taskDetails := taskResp.Data.GetValue().(prismConfig.Task)
+	aJSON, _ = json.MarshalIndent(taskDetails, "", "  ")
+	log.Printf("[DEBUG] SDA Cluster Config Update Task Details: %s", string(aJSON))
+
+	d.SetId(extID)
+	return resourceNutanixSdaClusterConfigV2Read(ctx, d, meta)
+}
+
+func resourceNutanixSdaClusterConfigV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	sdaPolicyExtID := d.Get("system_defined_policy_ext_id").(string)
+	extID := d.Id()
+
+	resp, err := conn.SystemDefinedPoliciesAPI.GetClusterConfigById(
+		utils.StringPtr(sdaPolicyExtID),
+		utils.StringPtr(extID),
+	)
+	if err != nil {
+		return diag.Errorf("error while reading SDA cluster config: %v", err)
+	}
+
+	body := resp.Data.GetValue().(monitoringModel.ClusterConfig)
+	aJSON, _ := json.MarshalIndent(body, "", "  ")
+	log.Printf("[DEBUG] Read SDA Cluster Config Response: %s", string(aJSON))
+
+	if err := flattenClusterConfigToState(d, body); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourceNutanixSdaClusterConfigV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	sdaPolicyExtID := d.Get("system_defined_policy_ext_id").(string)
+	extID := d.Id()
+
+	readResp, err := conn.SystemDefinedPoliciesAPI.GetClusterConfigById(
+		utils.StringPtr(sdaPolicyExtID),
+		utils.StringPtr(extID),
+	)
+	if err != nil {
+		return diag.Errorf("error while fetching SDA cluster config for update: %v", err)
+	}
+
+	etagValue := conn.SystemDefinedPoliciesAPI.ApiClient.GetEtag(readResp)
+	args := make(map[string]interface{})
+	args["If-Match"] = utils.StringPtr(etagValue)
+
+	body := readResp.Data.GetValue().(monitoringModel.ClusterConfig)
+
+	if d.HasChange("is_enabled") {
+		body.IsEnabled = utils.BoolPtr(d.Get("is_enabled").(bool))
+	}
+	if d.HasChange("alert_config") {
+		if v, ok := d.GetOk("alert_config"); ok {
+			alertConfigList := v.([]interface{})
+			if len(alertConfigList) > 0 && alertConfigList[0] != nil {
+				body.AlertConfig = expandAlertConfig(alertConfigList[0].(map[string]interface{}))
+			}
+		}
+	}
+	if d.HasChange("configurable_parameters") {
+		if v, ok := d.GetOk("configurable_parameters"); ok {
+			body.ConfigurableParameters = expandConfigurableParameters(v.([]interface{}))
+		}
+	}
+
+	aJSON, _ := json.MarshalIndent(body, "", "  ")
+	log.Printf("[DEBUG] Update SDA Cluster Config Payload: %s", string(aJSON))
+
+	resp, err := conn.SystemDefinedPoliciesAPI.UpdateClusterConfigById(
+		utils.StringPtr(sdaPolicyExtID),
+		utils.StringPtr(extID),
+		&body,
+		args,
+	)
+	if err != nil {
+		return diag.Errorf("error while updating SDA cluster config: %v", err)
+	}
+
+	TaskRefVal := resp.Data.GetValue().(taskRef.TaskReference)
+	taskUUID := TaskRefVal.ExtId
+
+	taskconn := meta.(*conns.Client).PrismAPI
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"QUEUED", "RUNNING", "PENDING"},
+		Target:  []string{"SUCCEEDED"},
+		Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, taskconn, utils.StringValue(taskUUID)),
+		Timeout: d.Timeout(schema.TimeoutUpdate),
+	}
+
+	if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
+		return diag.Errorf("error waiting for SDA cluster config (%s) to update: %s", utils.StringValue(taskUUID), errWaitTask)
+	}
+
+	return resourceNutanixSdaClusterConfigV2Read(ctx, d, meta)
+}
+
+func resourceNutanixSdaClusterConfigV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_sda_cluster_config_v2.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_sda_cluster_config_v2.go
@@ -63,8 +63,8 @@ func ResourceNutanixSdaClusterConfigV2() *schema.Resource {
 				Computed:    true,
 				Description: "Interval in seconds for periodically executing the SDA policy. This will not be set for policies with the type NOT_SCHEDULED & EVENT_DRIVEN.",
 			},
-			"alert_config":              schemaForAlertConfigResource(),
-			"configurable_parameters":   schemaForConfigurableParametersResource(),
+			"alert_config":            schemaForAlertConfigResource(),
+			"configurable_parameters": schemaForConfigurableParametersResource(),
 		},
 	}
 }

--- a/nutanix/services/monitoringv2/resource_nutanix_sda_cluster_config_v2_test.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_sda_cluster_config_v2_test.go
@@ -1,0 +1,37 @@
+package monitoringv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const resourceNameClusterConfig = "nutanix_sda_cluster_config_v2.test"
+
+func TestAccV2NutanixSdaClusterConfigResource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSdaClusterConfigResourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameClusterConfig, "ext_id"),
+					resource.TestCheckResourceAttrSet(resourceNameClusterConfig, "system_defined_policy_ext_id"),
+					resource.TestCheckResourceAttrSet(resourceNameClusterConfig, "is_enabled"),
+					resource.TestCheckResourceAttrSet(resourceNameClusterConfig, "last_modified_by_user"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSdaClusterConfigResourceConfig() string {
+	return `
+		resource "nutanix_sda_cluster_config_v2" "test" {
+			system_defined_policy_ext_id = "` + testVars.SystemDefinedPolicyExtID + `"
+			ext_id                       = "` + testVars.ClusterExtID + `"
+		}
+	`
+}

--- a/website/docs/d/sda_cluster_config_v2.html.markdown
+++ b/website/docs/d/sda_cluster_config_v2.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_sda_cluster_config_v2"
+sidebar_current: "docs-nutanix-datasource-sda-cluster-config-v2"
+description: |-
+  Retrieves the cluster specific configuration associated with a System-Defined Alert Policy identified by external identifier of the System-Defined Alert Policy for a cluster identified by cluster identifier.
+---
+
+# nutanix_sda_cluster_config_v2
+
+Retrieves the cluster specific configuration associated with a System-Defined Alert Policy identified by external identifier of the System-Defined Alert Policy for a cluster identified by cluster identifier.
+
+## Example Usage
+
+```hcl
+data "nutanix_sda_cluster_config_v2" "example" {
+  system_defined_policy_ext_id = "<system-defined-policy-ext-id>"
+  ext_id                       = "<cluster-uuid>"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `system_defined_policy_ext_id`: (Required) Unique ID of the System-Defined Alert Policy.
+* `ext_id`: (Required) Cluster UUID.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `tenant_id`: A globally unique identifier that represents the tenant that owns this entity. The system automatically assigns it, and it and is immutable from an API consumer perspective (some use cases may cause this ID to change - For instance, a use case may require the transfer of ownership of the entity, but these cases are handled automatically on the server).
+* `links`: A HATEOAS style link for the response. Each link contains a user-friendly name identifying the link and an address for retrieving the particular resource.
+  * `rel`: A name that identifies the relationship of the link to the object that is returned by the URL. The unique value of "self" identifies the URL for the object.
+  * `href`: The URL at which the entity described by the link can be accessed.
+* `is_enabled`: Indicates whether the SDA policy is enabled or not on the cluster.
+* `last_modified_by_user`: Name of the user who made the latest update to this policy. Its value will be Nutanix if the last update is due to an upgrade event.
+* `last_modified_time`: Time in ISO 8601 format when the SDA policy was last modified. It gets automatically updated by the Nutanix service from the user context during an update event.
+* `schedule_interval_seconds`: Interval in seconds for periodically executing the SDA policy. This will not be set for policies with the type NOT_SCHEDULED & EVENT_DRIVEN.
+* `alert_config`: Alert configuration for the cluster.
+  * `auto_resolve`: Auto-resolve state for the alert policy.
+  * `critical_severity`: Configuration for critical severity.
+    * `state`: Property state (ENABLED, DISABLED, NOT_SUPPORTED).
+    * `threshold_parameters`: Captures alert-related thresholds that correspond to a particular severity.
+      * `display_name`: Equivalent name for the parameter used to display it on Prism UI.
+      * `name`: Unique identifier name for the parameter.
+      * `param_value`: Captures the parameter value.
+        * `int_value`: Integer parameter value.
+          * `current_int_value`: Captures the current value of the parameter.
+          * `default_int_value`: Captures the default value of the parameter.
+        * `float_value`: Float parameter value.
+          * `current_float_value`: Captures the current value of the parameter.
+          * `default_float_value`: Captures the default value of the parameter.
+        * `bool_value`: Boolean parameter value.
+          * `current_bool_value`: Captures the current value of the parameter.
+          * `default_bool_value`: Captures the default value of the parameter.
+        * `string_value`: String parameter value.
+          * `current_str_value`: Captures the current value of the parameter.
+          * `default_str_value`: Captures the default value of the parameter.
+      * `unit`: Unit for the parameter. For example, sec, %, MB, GB, and so on.
+  * `info_severity`: Configuration for info severity. Same structure as `critical_severity`.
+  * `warning_severity`: Configuration for warning severity. Same structure as `critical_severity`.
+* `configurable_parameters`: Parameters of the SDA that are configurable by a user. Same structure as `threshold_parameters`.
+
+See detailed information in [Nutanix Monitoring v4 API Reference](https://developers.nutanix.com/).

--- a/website/docs/d/sda_cluster_configs_v2.html.markdown
+++ b/website/docs/d/sda_cluster_configs_v2.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_sda_cluster_configs_v2"
+sidebar_current: "docs-nutanix-datasource-sda-cluster-configs-v2"
+description: |-
+  Retrieves cluster specific configurations associated with a System-Defined Alert Policy identified by the external identifier of the System-Defined Alert Policy.
+---
+
+# nutanix_sda_cluster_configs_v2
+
+Retrieves cluster specific configurations associated with a System-Defined Alert Policy identified by the external identifier of the System-Defined Alert Policy.
+
+## Example Usage
+
+```hcl
+data "nutanix_sda_cluster_configs_v2" "example" {
+  system_defined_policy_ext_id = "<system-defined-policy-ext-id>"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `system_defined_policy_ext_id`: (Required) Unique ID of the System-Defined Alert Policy.
+* `page`: (Optional) Page number for pagination.
+* `limit`: (Optional) Number of results per page.
+* `filter`: (Optional) OData filter expression.
+* `order_by`: (Optional) OData order-by expression.
+* `select`: (Optional) OData select expression.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `cluster_configs`: List of cluster configurations.
+
+Each entry in `cluster_configs` contains the same attributes as the `nutanix_sda_cluster_config_v2` datasource. Please refer to the [nutanix_sda_cluster_config_v2](sda_cluster_config_v2) documentation for attribute details.
+
+See detailed information in [Nutanix Monitoring v4 API Reference](https://developers.nutanix.com/).

--- a/website/docs/r/sda_cluster_config_v2.html.markdown
+++ b/website/docs/r/sda_cluster_config_v2.html.markdown
@@ -1,0 +1,85 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_sda_cluster_config_v2"
+sidebar_current: "docs-nutanix-resource-sda-cluster-config-v2"
+description: |-
+  Modifies cluster-specific configuration associated with a System-Defined Alert Policy identified by external identifier of the System-Defined Alert Policy for a cluster identified by cluster identifier.
+---
+
+# nutanix_sda_cluster_config_v2
+
+Modifies cluster-specific configuration associated with a System-Defined Alert Policy identified by external identifier of the System-Defined Alert Policy for a cluster identified by cluster identifier.
+
+~> **Note:** This resource does not support delete. Destroying this resource will only remove it from state.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+resource "nutanix_sda_cluster_config_v2" "example" {
+  system_defined_policy_ext_id = "<system-defined-policy-ext-id>"
+  ext_id                       = "<cluster-uuid>"
+  is_enabled                   = true
+}
+```
+
+### With Alert Config
+
+```hcl
+resource "nutanix_sda_cluster_config_v2" "example" {
+  system_defined_policy_ext_id = "<system-defined-policy-ext-id>"
+  ext_id                       = "<cluster-uuid>"
+  is_enabled                   = true
+
+  alert_config {
+    auto_resolve = "ENABLED"
+    critical_severity {
+      state = "ENABLED"
+    }
+    warning_severity {
+      state = "ENABLED"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `system_defined_policy_ext_id`: (Required) Unique ID of the System-Defined Alert Policy.
+* `ext_id`: (Required) Cluster UUID.
+* `is_enabled`: (Optional) Indicates whether the SDA policy is enabled or not on the cluster.
+* `schedule_interval_seconds`: (Optional) Interval in seconds for periodically executing the SDA policy. This will not be set for policies with the type NOT_SCHEDULED & EVENT_DRIVEN.
+* `alert_config`: (Optional) Alert configuration for the cluster.
+  * `auto_resolve`: (Optional) Auto-resolve state for the alert policy. Valid values: `ENABLED`, `DISABLED`, `NOT_SUPPORTED`.
+  * `critical_severity`: (Optional) Configuration for critical severity.
+    * `state`: (Optional) Property state. Valid values: `ENABLED`, `DISABLED`, `NOT_SUPPORTED`.
+    * `threshold_parameters`: (Optional) Captures alert-related thresholds that correspond to a particular severity.
+      * `name`: (Optional) Unique identifier name for the parameter.
+      * `param_value`: (Optional) Captures the parameter value.
+        * `int_value`: (Optional) Integer parameter value.
+          * `current_int_value`: (Optional) Captures the current value of the parameter.
+        * `float_value`: (Optional) Float parameter value.
+          * `current_float_value`: (Optional) Captures the current value of the parameter.
+        * `bool_value`: (Optional) Boolean parameter value.
+          * `current_bool_value`: (Optional) Captures the current value of the parameter.
+        * `string_value`: (Optional) String parameter value.
+          * `current_str_value`: (Optional) Captures the current value of the parameter.
+  * `info_severity`: (Optional) Configuration for info severity. Same structure as `critical_severity`.
+  * `warning_severity`: (Optional) Configuration for warning severity. Same structure as `critical_severity`.
+* `configurable_parameters`: (Optional) Parameters of the SDA that are configurable by a user. Same structure as `threshold_parameters`.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `tenant_id`: A globally unique identifier that represents the tenant that owns this entity.
+* `links`: A HATEOAS style link for the response.
+  * `rel`: A name that identifies the relationship of the link to the object that is returned by the URL.
+  * `href`: The URL at which the entity described by the link can be accessed.
+* `last_modified_by_user`: Name of the user who made the latest update to this policy.
+* `last_modified_time`: Time in ISO 8601 format when the SDA policy was last modified.
+
+See detailed information in [Nutanix Monitoring v4 API Reference](https://developers.nutanix.com/).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Auto-generated Terraform provider code for the **monitoring** namespace, entity
**cluster**, based on the inline `sdk_info.json` (see prompt). One PR per code-gen run.

- SDK module: `github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4@v4.2.2`
- API methods covered: 3 (GetClusterConfigById, ListClusterConfigsBySdaId, UpdateClusterConfigById)
- Datasources generated: 2 (`nutanix_sda_cluster_config_v2`, `nutanix_sda_cluster_configs_v2`)
- Resources generated: 1 (`nutanix_sda_cluster_config_v2`)

## Files changed

### `nutanix/sdks/v4/monitoring/`
- `monitoring.go` — New monitoring SDK client wrapping `SystemDefinedPoliciesApi`

### `nutanix/` (config & provider)
- `config.go` — Added `MonitoringAPI *monitoring.Client` field and initialization
- `provider/provider.go` — Registered 2 datasources and 1 resource, added `monitoringv2` import

### `nutanix/services/monitoringv2/`
- `data_source_nutanix_sda_cluster_config_v2.go` — Singular datasource (GetClusterConfigById)
- `data_source_nutanix_sda_cluster_configs_v2.go` — Plural datasource (ListClusterConfigsBySdaId)
- `resource_nutanix_sda_cluster_config_v2.go` — Resource with Create(=Update), Read, Update, Delete(=no-op)
- `helpers.go` — Schema definitions, flatten/expand functions for ClusterConfig, AlertConfig, SeverityConfig, ConfigurableParameters, ParamValue (OneOf handling via GetValue() + type switch)
- `main_test.go` — Test config loader
- `data_source_nutanix_sda_cluster_config_v2_test.go` — Singular datasource acceptance test
- `data_source_nutanix_sda_cluster_configs_v2_test.go` — Plural datasource acceptance test
- `resource_nutanix_sda_cluster_config_v2_test.go` — Resource acceptance test

### `examples/monitoring_v2/cluster_config/`
- `main.tf` — Working examples for datasources and resource
- `variables.tf` — Variable definitions

### `website/docs/d/`
- `sda_cluster_config_v2.html.markdown` — Singular datasource documentation
- `sda_cluster_configs_v2.html.markdown` — Plural datasource documentation

### `website/docs/r/`
- `sda_cluster_config_v2.html.markdown` — Resource documentation

### `go.mod` / `go.sum`
- Added `github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2`

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `TF_ACC=1 go test ./nutanix/services/monitoringv2 -v -run="TestAccV2NutanixSda" -timeout 500m -coverprofile c.out -covermode=count` |
| Total testcases     | 3                                              |
| Passed              | 0                                              |
| Failed              | 3 (see analysis below)                         |
| Skipped             | 0                                              |
| Wall-clock duration | 0:00:32                                        |
| Cluster (PC)        | `10.44.76.91`                                  |

### Analysis

All 3 tests failed due to the Nutanix cluster at `10.44.76.91` being unreachable — every TCP connection is reset by peer. This is an **infrastructure connectivity issue**, not a code defect.

**Known issues:**
- `TestAccV2NutanixSdaClusterConfigDatasource_Basic` — Connection reset by peer to 10.44.76.91:9440
- `TestAccV2NutanixSdaClusterConfigsDatasource_Basic` — Connection reset by peer to 10.44.76.91:9440
- `TestAccV2NutanixSdaClusterConfigResource_Basic` — Connection reset by peer to 10.44.76.91:9440

Additionally, `test_config_v2.json` does not contain `system_defined_policy_ext_id` or `cluster_ext_id` values for the monitoring tests, so the URLs contain empty path segments (e.g., `/system-defined-policies//cluster-configs/`). These fields need to be populated in the test config for a real run.

The code compiles (`go build ./...`) and passes vet (`go vet ./nutanix/services/monitoringv2/...`) cleanly.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
2026/04/29 06:23:44 Setting up monitoringv2 tests
=== RUN   TestAccV2NutanixSdaClusterConfigDatasource_Basic
2026-04-29 06:23:44.511Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 06:23:44.511Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 06:23:49.514Z ERROR - Options "https://10.44.76.91:9440/api/monitoring/unversioned/info": read tcp 172.30.0.2:57132->10.44.76.91:9440: read: connection reset by peer
2026-04-29 06:23:49.514Z ERROR - Could not fetch supported versions from server with error
2026-04-29 06:23:49.514Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/system-defined-policies//cluster-configs
2026-04-29 06:23:49.515Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/system-defined-policies//cluster-configs/
2026-04-29 06:23:54.517Z ERROR - connection reset by peer
2026-04-29 06:23:54.518Z ERROR - connection reset by peer
--- FAIL: TestAccV2NutanixSdaClusterConfigDatasource_Basic (10.53s)
=== RUN   TestAccV2NutanixSdaClusterConfigsDatasource_Basic
2026-04-29 06:23:54.987Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 06:23:59.993Z ERROR - connection reset by peer
2026-04-29 06:23:59.993Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/system-defined-policies//cluster-configs
2026-04-29 06:24:04.996Z ERROR - connection reset by peer
--- FAIL: TestAccV2NutanixSdaClusterConfigsDatasource_Basic (10.46s)
=== RUN   TestAccV2NutanixSdaClusterConfigResource_Basic
2026-04-29 06:24:06.042Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 06:24:11.046Z ERROR - connection reset by peer
2026-04-29 06:24:11.046Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/system-defined-policies//cluster-configs/
2026-04-29 06:24:16.050Z ERROR - connection reset by peer
--- FAIL: TestAccV2NutanixSdaClusterConfigResource_Basic (11.14s)
FAIL
coverage: 11.8% of statements
FAIL	github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/monitoringv2	32.168s
FAIL
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` are stored only in the agent transcript;
  no `sdk_info.json` is committed to this branch.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1306fbae-ec78-4a49-80ed-829dc984cc8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1306fbae-ec78-4a49-80ed-829dc984cc8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


## Cursor Usage
```
"timestamp": "1777442940043",
            "model": "claude-4.6-opus-high",
            "kind": "USAGE_EVENT_KIND_USAGE_BASED",
            "maxMode": true,
            "requestsCosts": 295.70001220703125,
            "usageBasedCosts": "$11.83",
            "isTokenBasedCall": true,
            "tokenUsage": {
                "inputTokens": 470,
                "outputTokens": 41006,
                "cacheWriteTokens": 299293,
                "cacheReadTokens": 14316824,
                "totalCents": 1182.94091796875
            },
            "owningUser": "299808808",
            "owningTeam": "11877457",
            "cursorTokenFee": 0,
            "isChargeable": true,
            "isHeadless": true,
            "chargedCents": 1182.94091796875,
            "cloudAgentId": "bc-1306fbae-ec78-4a49-80ed-829dc984cc8a"
```
<img width="1506" height="938" alt="Screenshot 2026-04-30 at 11 11 00 AM" src="https://github.com/user-attachments/assets/13f5577a-8e42-4ed3-994d-927c01bcec69" />