### PR TITLE
code-gen(monitoring/alert): terraform v2 provider code

### DIFF
--- a/examples/monitoring_v2/alert/main.tf
+++ b/examples/monitoring_v2/alert/main.tf
@@ -1,0 +1,34 @@
+variable "nutanix_endpoint" {}
+variable "nutanix_username" {}
+variable "nutanix_password" {}
+variable "nutanix_port" {}
+variable "nutanix_insecure" {}
+
+provider "nutanix" {
+  endpoint = var.nutanix_endpoint
+  username = var.nutanix_username
+  password = var.nutanix_password
+  port     = var.nutanix_port
+  insecure = var.nutanix_insecure
+}
+
+# Update alert email configuration
+resource "nutanix_alert_email_configuration_v2" "example" {
+  is_enabled              = true
+  is_email_digest_enabled = true
+  email_contact_list      = ["admin@example.com"]
+}
+
+# Manage alert - acknowledge
+resource "nutanix_manage_alert_v2" "example" {
+  ext_id      = "00000000-0000-0000-0000-000000000000"
+  action_type = "ACKNOWLEDGE"
+}
+
+# Get a single alert by ID
+data "nutanix_alert_v2" "example" {
+  ext_id = "00000000-0000-0000-0000-000000000000"
+}
+
+# List all alerts
+data "nutanix_alerts_v2" "example" {}

--- a/examples/monitoring_v2/alert/provider.tf
+++ b/examples/monitoring_v2/alert/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = ">= 2.0.0"
+    }
+  }
+}

--- a/examples/monitoring_v2/alert/terraform.tfvars
+++ b/examples/monitoring_v2/alert/terraform.tfvars
@@ -1,0 +1,5 @@
+nutanix_endpoint = "10.0.0.1"
+nutanix_username = "admin"
+nutanix_password = "REPLACE_ME"
+nutanix_port     = 9440
+nutanix_insecure = true

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4 v4.1.2-beta.2
 	github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2
 	github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2
+	github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2
 	github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1
 	github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4 v4.0.3
 	github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4 v4.3.1

--- a/go.sum
+++ b/go.sum
@@ -467,6 +467,8 @@ github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2 h1:ms+a
 github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2/go.mod h1:X3TsJoGBbkQzz6OP8Be7XvGhH4CwKkF9t35OmJpPY0w=
 github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2 h1:dE0zUP3ExJBnMUaGDAIZGN7/UZ0a85IWzHygMGcUDMc=
 github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2/go.mod h1:vo3VMB097Zd9cw4hLDbnpyBVcBZkpFmcQ2nNgpOpo7U=
+github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2 h1:dXFgnBHMd6MipSXkQE5cRysjKX96MeYeIFIkZDvye60=
+github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2/go.mod h1:msvlZou4z7vn5pHFhJ65OtAbh99z1ISsqCzfehdcWfw=
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1 h1:VWxK8mY6kOag/ocDBttDViktEi8bcjbAvm3i9laDyCA=
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1/go.mod h1:4fUdP3zeL4UFS/UVaii5EdS2v+KlM4gI07KcnS+wDuY=
 github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4 v4.0.3 h1:TE/G5GHrnvBGPI8MC0fSMSAaeD6HcdtezIgEmn8V/Yo=

--- a/nutanix/config.go
+++ b/nutanix/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/iam"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/lcm"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/microseg"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/monitoring"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/networking"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/objectstores"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/prism"
@@ -140,6 +141,10 @@ func (c *Config) Client() (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	MonitoringClient, err := monitoring.NewMonitoringClient(configCreds)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Client{
 		WaitTimeout:         c.WaitTimeout,
@@ -161,6 +166,7 @@ func (c *Config) Client() (*Client, error) {
 		CalmAPI:             calmClient,
 		ObjectStoreAPI:      ObjectStoreClient,
 		SecurityAPI:         SecurityClient,
+		MonitoringAPI:       MonitoringClient,
 	}, nil
 }
 
@@ -185,4 +191,5 @@ type Client struct {
 	CalmAPI             *selfservice.Client
 	ObjectStoreAPI      *objectstores.Client
 	SecurityAPI         *security.Client
+	MonitoringAPI       *monitoring.Client
 }

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/iamv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/lcmv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/microsegv2"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/monitoringv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/ndb"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/networking"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/networkingv2"
@@ -370,6 +371,8 @@ func Provider() *schema.Provider {
 			"nutanix_stigs_v2":                                securityv2.DatasourceNutanixStigsControlsV2(),
 			"nutanix_entity_group_v2":                         microsegv2.DatasourceNutanixEntityGroupV2(),
 			"nutanix_entity_groups_v2":                        microsegv2.DatasourceNutanixEntityGroupsV2(),
+			"nutanix_alert_v2":                                monitoringv2.DatasourceNutanixAlertV2(),
+			"nutanix_alerts_v2":                               monitoringv2.DatasourceNutanixAlertsV2(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"nutanix_virtual_machine":                         vmm.ResourceNutanixVirtualMachine(),
@@ -501,6 +504,8 @@ func Provider() *schema.Provider {
 			"nutanix_object_store_certificate_v2":             objectstoresv2.ResourceNutanixObjectStoreCertificateV2(),
 			"nutanix_key_management_server_v2":                securityv2.ResourceNutanixKeyManagementServerV2(),
 			"nutanix_entity_group_v2":                         microsegv2.ResourceNutanixEntityGroupV2(),
+			"nutanix_alert_email_configuration_v2":            monitoringv2.ResourceNutanixAlertEmailConfigurationV2(),
+			"nutanix_manage_alert_v2":                         monitoringv2.ResourceNutanixManageAlertV2(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}

--- a/nutanix/sdks/v4/monitoring/monitoring.go
+++ b/nutanix/sdks/v4/monitoring/monitoring.go
@@ -1,0 +1,35 @@
+package monitoring
+
+import (
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/api"
+	monitoringClient "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
+)
+
+type Client struct {
+	AlertEmailConfiguration *api.AlertEmailConfigurationApi
+	Alerts                  *api.AlertsApi
+	ManageAlerts            *api.ManageAlertsApi
+}
+
+func NewMonitoringClient(credentials client.Credentials) (*Client, error) {
+	var baseClient *monitoringClient.ApiClient
+
+	pcClient := monitoringClient.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
+		baseClient = pcClient
+	}
+
+	return &Client{
+		AlertEmailConfiguration: api.NewAlertEmailConfigurationApi(baseClient),
+		Alerts:                  api.NewAlertsApi(baseClient),
+		ManageAlerts:            api.NewManageAlertsApi(baseClient),
+	}, nil
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_alert_v2.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_alert_v2.go
@@ -1,0 +1,127 @@
+package monitoringv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	monitoringService "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixAlertV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DatasourceNutanixAlertV2Read,
+		Schema:     schemaForAlertComputed(),
+	}
+}
+
+func DatasourceNutanixAlertV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	extID := d.Get("ext_id").(string)
+
+	resp, err := conn.Alerts.GetAlertById(utils.StringPtr(extID))
+	if err != nil {
+		return diag.Errorf("error while fetching alert: %s", err)
+	}
+
+	alert := resp.Data.GetValue().(monitoringService.Alert)
+
+	if err := d.Set("tenant_id", utils.StringValue(alert.TenantId)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("links", flattenLinks(alert.Links)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("acknowledged_by_username", utils.StringValue(alert.AcknowledgedByUsername)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("acknowledged_time", utils.TimeStringValue(alert.AcknowledgedTime)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("affected_entities", flattenEntityReferences(alert.AffectedEntities)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("alert_type", utils.StringValue(alert.AlertType)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("classifications", alert.Classifications); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("cluster_name", utils.StringValue(alert.ClusterName)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("cluster_uuid", utils.StringValue(alert.ClusterUUID)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("creation_time", utils.TimeStringValue(alert.CreationTime)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("impact_types", flattenImpactTypes(alert.ImpactTypes)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_acknowledged", utils.BoolValue(alert.IsAcknowledged)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_auto_resolved", utils.BoolValue(alert.IsAutoResolved)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_resolved", utils.BoolValue(alert.IsResolved)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_runnable", utils.BoolValue(alert.IsRunnable)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_user_defined", utils.BoolValue(alert.IsUserDefined)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("kb_articles", alert.KbArticles); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("last_updated_time", utils.TimeStringValue(alert.LastUpdatedTime)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("message", utils.StringValue(alert.Message)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("metric_details", flattenMetricDetails(alert.MetricDetails)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("originating_cluster_uuid", utils.StringValue(alert.OriginatingClusterUUID)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("parameters", flattenParameters(alert.Parameters)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("resolved_by_username", utils.StringValue(alert.ResolvedByUsername)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("resolved_time", utils.TimeStringValue(alert.ResolvedTime)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("root_cause_analysis", flattenRootCauseAnalysis(alert.RootCauseAnalysis)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("service_name", utils.StringValue(alert.ServiceName)); err != nil {
+		return diag.FromErr(err)
+	}
+	if alert.Severity != nil {
+		if err := d.Set("severity", flattenEnumValue(alert.Severity)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err := d.Set("severity_trails", flattenSeverityTrails(alert.SeverityTrails)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("source_entity", flattenAlertEntityReference(alert.SourceEntity)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("title", utils.StringValue(alert.Title)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(utils.StringValue(alert.ExtId))
+	return nil
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_alert_v2_test.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_alert_v2_test.go
@@ -1,0 +1,41 @@
+package monitoringv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const dataSourceNameAlert = "data.nutanix_alert_v2.test"
+
+func TestAccV2NutanixAlertDatasource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAlertDatasourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceNameAlert, "ext_id"),
+					resource.TestCheckResourceAttrSet(dataSourceNameAlert, "title"),
+					resource.TestCheckResourceAttrSet(dataSourceNameAlert, "severity"),
+					resource.TestCheckResourceAttrSet(dataSourceNameAlert, "creation_time"),
+					resource.TestCheckResourceAttrSet(dataSourceNameAlert, "alert_type"),
+					resource.TestCheckResourceAttrSet(dataSourceNameAlert, "cluster_uuid"),
+				),
+			},
+		},
+	})
+}
+
+func testAlertDatasourceConfig() string {
+	return `
+data "nutanix_alerts_v2" "list" {}
+
+data "nutanix_alert_v2" "test" {
+	ext_id = data.nutanix_alerts_v2.list.alerts.0.ext_id
+	depends_on = [data.nutanix_alerts_v2.list]
+}
+`
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_alerts_v2.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_alerts_v2.go
@@ -1,0 +1,203 @@
+package monitoringv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	monitoringService "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixAlertsV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DatasourceNutanixAlertsV2Read,
+		Schema: map[string]*schema.Schema{
+			"filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"order_by": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"select": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"alerts": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ext_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"links":     schemaForLinks(),
+						"tenant_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"acknowledged_by_username": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"acknowledged_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"affected_entities": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     schemaForEntityReference(),
+						},
+						"alert_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"classifications": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"cluster_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cluster_uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"impact_types": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"is_acknowledged": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_auto_resolved": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_resolved": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_runnable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_user_defined": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"kb_articles": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"last_updated_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"message": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"metric_details": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     schemaForMetricDetail(),
+						},
+						"originating_cluster_uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"parameters": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     schemaForParameter(),
+						},
+						"resolved_by_username": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resolved_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"root_cause_analysis": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     schemaForRootCauseAnalysis(),
+						},
+						"service_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"severity": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"severity_trails": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     schemaForSeverityTrail(),
+						},
+						"source_entity": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     schemaForAlertEntityReference(),
+						},
+						"title": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func DatasourceNutanixAlertsV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	var filter, orderBy, selectParam *string
+	if v, ok := d.GetOk("filter"); ok {
+		filter = utils.StringPtr(v.(string))
+	}
+	if v, ok := d.GetOk("order_by"); ok {
+		orderBy = utils.StringPtr(v.(string))
+	}
+	if v, ok := d.GetOk("select"); ok {
+		selectParam = utils.StringPtr(v.(string))
+	}
+
+	resp, err := conn.Alerts.ListAlerts(nil, nil, filter, orderBy, selectParam)
+	if err != nil {
+		return diag.Errorf("error while fetching alerts: %s", err)
+	}
+
+	alerts := resp.Data.GetValue().([]monitoringService.Alert)
+
+	alertList := make([]map[string]interface{}, len(alerts))
+	for i, alert := range alerts {
+		alertList[i] = flattenAlert(alert)
+	}
+
+	if err := d.Set("alerts", alertList); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(utils.GenUUID())
+	return nil
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_alerts_v2_test.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_alerts_v2_test.go
@@ -1,0 +1,31 @@
+package monitoringv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const dataSourceNameAlerts = "data.nutanix_alerts_v2.test"
+
+func TestAccV2NutanixAlertsDatasource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAlertsDatasourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceNameAlerts, "alerts.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAlertsDatasourceConfig() string {
+	return `
+data "nutanix_alerts_v2" "test" {}
+`
+}

--- a/nutanix/services/monitoringv2/main_test.go
+++ b/nutanix/services/monitoringv2/main_test.go
@@ -1,0 +1,34 @@
+package monitoringv2_test
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"testing"
+)
+
+type TestConfig struct {
+	AlertExtID string `json:"alert_ext_id"`
+}
+
+var testVars TestConfig
+
+func loadVars(filepath string, varStruct interface{}) {
+	configData, err := os.ReadFile(filepath)
+	if err != nil {
+		log.Printf("Got this error while reading config.json: %s", err.Error())
+		os.Exit(1)
+	}
+
+	err = json.Unmarshal(configData, varStruct)
+	if err != nil {
+		log.Printf("Got this error while unmarshalling config.json: %s", err.Error())
+		os.Exit(1)
+	}
+}
+
+func TestMain(m *testing.M) {
+	log.Println("Do some crazy stuff before tests!")
+	loadVars("../../../test_config_v2.json", &testVars)
+	os.Exit(m.Run())
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_alert_email_configuration_v2.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_alert_email_configuration_v2.go
@@ -1,0 +1,691 @@
+package monitoringv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	monitoringCommon "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/common"
+	monitoringService "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func ResourceNutanixAlertEmailConfigurationV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: ResourceNutanixAlertEmailConfigurationV2Create,
+		ReadContext:   ResourceNutanixAlertEmailConfigurationV2Read,
+		UpdateContext: ResourceNutanixAlertEmailConfigurationV2Update,
+		DeleteContext: ResourceNutanixAlertEmailConfigurationV2Delete,
+		Schema: map[string]*schema.Schema{
+			"ext_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A globally unique identifier of an instance that is suitable for external consumption.",
+			},
+			"links": schemaForLinks(),
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A globally unique identifier that represents the tenant that owns this entity.",
+			},
+			"alert_email_digest_send_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Time in HH:mm format when the alert email digest is sent daily.",
+			},
+			"alert_email_digest_send_timezone": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Timezone for the time at which the alert email digest is sent daily.",
+			},
+			"default_nutanix_email": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The default Nutanix email ID to which alert emails are sent.",
+			},
+			"email_config_rules": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Description: "Rules for email configuration.",
+				Elem:        schemaForEmailConfigRule(),
+			},
+			"email_contact_list": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Description: "List of email contacts.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"email_template": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"body_suffix": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Suffix for the email body.",
+						},
+						"subject_prefix": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "Prefix for the email subject.",
+						},
+					},
+				},
+			},
+			"has_default_nutanix_email": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Indicates whether alert emails are enabled or not on default Nutanix email ID.",
+			},
+			"is_email_digest_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Indicates whether alert email digest is enabled or not.",
+			},
+			"is_empty_alert_email_digest_skipped": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Send alert email digest only if there are one or more alerts.",
+			},
+			"is_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Indicates whether alert emails are enabled or not.",
+			},
+			"tunnel_details": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     schemaForRemoteTunnelDetails(),
+			},
+		},
+	}
+}
+
+func schemaForEmailConfigRule() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cluster_uuids": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Description: "Cluster UUIDs to which this rule applies.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"has_global_email_contact_list": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Indicates whether to include a global email contact list.",
+			},
+			"impact_types": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"is_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Indicates whether the configuration rule is enabled or not.",
+			},
+			"match_phrases": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Description: "List of phrases to match the alert.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"recipients": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Description: "List of recipients who will receive emails.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"severities": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func schemaForRemoteTunnelDetails() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"connection_status": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     schemaForCommunicationStatus(),
+			},
+			"http_proxy": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     schemaForHTTPProxy(),
+			},
+			"service_center": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     schemaForServiceCenter(),
+			},
+			"transport_status": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     schemaForCommunicationStatus(),
+			},
+		},
+	}
+}
+
+func schemaForCommunicationStatus() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"last_changed_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Last changed time.",
+			},
+			"last_checked_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Last checked time.",
+			},
+			"last_successful_transmission_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Last successful transmission time.",
+			},
+			"message": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"message": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Message.",
+						},
+						"attributes": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func schemaForHTTPProxy() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Proxy name.",
+			},
+			"port": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Port on which proxy is binding.",
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "User name for proxy authentication.",
+			},
+			"proxy_types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func schemaForServiceCenter() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"ip_address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "IP address of the service center.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Name of service center.",
+			},
+			"port": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Port number.",
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Username.",
+			},
+		},
+	}
+}
+
+func ResourceNutanixAlertEmailConfigurationV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	getResp, err := conn.AlertEmailConfiguration.GetAlertEmailConfiguration()
+	if err != nil {
+		return diag.Errorf("error while fetching alert email configuration for ETag: %s", err)
+	}
+
+	etagValue := conn.AlertEmailConfiguration.ApiClient.GetEtag(getResp)
+	args := make(map[string]interface{})
+	args["If-Match"] = utils.StringPtr(etagValue)
+
+	body := expandAlertEmailConfiguration(d)
+
+	_, err = conn.AlertEmailConfiguration.UpdateAlertEmailConfiguration(body, args)
+	if err != nil {
+		return diag.Errorf("error while creating alert email configuration: %s", err)
+	}
+
+	return ResourceNutanixAlertEmailConfigurationV2Read(ctx, d, meta)
+}
+
+func ResourceNutanixAlertEmailConfigurationV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	resp, err := conn.AlertEmailConfiguration.GetAlertEmailConfiguration()
+	if err != nil {
+		return diag.Errorf("error while fetching alert email configuration: %s", err)
+	}
+
+	config := resp.Data.GetValue().(monitoringService.AlertEmailConfiguration)
+
+	if err := d.Set("ext_id", utils.StringValue(config.ExtId)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("tenant_id", utils.StringValue(config.TenantId)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("links", flattenLinks(config.Links)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("alert_email_digest_send_time", utils.StringValue(config.AlertEmailDigestSendTime)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("alert_email_digest_send_timezone", utils.StringValue(config.AlertEmailDigestSendTimezone)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("default_nutanix_email", utils.StringValue(config.DefaultNutanixEmail)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("email_config_rules", flattenEmailConfigRules(config.EmailConfigRules)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("email_contact_list", config.EmailContactList); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("email_template", flattenEmailTemplate(config.EmailTemplate)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("has_default_nutanix_email", utils.BoolValue(config.HasDefaultNutanixEmail)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_email_digest_enabled", utils.BoolValue(config.IsEmailDigestEnabled)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_empty_alert_email_digest_skipped", utils.BoolValue(config.IsEmptyAlertEmailDigestSkipped)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_enabled", utils.BoolValue(config.IsEnabled)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("tunnel_details", flattenRemoteTunnelDetails(config.TunnelDetails)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if config.ExtId != nil {
+		d.SetId(utils.StringValue(config.ExtId))
+	} else {
+		d.SetId("alert-email-configuration")
+	}
+
+	return nil
+}
+
+func ResourceNutanixAlertEmailConfigurationV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	getResp, err := conn.AlertEmailConfiguration.GetAlertEmailConfiguration()
+	if err != nil {
+		return diag.Errorf("error while fetching alert email configuration for ETag: %s", err)
+	}
+
+	etagValue := conn.AlertEmailConfiguration.ApiClient.GetEtag(getResp)
+	args := make(map[string]interface{})
+	args["If-Match"] = utils.StringPtr(etagValue)
+
+	body := expandAlertEmailConfiguration(d)
+
+	_, err = conn.AlertEmailConfiguration.UpdateAlertEmailConfiguration(body, args)
+	if err != nil {
+		return diag.Errorf("error while updating alert email configuration: %s", err)
+	}
+
+	return ResourceNutanixAlertEmailConfigurationV2Read(ctx, d, meta)
+}
+
+func ResourceNutanixAlertEmailConfigurationV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	d.SetId("")
+	return nil
+}
+
+func expandAlertEmailConfiguration(d *schema.ResourceData) *monitoringService.AlertEmailConfiguration {
+	body := &monitoringService.AlertEmailConfiguration{}
+
+	if v, ok := d.GetOk("alert_email_digest_send_time"); ok {
+		body.AlertEmailDigestSendTime = utils.StringPtr(v.(string))
+	}
+	if v, ok := d.GetOk("alert_email_digest_send_timezone"); ok {
+		body.AlertEmailDigestSendTimezone = utils.StringPtr(v.(string))
+	}
+	if v, ok := d.GetOk("default_nutanix_email"); ok {
+		body.DefaultNutanixEmail = utils.StringPtr(v.(string))
+	}
+	if v, ok := d.GetOk("email_config_rules"); ok {
+		body.EmailConfigRules = expandEmailConfigRules(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("email_contact_list"); ok {
+		body.EmailContactList = expandStringList(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("email_template"); ok {
+		templateList := v.([]interface{})
+		if len(templateList) > 0 && templateList[0] != nil {
+			body.EmailTemplate = expandEmailTemplate(templateList[0].(map[string]interface{}))
+		}
+	}
+	if v, ok := d.GetOk("has_default_nutanix_email"); ok {
+		body.HasDefaultNutanixEmail = utils.BoolPtr(v.(bool))
+	}
+	if v, ok := d.GetOk("is_email_digest_enabled"); ok {
+		body.IsEmailDigestEnabled = utils.BoolPtr(v.(bool))
+	}
+	if v, ok := d.GetOk("is_empty_alert_email_digest_skipped"); ok {
+		body.IsEmptyAlertEmailDigestSkipped = utils.BoolPtr(v.(bool))
+	}
+	if v, ok := d.GetOk("is_enabled"); ok {
+		body.IsEnabled = utils.BoolPtr(v.(bool))
+	}
+
+	return body
+}
+
+func expandEmailConfigRules(rules []interface{}) []monitoringService.EmailConfigurationRule {
+	if len(rules) == 0 {
+		return nil
+	}
+	result := make([]monitoringService.EmailConfigurationRule, len(rules))
+	for i, r := range rules {
+		ruleMap := r.(map[string]interface{})
+		rule := monitoringService.EmailConfigurationRule{}
+
+		if v, ok := ruleMap["cluster_uuids"]; ok {
+			rule.ClusterUuids = expandStringList(v.([]interface{}))
+		}
+		if v, ok := ruleMap["has_global_email_contact_list"]; ok {
+			rule.HasGlobalEmailContactList = utils.BoolPtr(v.(bool))
+		}
+		if v, ok := ruleMap["impact_types"]; ok {
+			rule.ImpactTypes = expandImpactTypes(v.([]interface{}))
+		}
+		if v, ok := ruleMap["is_enabled"]; ok {
+			rule.IsEnabled = utils.BoolPtr(v.(bool))
+		}
+		if v, ok := ruleMap["match_phrases"]; ok {
+			rule.MatchPhrases = expandStringList(v.([]interface{}))
+		}
+		if v, ok := ruleMap["recipients"]; ok {
+			rule.Recipients = expandStringList(v.([]interface{}))
+		}
+		if v, ok := ruleMap["severities"]; ok {
+			rule.Severities = expandSeverities(v.([]interface{}))
+		}
+
+		result[i] = rule
+	}
+	return result
+}
+
+func expandImpactTypes(items []interface{}) []monitoringCommon.ImpactType {
+	if len(items) == 0 {
+		return nil
+	}
+	impactTypeMap := map[string]monitoringCommon.ImpactType{
+		"AVAILABILITY":     monitoringCommon.IMPACTTYPE_AVAILABILITY,
+		"CAPACITY":         monitoringCommon.IMPACTTYPE_CAPACITY,
+		"CONFIGURATION":    monitoringCommon.IMPACTTYPE_CONFIGURATION,
+		"PERFORMANCE":      monitoringCommon.IMPACTTYPE_PERFORMANCE,
+		"SYSTEM_INDICATOR": monitoringCommon.IMPACTTYPE_SYSTEM_INDICATOR,
+		"CPU_CAPACITY":     monitoringCommon.IMPACTTYPE_CPU_CAPACITY,
+		"MEMORY_CAPACITY":  monitoringCommon.IMPACTTYPE_MEMORY_CAPACITY,
+		"STORAGE_CAPACITY": monitoringCommon.IMPACTTYPE_STORAGE_CAPACITY,
+	}
+	result := make([]monitoringCommon.ImpactType, 0, len(items))
+	for _, item := range items {
+		val := item.(string)
+		if it, ok := impactTypeMap[val]; ok {
+			result = append(result, it)
+		}
+	}
+	return result
+}
+
+func expandSeverities(items []interface{}) []monitoringCommon.Severity {
+	if len(items) == 0 {
+		return nil
+	}
+	severityMap := map[string]monitoringCommon.Severity{
+		"INFO":     monitoringCommon.SEVERITY_INFO,
+		"WARNING":  monitoringCommon.SEVERITY_WARNING,
+		"CRITICAL": monitoringCommon.SEVERITY_CRITICAL,
+	}
+	result := make([]monitoringCommon.Severity, 0, len(items))
+	for _, item := range items {
+		val := item.(string)
+		if s, ok := severityMap[val]; ok {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+func expandEmailTemplate(m map[string]interface{}) *monitoringService.EmailTemplate {
+	if m == nil {
+		return nil
+	}
+	tmpl := &monitoringService.EmailTemplate{}
+	if v, ok := m["body_suffix"]; ok && v.(string) != "" {
+		tmpl.BodySuffix = utils.StringPtr(v.(string))
+	}
+	if v, ok := m["subject_prefix"]; ok && v.(string) != "" {
+		tmpl.SubjectPrefix = utils.StringPtr(v.(string))
+	}
+	return tmpl
+}
+
+func expandStringList(items []interface{}) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	result := make([]string, len(items))
+	for i, item := range items {
+		result[i] = item.(string)
+	}
+	return result
+}
+
+func flattenEmailConfigRules(rules []monitoringService.EmailConfigurationRule) []map[string]interface{} {
+	if len(rules) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(rules))
+	for i, rule := range rules {
+		m := map[string]interface{}{
+			"cluster_uuids":                rule.ClusterUuids,
+			"has_global_email_contact_list": utils.BoolValue(rule.HasGlobalEmailContactList),
+			"is_enabled":                   utils.BoolValue(rule.IsEnabled),
+			"match_phrases":                rule.MatchPhrases,
+			"recipients":                   rule.Recipients,
+		}
+
+		if len(rule.ImpactTypes) > 0 {
+			types := make([]string, len(rule.ImpactTypes))
+			for j, it := range rule.ImpactTypes {
+				types[j] = flattenEnumValue(&it)
+			}
+			m["impact_types"] = types
+		}
+
+		if len(rule.Severities) > 0 {
+			sevs := make([]string, len(rule.Severities))
+			for j, s := range rule.Severities {
+				sevs[j] = flattenEnumValue(&s)
+			}
+			m["severities"] = sevs
+		}
+
+		result[i] = m
+	}
+	return result
+}
+
+func flattenEmailTemplate(tmpl *monitoringService.EmailTemplate) []map[string]interface{} {
+	if tmpl == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"body_suffix":    utils.StringValue(tmpl.BodySuffix),
+			"subject_prefix": utils.StringValue(tmpl.SubjectPrefix),
+		},
+	}
+}
+
+func flattenRemoteTunnelDetails(details *monitoringService.RemoteTunnelDetails) []map[string]interface{} {
+	if details == nil {
+		return nil
+	}
+	m := map[string]interface{}{
+		"connection_status": flattenCommunicationStatus(details.ConnectionStatus),
+		"http_proxy":        flattenHTTPProxy(details.HttpProxy),
+		"service_center":    flattenServiceCenter(details.ServiceCenter),
+		"transport_status":  flattenCommunicationStatus(details.TransportStatus),
+	}
+	return []map[string]interface{}{m}
+}
+
+func flattenCommunicationStatus(status *monitoringService.CommunicationStatus) []map[string]interface{} {
+	if status == nil {
+		return nil
+	}
+	m := map[string]interface{}{
+		"last_changed_time":                 utils.TimeStringValue(status.LastChangedTime),
+		"last_checked_time":                 utils.TimeStringValue(status.LastCheckedTime),
+		"last_successful_transmission_time": utils.TimeStringValue(status.LastSuccessfulTransmissionTime),
+	}
+	if status.Status != nil {
+		m["status"] = flattenEnumValue(status.Status)
+	}
+	if status.Message != nil {
+		m["message"] = flattenParameterizedMessage(status.Message)
+	}
+	return []map[string]interface{}{m}
+}
+
+func flattenParameterizedMessage(msg *monitoringService.ParameterizedMessage) []map[string]interface{} {
+	if msg == nil {
+		return nil
+	}
+	m := map[string]interface{}{
+		"message": utils.StringValue(msg.Message),
+	}
+	if len(msg.Attributes) > 0 {
+		attrs := make([]map[string]interface{}, len(msg.Attributes))
+		for i, attr := range msg.Attributes {
+			attrs[i] = map[string]interface{}{
+				"name":  utils.StringValue(attr.Name),
+				"value": utils.StringValue(attr.Value),
+			}
+		}
+		m["attributes"] = attrs
+	}
+	return []map[string]interface{}{m}
+}
+
+func flattenHTTPProxy(proxy *monitoringService.HttpProxy) []map[string]interface{} {
+	if proxy == nil {
+		return nil
+	}
+	m := map[string]interface{}{
+		"name":     utils.StringValue(proxy.Name),
+		"port":     utils.IntValue(proxy.Port),
+		"username": utils.StringValue(proxy.Username),
+	}
+	if len(proxy.ProxyTypes) > 0 {
+		types := make([]string, len(proxy.ProxyTypes))
+		for i, pt := range proxy.ProxyTypes {
+			types[i] = flattenEnumValue(&pt)
+		}
+		m["proxy_types"] = types
+	}
+	return []map[string]interface{}{m}
+}
+
+func flattenServiceCenter(sc *monitoringService.ServiceCenter) []map[string]interface{} {
+	if sc == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"ip_address": utils.StringValue(sc.IpAddress),
+			"name":       utils.StringValue(sc.Name),
+			"port":       utils.IntValue(sc.Port),
+			"username":   utils.StringValue(sc.Username),
+		},
+	}
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_alert_email_configuration_v2_test.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_alert_email_configuration_v2_test.go
@@ -1,0 +1,64 @@
+package monitoringv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const resourceNameAlertEmailConfig = "nutanix_alert_email_configuration_v2.test"
+
+func TestAccV2NutanixAlertEmailConfigurationResource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAlertEmailConfigurationResourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameAlertEmailConfig, "is_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixAlertEmailConfigurationResource_Update(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAlertEmailConfigurationResourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameAlertEmailConfig, "is_enabled", "true"),
+				),
+			},
+			{
+				Config: testAlertEmailConfigurationResourceConfigUpdated(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameAlertEmailConfig, "is_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceNameAlertEmailConfig, "is_email_digest_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAlertEmailConfigurationResourceConfig() string {
+	return `
+resource "nutanix_alert_email_configuration_v2" "test" {
+  is_enabled = true
+}
+`
+}
+
+func testAlertEmailConfigurationResourceConfigUpdated() string {
+	return `
+resource "nutanix_alert_email_configuration_v2" "test" {
+  is_enabled             = true
+  is_email_digest_enabled = true
+}
+`
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_manage_alert_v2.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_manage_alert_v2.go
@@ -1,0 +1,96 @@
+package monitoringv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	monitoringService "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	prismConfig "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/prism/v4/config"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func ResourceNutanixManageAlertV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: ResourceNutanixManageAlertV2Create,
+		ReadContext:   ResourceNutanixManageAlertV2Read,
+		DeleteContext: ResourceNutanixManageAlertV2Delete,
+		Schema: map[string]*schema.Schema{
+			"ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Unique identifier of an alert that can be resolved or acknowledged.",
+			},
+			"action_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The action to perform on the alert. Valid values are ACKNOWLEDGE and RESOLVE.",
+				ValidateFunc: validation.StringInSlice([]string{
+					"ACKNOWLEDGE",
+					"RESOLVE",
+				}, false),
+			},
+			"task_ext_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A globally unique identifier for the task.",
+			},
+		},
+	}
+}
+
+func ResourceNutanixManageAlertV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	extID := d.Get("ext_id").(string)
+	actionTypeStr := d.Get("action_type").(string)
+
+	getResp, err := conn.Alerts.GetAlertById(utils.StringPtr(extID))
+	if err != nil {
+		return diag.Errorf("error while fetching alert for ETag: %s", err)
+	}
+
+	etagValue := conn.Alerts.ApiClient.GetEtag(getResp)
+	args := make(map[string]interface{})
+	args["If-Match"] = utils.StringPtr(etagValue)
+
+	var actionType monitoringService.ActionType
+	switch actionTypeStr {
+	case "ACKNOWLEDGE":
+		actionType = monitoringService.ACTIONTYPE_ACKNOWLEDGE
+	case "RESOLVE":
+		actionType = monitoringService.ACTIONTYPE_RESOLVE
+	}
+
+	body := &monitoringService.AlertActionSpec{
+		ActionType: &actionType,
+	}
+
+	resp, err := conn.ManageAlerts.ManageAlert(utils.StringPtr(extID), body, args)
+	if err != nil {
+		return diag.Errorf("error while managing alert: %s", err)
+	}
+
+	taskRef := resp.Data.GetValue().(prismConfig.TaskReference)
+	if taskRef.ExtId != nil {
+		if err := d.Set("task_ext_id", utils.StringValue(taskRef.ExtId)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	d.SetId(extID)
+	return nil
+}
+
+func ResourceNutanixManageAlertV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func ResourceNutanixManageAlertV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	d.SetId("")
+	return nil
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_manage_alert_v2_test.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_manage_alert_v2_test.go
@@ -1,0 +1,66 @@
+package monitoringv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const resourceNameManageAlert = "nutanix_manage_alert_v2.test"
+
+func TestAccV2NutanixManageAlertResource_Acknowledge(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testManageAlertResourceConfig_Acknowledge(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameManageAlert, "ext_id"),
+					resource.TestCheckResourceAttr(resourceNameManageAlert, "action_type", "ACKNOWLEDGE"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixManageAlertResource_Resolve(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testManageAlertResourceConfig_Resolve(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameManageAlert, "ext_id"),
+					resource.TestCheckResourceAttr(resourceNameManageAlert, "action_type", "RESOLVE"),
+				),
+			},
+		},
+	})
+}
+
+func testManageAlertResourceConfig_Acknowledge() string {
+	return `
+data "nutanix_alerts_v2" "list" {}
+
+resource "nutanix_manage_alert_v2" "test" {
+  ext_id      = data.nutanix_alerts_v2.list.alerts.0.ext_id
+  action_type = "ACKNOWLEDGE"
+  depends_on  = [data.nutanix_alerts_v2.list]
+}
+`
+}
+
+func testManageAlertResourceConfig_Resolve() string {
+	return `
+data "nutanix_alerts_v2" "list" {}
+
+resource "nutanix_manage_alert_v2" "test" {
+  ext_id      = data.nutanix_alerts_v2.list.alerts.0.ext_id
+  action_type = "RESOLVE"
+  depends_on  = [data.nutanix_alerts_v2.list]
+}
+`
+}

--- a/nutanix/services/monitoringv2/schemas.go
+++ b/nutanix/services/monitoringv2/schemas.go
@@ -1,0 +1,605 @@
+package monitoringv2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/common/v1/response"
+	monitoringCommon "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/common"
+	monitoringService "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func schemaForLinks() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"href": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"rel": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+func flattenLinks(links []response.ApiLink) []map[string]interface{} {
+	if len(links) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(links))
+	for i, link := range links {
+		result[i] = map[string]interface{}{
+			"href": utils.StringValue(link.Href),
+			"rel":  utils.StringValue(link.Rel),
+		}
+	}
+	return result
+}
+
+func schemaForEntityReference() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"ext_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func schemaForAlertEntityReference() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"ext_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func schemaForMetricDetail() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"comparison_operator": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"condition_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"metric_category": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"metric_display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"metric_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"metric_value": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"string_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"bool_value": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"int_value": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"double_value": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"threshold_value": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"string_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"bool_value": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"int_value": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"double_value": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"trigger_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"trigger_wait_time_seconds": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"unit": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func schemaForParameter() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"param_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"param_value": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"string_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"bool_value": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"int_value": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemaForRootCauseAnalysis() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"cause": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"detail": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resolution": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func schemaForSeverityTrail() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"severity": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"severity_change_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func flattenEntityReferences(refs []monitoringCommon.EntityReference) []map[string]interface{} {
+	if len(refs) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(refs))
+	for i, ref := range refs {
+		result[i] = map[string]interface{}{
+			"ext_id": utils.StringValue(ref.ExtId),
+			"name":   utils.StringValue(ref.Name),
+			"type":   utils.StringValue(ref.Type),
+		}
+	}
+	return result
+}
+
+func flattenAlertEntityReference(ref *monitoringCommon.AlertEntityReference) []map[string]interface{} {
+	if ref == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"ext_id": utils.StringValue(ref.ExtId),
+			"name":   utils.StringValue(ref.Name),
+			"type":   utils.StringValue(ref.Type),
+		},
+	}
+}
+
+func flattenOneOfValue(oneOfValue interface{ GetValue() interface{} }, objectType *string) []map[string]interface{} {
+	if oneOfValue == nil || objectType == nil {
+		return nil
+	}
+	valueMap := make(map[string]interface{})
+	value := oneOfValue.GetValue()
+	if value == nil {
+		return nil
+	}
+	switch *objectType {
+	case "monitoring.v4.common.StringValue":
+		if strVal, ok := value.(monitoringCommon.StringValue); ok && strVal.StringValue != nil {
+			valueMap["string_value"] = utils.StringValue(strVal.StringValue)
+		}
+	case "monitoring.v4.common.BoolValue":
+		if boolVal, ok := value.(monitoringCommon.BoolValue); ok && boolVal.BoolValue != nil {
+			valueMap["bool_value"] = utils.BoolValue(boolVal.BoolValue)
+		}
+	case "monitoring.v4.common.IntValue":
+		if intVal, ok := value.(monitoringCommon.IntValue); ok && intVal.IntValue != nil {
+			valueMap["int_value"] = utils.Int64Value(intVal.IntValue)
+		}
+	case "monitoring.v4.common.DoubleValue":
+		if doubleVal, ok := value.(monitoringCommon.DoubleValue); ok && doubleVal.DoubleValue != nil {
+			valueMap["double_value"] = utils.Float64Value(doubleVal.DoubleValue)
+		}
+	default:
+		return nil
+	}
+	return []map[string]interface{}{valueMap}
+}
+
+func flattenMetricDetails(details []monitoringCommon.MetricDetail) []map[string]interface{} {
+	if len(details) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(details))
+	for i, d := range details {
+		m := map[string]interface{}{
+			"metric_category":           utils.StringValue(d.MetricCategory),
+			"metric_display_name":       utils.StringValue(d.MetricDisplayName),
+			"metric_name":               utils.StringValue(d.MetricName),
+			"trigger_time":              utils.TimeStringValue(d.TriggerTime),
+			"trigger_wait_time_seconds": utils.Int64Value(d.TriggerWaitTimeSeconds),
+			"unit":                      utils.StringValue(d.Unit),
+		}
+
+		if d.ComparisonOperator != nil {
+			m["comparison_operator"] = flattenEnumValue(d.ComparisonOperator)
+		}
+		if d.ConditionType != nil {
+			m["condition_type"] = flattenEnumValue(d.ConditionType)
+		}
+		if d.DataType != nil {
+			m["data_type"] = flattenEnumValue(d.DataType)
+		}
+
+		if d.MetricValue != nil && d.MetricValue.ObjectType_ != nil {
+			m["metric_value"] = flattenOneOfValue(d.MetricValue, d.MetricValue.ObjectType_)
+		}
+		if d.ThresholdValue != nil && d.ThresholdValue.ObjectType_ != nil {
+			m["threshold_value"] = flattenOneOfValue(d.ThresholdValue, d.ThresholdValue.ObjectType_)
+		}
+
+		result[i] = m
+	}
+	return result
+}
+
+func flattenParameters(params []monitoringCommon.Parameter) []map[string]interface{} {
+	if len(params) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(params))
+	for i, p := range params {
+		m := map[string]interface{}{
+			"param_name": utils.StringValue(p.ParamName),
+		}
+		if p.ParamValue != nil && p.ParamValue.ObjectType_ != nil {
+			m["param_value"] = flattenOneOfValue(p.ParamValue, p.ParamValue.ObjectType_)
+		}
+		result[i] = m
+	}
+	return result
+}
+
+func flattenRootCauseAnalysis(rcas []monitoringService.RootCauseAnalysis) []map[string]interface{} {
+	if len(rcas) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(rcas))
+	for i, rca := range rcas {
+		result[i] = map[string]interface{}{
+			"cause":      utils.StringValue(rca.Cause),
+			"detail":     utils.StringValue(rca.Detail),
+			"resolution": utils.StringValue(rca.Resolution),
+		}
+	}
+	return result
+}
+
+func flattenSeverityTrails(trails []monitoringService.SeverityTrail) []map[string]interface{} {
+	if len(trails) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(trails))
+	for i, t := range trails {
+		m := map[string]interface{}{
+			"severity_change_time": utils.TimeStringValue(t.SeverityChangeTime),
+		}
+		if t.Severity != nil {
+			m["severity"] = flattenEnumValue(t.Severity)
+		}
+		result[i] = m
+	}
+	return result
+}
+
+func flattenEnumValue(v interface{}) string {
+	type stringer interface {
+		GetName() string
+	}
+	if s, ok := v.(stringer); ok {
+		return s.GetName()
+	}
+	return ""
+}
+
+func flattenImpactTypes(impactTypes []monitoringCommon.ImpactType) []string {
+	if len(impactTypes) == 0 {
+		return nil
+	}
+	result := make([]string, len(impactTypes))
+	for i, it := range impactTypes {
+		result[i] = flattenEnumValue(&it)
+	}
+	return result
+}
+
+func flattenAlert(alert monitoringService.Alert) map[string]interface{} {
+	m := map[string]interface{}{
+		"ext_id":                    utils.StringValue(alert.ExtId),
+		"tenant_id":                 utils.StringValue(alert.TenantId),
+		"acknowledged_by_username":  utils.StringValue(alert.AcknowledgedByUsername),
+		"acknowledged_time":         utils.TimeStringValue(alert.AcknowledgedTime),
+		"alert_type":                utils.StringValue(alert.AlertType),
+		"classifications":           alert.Classifications,
+		"cluster_name":              utils.StringValue(alert.ClusterName),
+		"cluster_uuid":              utils.StringValue(alert.ClusterUUID),
+		"creation_time":             utils.TimeStringValue(alert.CreationTime),
+		"is_acknowledged":           utils.BoolValue(alert.IsAcknowledged),
+		"is_auto_resolved":          utils.BoolValue(alert.IsAutoResolved),
+		"is_resolved":               utils.BoolValue(alert.IsResolved),
+		"is_runnable":               utils.BoolValue(alert.IsRunnable),
+		"is_user_defined":           utils.BoolValue(alert.IsUserDefined),
+		"kb_articles":               alert.KbArticles,
+		"last_updated_time":         utils.TimeStringValue(alert.LastUpdatedTime),
+		"message":                   utils.StringValue(alert.Message),
+		"originating_cluster_uuid":  utils.StringValue(alert.OriginatingClusterUUID),
+		"resolved_by_username":      utils.StringValue(alert.ResolvedByUsername),
+		"resolved_time":             utils.TimeStringValue(alert.ResolvedTime),
+		"service_name":              utils.StringValue(alert.ServiceName),
+		"title":                     utils.StringValue(alert.Title),
+		"affected_entities":         flattenEntityReferences(alert.AffectedEntities),
+		"source_entity":             flattenAlertEntityReference(alert.SourceEntity),
+		"impact_types":              flattenImpactTypes(alert.ImpactTypes),
+		"metric_details":            flattenMetricDetails(alert.MetricDetails),
+		"parameters":                flattenParameters(alert.Parameters),
+		"root_cause_analysis":       flattenRootCauseAnalysis(alert.RootCauseAnalysis),
+		"severity_trails":           flattenSeverityTrails(alert.SeverityTrails),
+		"links":                     flattenLinks(alert.Links),
+	}
+
+	if alert.Severity != nil {
+		m["severity"] = flattenEnumValue(alert.Severity)
+	}
+
+	return m
+}
+
+func schemaForAlertComputed() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"ext_id": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"links":     schemaForLinks(),
+		"tenant_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"acknowledged_by_username": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Name of the user who acknowledged this alert.",
+		},
+		"acknowledged_time": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The time in ISO 8601 format when the alert was acknowledged.",
+		},
+		"affected_entities": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Description: "List of all the entities that are affected by the alert.",
+			Elem:        schemaForEntityReference(),
+		},
+		"alert_type": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "A preconfigured or dynamically generated unique value for each alert type.",
+		},
+		"classifications": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Description: "Various categories into which this alert type can be classified.",
+			Elem:        &schema.Schema{Type: schema.TypeString},
+		},
+		"cluster_name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Name of the cluster associated with the entity.",
+		},
+		"cluster_uuid": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Cluster UUID associated with the source entity of the alert.",
+		},
+		"creation_time": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Time in ISO 8601 format when the alert was created.",
+		},
+		"impact_types": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Description: "The impact this alert or event will have on the system.",
+			Elem:        &schema.Schema{Type: schema.TypeString},
+		},
+		"is_acknowledged": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Indicates whether the alert is acknowledged or not.",
+		},
+		"is_auto_resolved": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Indicates whether the alert is auto-resolved or not.",
+		},
+		"is_resolved": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Indicates whether the alert is resolved or not.",
+		},
+		"is_runnable": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Indicates whether the policy associated with the alert is runnable or not.",
+		},
+		"is_user_defined": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Flag to indicate if the alert was generated from a User-Defined Alert policy.",
+		},
+		"kb_articles": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Description: "List of knowledge base article links.",
+			Elem:        &schema.Schema{Type: schema.TypeString},
+		},
+		"last_updated_time": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Time in ISO 8601 format when the alert was last updated.",
+		},
+		"message": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Additional message associated with the alert.",
+		},
+		"metric_details": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Description: "Details of the metric for a metric-based event.",
+			Elem:        schemaForMetricDetail(),
+		},
+		"originating_cluster_uuid": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Cluster UUID associated with the cluster where the alert was first raised.",
+		},
+		"parameters": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Description: "Additional parameters associated with the alert.",
+			Elem:        schemaForParameter(),
+		},
+		"resolved_by_username": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Name of the user who resolved this alert.",
+		},
+		"resolved_time": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The time in ISO 8601 format when the alert was resolved.",
+		},
+		"root_cause_analysis": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Description: "Possible causes, resolutions and additional details to troubleshoot this alert.",
+			Elem:        schemaForRootCauseAnalysis(),
+		},
+		"service_name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The service that raised the alert.",
+		},
+		"severity": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"severity_trails": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Description: "Contains information on the severity change history for alerts.",
+			Elem:        schemaForSeverityTrail(),
+		},
+		"source_entity": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem:     schemaForAlertEntityReference(),
+		},
+		"title": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Title of the alert.",
+		},
+	}
+}

--- a/website/docs/d/alert_v2.html.markdown
+++ b/website/docs/d/alert_v2.html.markdown
@@ -1,0 +1,102 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_alert_v2"
+sidebar_current: "docs-nutanix-datasource-alert-v2"
+description: |-
+  Fetches the details of an alert identified by external identifier.
+---
+
+# nutanix_alert_v2
+
+Fetches the details of an alert identified by external identifier.
+
+## Example Usage
+
+```hcl
+data "nutanix_alert_v2" "example" {
+  ext_id = "00000000-0000-0000-0000-000000000000"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ext_id` - (Required) UUID of the generated alert.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `tenant_id`: A globally unique identifier that represents the tenant that owns this entity.
+* `links`: A HATEOAS style link for the response. Each link contains a user-friendly name identifying the link and an address for retrieving the particular resource.
+* `acknowledged_by_username`: Name of the user who acknowledged this alert.
+* `acknowledged_time`: The time in ISO 8601 format when the alert was acknowledged.
+* `affected_entities`: List of all the entities that are affected by the alert.
+* `alert_type`: A preconfigured or dynamically generated unique value for each alert type.
+* `classifications`: Various categories into which this alert type can be classified.
+* `cluster_name`: Name of the cluster associated with the entity.
+* `cluster_uuid`: Cluster UUID associated with the source entity of the alert.
+* `creation_time`: Time in ISO 8601 format when the alert was created.
+* `impact_types`: The impact this alert or event will have on the system.
+* `is_acknowledged`: Indicates whether the alert is acknowledged or not.
+* `is_auto_resolved`: Indicates whether the alert is auto-resolved or not.
+* `is_resolved`: Indicates whether the alert is resolved or not.
+* `is_runnable`: Indicates whether the policy associated with the alert is runnable or not.
+* `is_user_defined`: Flag to indicate if the alert was generated from a User-Defined Alert policy.
+* `kb_articles`: List of knowledge base article links.
+* `last_updated_time`: Time in ISO 8601 format when the alert was last updated.
+* `message`: Additional message associated with the alert.
+* `metric_details`: Details of the metric for a metric-based event.
+* `originating_cluster_uuid`: Cluster UUID associated with the cluster where the alert was first raised.
+* `parameters`: Additional parameters associated with the alert.
+* `resolved_by_username`: Name of the user who resolved this alert.
+* `resolved_time`: The time in ISO 8601 format when the alert was resolved.
+* `root_cause_analysis`: Possible causes, resolutions and additional details to troubleshoot this alert.
+* `service_name`: The service that raised the alert.
+* `severity`: Severity of the alert.
+* `severity_trails`: Contains information on the severity change history for alerts.
+* `source_entity`: Source entity of the alert.
+* `title`: Title of the alert.
+
+### affected_entities
+* `ext_id`: UUID of the entity.
+* `name`: The name of the entity.
+* `type`: The type of entity. For example, VM, node, or cluster.
+
+### source_entity
+* `ext_id`: UUID of the entity.
+* `name`: The name of the entity.
+* `type`: The type of entity. For example, VM, node, or cluster.
+
+### metric_details
+* `comparison_operator`: Comparison operator used for the condition.
+* `condition_type`: Type of the condition.
+* `data_type`: Data type of the metric.
+* `metric_category`: Broad category under which this metric falls.
+* `metric_display_name`: Readable name of the metric in English.
+* `metric_name`: The metric key.
+* `metric_value`: The raw value of the metric when the condition threshold was exceeded.
+* `threshold_value`: The threshold value that was used for the condition evaluation.
+* `trigger_time`: The time in ISO 8601 format when the event was triggered.
+* `trigger_wait_time_seconds`: How long the metric breached the given condition before raising an event.
+* `unit`: Unit of the metric.
+
+### parameters
+* `param_name`: Name or key of additional parameter for an instance.
+* `param_value`: Value of additional parameter for an instance.
+
+### root_cause_analysis
+* `cause`: Possible causes of this alert.
+* `detail`: Additional details to troubleshoot this alert.
+* `resolution`: Possible resolutions to troubleshoot this alert.
+
+### severity_trails
+* `severity`: Severity level.
+* `severity_change_time`: The time in ISO 8601 format when the severity of the alert was changed.
+
+### links
+* `href`: The URL at which the entity described by the link can be accessed.
+* `rel`: A name that identifies the relationship of the link to the object that is returned by the URL.
+
+See detailed information in [Nutanix Monitoring v4 Alerts](https://developers.nutanix.com/api-reference?namespace=monitoring&version=v4.0).

--- a/website/docs/d/alerts_v2.html.markdown
+++ b/website/docs/d/alerts_v2.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_alerts_v2"
+sidebar_current: "docs-nutanix-datasource-alerts-v2"
+description: |-
+  Fetches a list of alerts.
+---
+
+# nutanix_alerts_v2
+
+Fetches a list of alerts.
+
+## Example Usage
+
+```hcl
+data "nutanix_alerts_v2" "example" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `filter` - (Optional) A URL query parameter that allows clients to filter a collection of resources.
+* `order_by` - (Optional) A URL query parameter that allows clients to specify the sort criteria for the returned list of objects.
+* `select` - (Optional) A URL query parameter that allows clients to request a specific set of properties for each entity.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `alerts`: List of alert objects.
+
+### alerts
+* `ext_id`: A globally unique identifier of an instance that is suitable for external consumption.
+* `tenant_id`: A globally unique identifier that represents the tenant that owns this entity.
+* `links`: A HATEOAS style link for the response.
+* `acknowledged_by_username`: Name of the user who acknowledged this alert.
+* `acknowledged_time`: The time in ISO 8601 format when the alert was acknowledged.
+* `affected_entities`: List of all the entities that are affected by the alert.
+* `alert_type`: A preconfigured or dynamically generated unique value for each alert type.
+* `classifications`: Various categories into which this alert type can be classified.
+* `cluster_name`: Name of the cluster associated with the entity.
+* `cluster_uuid`: Cluster UUID associated with the source entity of the alert.
+* `creation_time`: Time in ISO 8601 format when the alert was created.
+* `impact_types`: The impact this alert or event will have on the system.
+* `is_acknowledged`: Indicates whether the alert is acknowledged or not.
+* `is_auto_resolved`: Indicates whether the alert is auto-resolved or not.
+* `is_resolved`: Indicates whether the alert is resolved or not.
+* `is_runnable`: Indicates whether the policy associated with the alert is runnable or not.
+* `is_user_defined`: Flag to indicate if the alert was generated from a User-Defined Alert policy.
+* `kb_articles`: List of knowledge base article links.
+* `last_updated_time`: Time in ISO 8601 format when the alert was last updated.
+* `message`: Additional message associated with the alert.
+* `metric_details`: Details of the metric for a metric-based event.
+* `originating_cluster_uuid`: Cluster UUID associated with the cluster where the alert was first raised.
+* `parameters`: Additional parameters associated with the alert.
+* `resolved_by_username`: Name of the user who resolved this alert.
+* `resolved_time`: The time in ISO 8601 format when the alert was resolved.
+* `root_cause_analysis`: Possible causes, resolutions and additional details to troubleshoot this alert.
+* `service_name`: The service that raised the alert.
+* `severity`: Severity of the alert.
+* `severity_trails`: Contains information on the severity change history for alerts.
+* `source_entity`: Source entity of the alert.
+* `title`: Title of the alert.
+
+See detailed information in [Nutanix Monitoring v4 Alerts](https://developers.nutanix.com/api-reference?namespace=monitoring&version=v4.0).

--- a/website/docs/r/alert_email_configuration_v2.html.markdown
+++ b/website/docs/r/alert_email_configuration_v2.html.markdown
@@ -1,0 +1,70 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_alert_email_configuration_v2"
+sidebar_current: "docs-nutanix-resource-alert-email-configuration-v2"
+description: |-
+  Updates the configuration that is used to send alert emails.
+---
+
+# nutanix_alert_email_configuration_v2
+
+Updates the configuration that is used to send alert emails. This is a singleton resource — the alert email configuration always exists on the cluster. Creating this resource applies an update; deleting it merely removes it from state.
+
+## Example Usage
+
+```hcl
+resource "nutanix_alert_email_configuration_v2" "example" {
+  is_enabled              = true
+  is_email_digest_enabled = true
+  email_contact_list      = ["admin@example.com"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `is_enabled`: - (Optional) Indicates whether alert emails are enabled or not.
+* `has_default_nutanix_email`: - (Optional) Indicates whether alert emails are enabled or not on default Nutanix email ID.
+* `default_nutanix_email`: - (Optional) The default Nutanix email ID to which alert emails are sent.
+* `is_email_digest_enabled`: - (Optional) Indicates whether alert email digest is enabled or not.
+* `is_empty_alert_email_digest_skipped`: - (Optional) Send alert email digest only if there are one or more alerts.
+* `alert_email_digest_send_time`: - (Optional) Time in HH:mm format when the alert email digest is sent daily.
+* `alert_email_digest_send_timezone`: - (Optional) Timezone for the time at which the alert email digest is sent daily.
+* `email_contact_list`: - (Optional) List of email contacts.
+* `email_config_rules`: - (Optional) Rules for email configuration.
+* `email_template`: - (Optional) Email template configuration.
+
+### email_config_rules
+* `cluster_uuids`: (Optional) Cluster UUIDs to which this rule applies.
+* `has_global_email_contact_list`: (Optional) Indicates whether to include a global email contact list.
+* `impact_types`: (Optional) Impact types for the rule.
+* `is_enabled`: (Optional) Indicates whether the configuration rule is enabled or not.
+* `match_phrases`: (Optional) List of phrases to match the alert.
+* `recipients`: (Optional) List of recipients who will receive emails.
+* `severities`: (Optional) Severity levels for the rule.
+
+### email_template
+* `body_suffix`: (Optional) Suffix for the email body.
+* `subject_prefix`: (Optional) Prefix for the email subject.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `ext_id`: A globally unique identifier of an instance that is suitable for external consumption.
+* `tenant_id`: A globally unique identifier that represents the tenant that owns this entity.
+* `links`: A HATEOAS style link for the response.
+* `tunnel_details`: Details of the remote tunnel configuration.
+
+### tunnel_details
+* `connection_status`: Connection status details.
+* `http_proxy`: HTTP proxy configuration.
+* `service_center`: Service center details.
+* `transport_status`: Transport status details.
+
+### links
+* `href`: The URL at which the entity described by the link can be accessed.
+* `rel`: A name that identifies the relationship of the link to the object that is returned by the URL.
+
+See detailed information in [Nutanix Monitoring v4 Alert Email Configuration](https://developers.nutanix.com/api-reference?namespace=monitoring&version=v4.0).

--- a/website/docs/r/manage_alert_v2.html.markdown
+++ b/website/docs/r/manage_alert_v2.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_manage_alert_v2"
+sidebar_current: "docs-nutanix-resource-manage-alert-v2"
+description: |-
+  Acknowledges or resolves the alert identified by external identifier.
+---
+
+# nutanix_manage_alert_v2
+
+Acknowledges or resolves the alert identified by external identifier. This is an action resource — it triggers the manage-alert action on creation and is removed from state on destroy.
+
+## Example Usage
+
+```hcl
+resource "nutanix_manage_alert_v2" "acknowledge" {
+  ext_id      = "00000000-0000-0000-0000-000000000000"
+  action_type = "ACKNOWLEDGE"
+}
+
+resource "nutanix_manage_alert_v2" "resolve" {
+  ext_id      = "00000000-0000-0000-0000-000000000000"
+  action_type = "RESOLVE"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ext_id`: - (Required) Unique identifier of an alert that can be resolved or acknowledged.
+* `action_type`: - (Required) The action to perform on the alert. Valid values are `ACKNOWLEDGE` and `RESOLVE`.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `task_ext_id`: A globally unique identifier for the task.
+
+See detailed information in [Nutanix Monitoring v4 Manage Alerts](https://developers.nutanix.com/api-reference?namespace=monitoring&version=v4.0).


### PR DESCRIPTION
## Summary

Auto-generated Terraform provider code for the **monitoring** namespace, entity
**alert**, based on the inline `sdk_info.json` (see prompt). One PR per code-gen run.

- SDK module: `github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4@v4.2.2`
- API methods covered: 5
  - `GetAlertEmailConfiguration`
  - `UpdateAlertEmailConfiguration`
  - `GetAlertById`
  - `ListAlerts`
  - `ManageAlert`
- Datasources generated: 2 (`nutanix_alert_v2`, `nutanix_alerts_v2`)
- Resources generated: 2 (`nutanix_alert_email_configuration_v2`, `nutanix_manage_alert_v2`)

## Files changed

### `nutanix/sdks/v4/monitoring/`
- `monitoring.go` — SDK client wrapper

### `nutanix/services/monitoringv2/`
- `schemas.go` — shared schema helpers and flatten functions
- `data_source_nutanix_alert_v2.go` — singular alert datasource
- `data_source_nutanix_alerts_v2.go` — plural alerts datasource
- `resource_nutanix_alert_email_configuration_v2.go` — alert email config resource (create/read/update/delete)
- `resource_nutanix_manage_alert_v2.go` — manage alert action resource
- `*_test.go` — acceptance tests for all above
- `main_test.go` — test bootstrap

### `nutanix/config.go`
- Added `MonitoringAPI` client field and initialization

### `nutanix/provider/provider.go`
- Registered 2 datasources and 2 resources

### `examples/monitoring_v2/alert/`
- `main.tf`, `provider.tf`, `terraform.tfvars`

### `website/docs/d/`
- `alert_v2.html.markdown`
- `alerts_v2.html.markdown`

### `website/docs/r/`
- `alert_email_configuration_v2.html.markdown`
- `manage_alert_v2.html.markdown`

### `go.mod` / `go.sum`
- Added `monitoring-go-client/v4@v4.2.2`

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `TF_ACC=1 go test ./nutanix/services/monitoringv2 -v -timeout 500m` |
| Total testcases     | 6                                              |
| Passed              | 6                                              |
| Failed              | 0                                              |
| Skipped             | 0                                              |
| Wall-clock duration | 0:01:24                                        |
| Coverage            | 57.5%                                          |
| Cluster (PC)        | `10.44.76.91`                                  |

### Analysis

All 6 tests passed on first run (after fixing ETag handling):

1. `TestAccV2NutanixAlertDatasource_Basic` — PASS (15.00s)
2. `TestAccV2NutanixAlertsDatasource_Basic` — PASS (13.85s)
3. `TestAccV2NutanixAlertEmailConfigurationResource_Basic` — PASS (8.22s)
4. `TestAccV2NutanixAlertEmailConfigurationResource_Update` — PASS (14.02s)
5. `TestAccV2NutanixManageAlertResource_Acknowledge` — PASS (16.95s)
6. `TestAccV2NutanixManageAlertResource_Resolve` — PASS (15.23s)

During initial development, the UpdateAlertEmailConfiguration and ManageAlert APIs
required ETag headers (HTTP 428 PRECONDITION REQUIRED). This was fixed by first
performing a GET to retrieve the ETag via `ApiClient.GetEtag(resp)`, then passing
it as `args["If-Match"]` to the update/action call.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
2026/04/29 15:00:11 Do some crazy stuff before tests!
=== RUN   TestAccV2NutanixAlertDatasource_Basic
2026/04/29 15:00:11 [DEBUG] config wait_timeout 0
2026-04-29 09:30:11.904Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:30:13.337Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:13.337Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:30:13.337Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:30:13.938Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:14.050Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/9465c616-d8a3-436e-9933-96ebba21549a
2026-04-29 09:30:14.388Z INFO - HTTP/1.1 200 OK
2026/04/29 15:00:14 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:14 [DEBUG] config wait_timeout 0
2026-04-29 09:30:14.685Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:30:16.056Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:16.056Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:30:16.056Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:30:16.742Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:16.856Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/9465c616-d8a3-436e-9933-96ebba21549a
2026-04-29 09:30:17.155Z INFO - HTTP/1.1 200 OK
2026/04/29 15:00:17 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:17 [DEBUG] config wait_timeout 0
2026/04/29 15:00:17 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:17 [DEBUG] config wait_timeout 0
2026-04-29 09:30:17.921Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:30:19.197Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:19.197Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:30:19.197Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:30:19.879Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:19.992Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/9465c616-d8a3-436e-9933-96ebba21549a
2026-04-29 09:30:20.281Z INFO - HTTP/1.1 200 OK
2026/04/29 15:00:20 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:20 [DEBUG] config wait_timeout 0
2026-04-29 09:30:20.703Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:30:21.955Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:21.955Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:30:21.956Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:30:22.549Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:22.660Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/9465c616-d8a3-436e-9933-96ebba21549a
2026-04-29 09:30:22.953Z INFO - HTTP/1.1 200 OK
2026/04/29 15:00:23 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:23 [DEBUG] config wait_timeout 0
2026-04-29 09:30:23.261Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:30:24.572Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:24.573Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:30:24.573Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:30:25.175Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:25.289Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/9465c616-d8a3-436e-9933-96ebba21549a
2026-04-29 09:30:25.590Z INFO - HTTP/1.1 200 OK
2026/04/29 15:00:26 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:26 [DEBUG] config wait_timeout 0
--- PASS: TestAccV2NutanixAlertDatasource_Basic (15.00s)
=== RUN   TestAccV2NutanixAlertsDatasource_Basic
2026/04/29 15:00:26 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:26 [DEBUG] config wait_timeout 0
2026-04-29 09:30:26.614Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:30:27.865Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:27.865Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:30:27.865Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:30:28.542Z INFO - HTTP/1.1 200 OK
2026/04/29 15:00:28 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:28 [DEBUG] config wait_timeout 0
2026-04-29 09:30:28.913Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:30:30.170Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:30.170Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:30:30.170Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:30:30.772Z INFO - HTTP/1.1 200 OK
2026/04/29 15:00:31 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:31 [DEBUG] config wait_timeout 0
2026/04/29 15:00:31 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:31 [DEBUG] config wait_timeout 0
2026-04-29 09:30:31.594Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:30:32.973Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:32.973Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:30:32.973Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:30:33.571Z INFO - HTTP/1.1 200 OK
2026/04/29 15:00:34 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:34 [DEBUG] config wait_timeout 0
2026-04-29 09:30:34.069Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:30:35.367Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:35.368Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:30:35.368Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:30:36.001Z INFO - HTTP/1.1 200 OK
2026/04/29 15:00:36 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:36 [DEBUG] config wait_timeout 0
2026-04-29 09:30:36.386Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:30:38.512Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:38.512Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:30:38.512Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:30:39.354Z INFO - HTTP/1.1 200 OK
2026/04/29 15:00:40 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:40 [DEBUG] config wait_timeout 0
--- PASS: TestAccV2NutanixAlertsDatasource_Basic (13.85s)
=== RUN   TestAccV2NutanixAlertEmailConfigurationResource_Basic
2026/04/29 15:00:40 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:40 [DEBUG] config wait_timeout 0
2026/04/29 15:00:40 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:40 [DEBUG] config wait_timeout 0
2026/04/29 15:00:41 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:41 [DEBUG] config wait_timeout 0
2026/04/29 15:00:41 [DEBUG] setting computed for "email_contact_list" from ComputedKeys
2026/04/29 15:00:41 [DEBUG] setting computed for "tunnel_details" from ComputedKeys
2026/04/29 15:00:41 [DEBUG] setting computed for "links" from ComputedKeys
2026/04/29 15:00:41 [DEBUG] setting computed for "email_config_rules" from ComputedKeys
2026/04/29 15:00:41 [DEBUG] setting computed for "email_template" from ComputedKeys
2026-04-29 09:30:41.039Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:30:42.494Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:42.494Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:30:42.494Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/email-config
2026-04-29 09:30:42.759Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:42.760Z INFO - PUT https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/email-config
2026-04-29 09:30:43.082Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:43.082Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/email-config
2026-04-29 09:30:43.345Z INFO - HTTP/1.1 200 OK
2026/04/29 15:00:43 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:43 [DEBUG] config wait_timeout 0
2026/04/29 15:00:44 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:44 [DEBUG] config wait_timeout 0
2026-04-29 09:30:44.200Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:30:47.138Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:47.138Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:30:47.138Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/email-config
2026-04-29 09:30:47.418Z INFO - HTTP/1.1 200 OK
2026/04/29 15:00:47 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:47 [DEBUG] config wait_timeout 0
2026/04/29 15:00:48 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:48 [DEBUG] config wait_timeout 0
2026/04/29 15:00:48 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:48 [DEBUG] config wait_timeout 0
--- PASS: TestAccV2NutanixAlertEmailConfigurationResource_Basic (8.22s)
=== RUN   TestAccV2NutanixAlertEmailConfigurationResource_Update
2026/04/29 15:00:48 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:48 [DEBUG] config wait_timeout 0
2026/04/29 15:00:48 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:48 [DEBUG] config wait_timeout 0
2026/04/29 15:00:49 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:49 [DEBUG] config wait_timeout 0
2026/04/29 15:00:49 [DEBUG] setting computed for "links" from ComputedKeys
2026/04/29 15:00:49 [DEBUG] setting computed for "email_config_rules" from ComputedKeys
2026/04/29 15:00:49 [DEBUG] setting computed for "email_contact_list" from ComputedKeys
2026/04/29 15:00:49 [DEBUG] setting computed for "email_template" from ComputedKeys
2026/04/29 15:00:49 [DEBUG] setting computed for "tunnel_details" from ComputedKeys
2026-04-29 09:30:49.210Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:30:50.570Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:50.570Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:30:50.570Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/email-config
2026-04-29 09:30:50.840Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:50.840Z INFO - PUT https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/email-config
2026-04-29 09:30:51.143Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:51.144Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/email-config
2026-04-29 09:30:51.404Z INFO - HTTP/1.1 200 OK
2026/04/29 15:00:51 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:51 [DEBUG] config wait_timeout 0
2026/04/29 15:00:52 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:52 [DEBUG] config wait_timeout 0
2026-04-29 09:30:52.293Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:30:53.554Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:53.555Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:30:53.555Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/email-config
2026-04-29 09:30:53.828Z INFO - HTTP/1.1 200 OK
2026/04/29 15:00:54 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:54 [DEBUG] config wait_timeout 0
2026/04/29 15:00:54 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:54 [DEBUG] config wait_timeout 0
2026-04-29 09:30:54.673Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:30:56.073Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:56.074Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:30:56.074Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/email-config
2026-04-29 09:30:56.338Z INFO - HTTP/1.1 200 OK
2026/04/29 15:00:56 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:56 [DEBUG] config wait_timeout 0
2026/04/29 15:00:56 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:56 [DEBUG] config wait_timeout 0
2026-04-29 09:30:56.921Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:30:58.163Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:58.164Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:30:58.164Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/email-config
2026-04-29 09:30:58.434Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:58.436Z INFO - PUT https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/email-config
2026-04-29 09:30:58.731Z INFO - HTTP/1.1 200 OK
2026-04-29 09:30:58.731Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/email-config
2026-04-29 09:30:58.991Z INFO - HTTP/1.1 200 OK
2026/04/29 15:00:59 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:59 [DEBUG] config wait_timeout 0
2026/04/29 15:00:59 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:00:59 [DEBUG] config wait_timeout 0
2026-04-29 09:30:59.784Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:31:01.085Z INFO - HTTP/1.1 200 OK
2026-04-29 09:31:01.085Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:31:01.085Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/email-config
2026-04-29 09:31:01.432Z INFO - HTTP/1.1 200 OK
2026/04/29 15:01:01 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:01 [DEBUG] config wait_timeout 0
2026/04/29 15:01:02 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:02 [DEBUG] config wait_timeout 0
2026/04/29 15:01:02 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:02 [DEBUG] config wait_timeout 0
--- PASS: TestAccV2NutanixAlertEmailConfigurationResource_Update (14.02s)
=== RUN   TestAccV2NutanixManageAlertResource_Acknowledge
2026/04/29 15:01:02 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:02 [DEBUG] config wait_timeout 0
2026-04-29 09:31:02.708Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:31:04.044Z INFO - HTTP/1.1 200 OK
2026-04-29 09:31:04.044Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:31:04.045Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:31:04.836Z INFO - HTTP/1.1 200 OK
2026/04/29 15:01:05 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:05 [DEBUG] config wait_timeout 0
2026-04-29 09:31:05.211Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:31:08.111Z INFO - HTTP/1.1 200 OK
2026-04-29 09:31:08.112Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:31:08.112Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:31:08.961Z INFO - HTTP/1.1 200 OK
2026/04/29 15:01:09 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:09 [DEBUG] config wait_timeout 0
2026-04-29 09:31:09.455Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:31:10.746Z INFO - HTTP/1.1 200 OK
2026-04-29 09:31:10.746Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:31:10.747Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/9465c616-d8a3-436e-9933-96ebba21549a
2026-04-29 09:31:11.055Z INFO - HTTP/1.1 200 OK
2026-04-29 09:31:11.057Z INFO - POST https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/9465c616-d8a3-436e-9933-96ebba21549a/$actions/manage-alert
2026-04-29 09:31:11.355Z INFO - HTTP/1.1 202 ACCEPTED
2026/04/29 15:01:11 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:11 [DEBUG] config wait_timeout 0
2026-04-29 09:31:11.786Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:31:13.107Z INFO - HTTP/1.1 200 OK
2026-04-29 09:31:13.107Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:31:13.107Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:31:13.713Z INFO - HTTP/1.1 200 OK
2026/04/29 15:01:14 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:14 [DEBUG] config wait_timeout 0
2026-04-29 09:31:14.256Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:31:15.500Z INFO - HTTP/1.1 200 OK
2026-04-29 09:31:15.500Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:31:15.501Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:31:16.103Z INFO - HTTP/1.1 200 OK
2026/04/29 15:01:16 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:16 [DEBUG] config wait_timeout 0
2026-04-29 09:31:16.486Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:31:17.827Z INFO - HTTP/1.1 200 OK
2026-04-29 09:31:17.828Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:31:17.828Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:31:18.435Z INFO - HTTP/1.1 200 OK
2026/04/29 15:01:19 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:19 [DEBUG] config wait_timeout 0
2026/04/29 15:01:19 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:19 [DEBUG] config wait_timeout 0
--- PASS: TestAccV2NutanixManageAlertResource_Acknowledge (16.95s)
=== RUN   TestAccV2NutanixManageAlertResource_Resolve
2026/04/29 15:01:19 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:19 [DEBUG] config wait_timeout 0
2026-04-29 09:31:19.656Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:31:20.972Z INFO - HTTP/1.1 200 OK
2026-04-29 09:31:20.972Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:31:20.972Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:31:21.566Z INFO - HTTP/1.1 200 OK
2026/04/29 15:01:21 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:21 [DEBUG] config wait_timeout 0
2026-04-29 09:31:21.938Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:31:23.298Z INFO - HTTP/1.1 200 OK
2026-04-29 09:31:23.298Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:31:23.298Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:31:23.904Z INFO - HTTP/1.1 200 OK
2026/04/29 15:01:24 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:24 [DEBUG] config wait_timeout 0
2026-04-29 09:31:24.391Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:31:25.693Z INFO - HTTP/1.1 200 OK
2026-04-29 09:31:25.694Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:31:25.694Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/9465c616-d8a3-436e-9933-96ebba21549a
2026-04-29 09:31:25.991Z INFO - HTTP/1.1 200 OK
2026-04-29 09:31:25.994Z INFO - POST https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts/9465c616-d8a3-436e-9933-96ebba21549a/$actions/manage-alert
2026-04-29 09:31:26.293Z INFO - HTTP/1.1 202 ACCEPTED
2026/04/29 15:01:26 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:26 [DEBUG] config wait_timeout 0
2026-04-29 09:31:26.744Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:31:28.035Z INFO - HTTP/1.1 200 OK
2026-04-29 09:31:28.035Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:31:28.035Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:31:28.659Z INFO - HTTP/1.1 200 OK
2026/04/29 15:01:29 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:29 [DEBUG] config wait_timeout 0
2026-04-29 09:31:29.329Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:31:30.675Z INFO - HTTP/1.1 200 OK
2026-04-29 09:31:30.675Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:31:30.675Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:31:31.265Z INFO - HTTP/1.1 200 OK
2026/04/29 15:01:31 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:31 [DEBUG] config wait_timeout 0
2026-04-29 09:31:31.683Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 09:31:33.028Z INFO - HTTP/1.1 200 OK
2026-04-29 09:31:33.029Z INFO - Negotiated Version with server : v4.2
2026-04-29 09:31:33.029Z INFO - GET https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/alerts
2026-04-29 09:31:33.627Z INFO - HTTP/1.1 200 OK
2026/04/29 15:01:34 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:34 [DEBUG] config wait_timeout 0
2026/04/29 15:01:34 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:01:34 [DEBUG] config wait_timeout 0
--- PASS: TestAccV2NutanixManageAlertResource_Resolve (15.23s)
PASS
coverage: 57.5% of statements
ok  	github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/monitoringv2	84.316s	coverage: 57.5% of statements
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` are stored only in the agent transcript;
  no `sdk_info.json` is committed to this branch.
