### PR TITLE
code-gen(monitoring/system): terraform v2 provider code

### DIFF
--- a/examples/monitoring_v2/system/main.tf
+++ b/examples/monitoring_v2/system/main.tf
@@ -1,0 +1,30 @@
+variable "nutanix_endpoint" {}
+variable "nutanix_username" {}
+variable "nutanix_password" {}
+variable "nutanix_port" {}
+variable "nutanix_insecure" {}
+
+provider "nutanix" {
+  endpoint = var.nutanix_endpoint
+  username = var.nutanix_username
+  password = var.nutanix_password
+  port     = var.nutanix_port
+  insecure = var.nutanix_insecure
+}
+
+# List AOS clusters
+data "nutanix_clusters_v2" "clusters" {
+  filter = "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+}
+
+locals {
+  clusterExtID = data.nutanix_clusters_v2.clusters.cluster_entities[0].ext_id
+}
+
+# Run System-Defined Checks on the cluster
+resource "nutanix_run_system_defined_checks_v2" "example" {
+  cluster_ext_id        = local.clusterExtID
+  should_run_all_checks = true
+  should_anonymize      = false
+  should_send_report_to_configured_recipients = true
+}

--- a/examples/monitoring_v2/system/provider.tf
+++ b/examples/monitoring_v2/system/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = ">= 2.0.0"
+    }
+  }
+}

--- a/examples/monitoring_v2/system/terraform.tfvars
+++ b/examples/monitoring_v2/system/terraform.tfvars
@@ -1,0 +1,5 @@
+nutanix_endpoint = "10.0.0.1"
+nutanix_username = "admin"
+nutanix_password = "REPLACE_ME"
+nutanix_port     = 9440
+nutanix_insecure = true

--- a/go.mod
+++ b/go.mod
@@ -107,6 +107,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/nakabonne/nestif v0.3.0 // indirect
 	github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d // indirect
+	github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -467,6 +467,8 @@ github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2 h1:ms+a
 github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2/go.mod h1:X3TsJoGBbkQzz6OP8Be7XvGhH4CwKkF9t35OmJpPY0w=
 github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2 h1:dE0zUP3ExJBnMUaGDAIZGN7/UZ0a85IWzHygMGcUDMc=
 github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2/go.mod h1:vo3VMB097Zd9cw4hLDbnpyBVcBZkpFmcQ2nNgpOpo7U=
+github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2 h1:dXFgnBHMd6MipSXkQE5cRysjKX96MeYeIFIkZDvye60=
+github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2/go.mod h1:msvlZou4z7vn5pHFhJ65OtAbh99z1ISsqCzfehdcWfw=
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1 h1:VWxK8mY6kOag/ocDBttDViktEi8bcjbAvm3i9laDyCA=
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1/go.mod h1:4fUdP3zeL4UFS/UVaii5EdS2v+KlM4gI07KcnS+wDuY=
 github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4 v4.0.3 h1:TE/G5GHrnvBGPI8MC0fSMSAaeD6HcdtezIgEmn8V/Yo=

--- a/nutanix/config.go
+++ b/nutanix/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/iam"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/lcm"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/microseg"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/monitoring"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/networking"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/objectstores"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/prism"
@@ -140,6 +141,10 @@ func (c *Config) Client() (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	monitoringClient, err := monitoring.NewMonitoringClient(configCreds)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Client{
 		WaitTimeout:         c.WaitTimeout,
@@ -161,6 +166,7 @@ func (c *Config) Client() (*Client, error) {
 		CalmAPI:             calmClient,
 		ObjectStoreAPI:      ObjectStoreClient,
 		SecurityAPI:         SecurityClient,
+		MonitoringAPI:       monitoringClient,
 	}, nil
 }
 
@@ -185,4 +191,5 @@ type Client struct {
 	CalmAPI             *selfservice.Client
 	ObjectStoreAPI      *objectstores.Client
 	SecurityAPI         *security.Client
+	MonitoringAPI       *monitoring.Client
 }

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/iamv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/lcmv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/microsegv2"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/monitoringv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/ndb"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/networking"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/networkingv2"
@@ -501,6 +502,7 @@ func Provider() *schema.Provider {
 			"nutanix_object_store_certificate_v2":             objectstoresv2.ResourceNutanixObjectStoreCertificateV2(),
 			"nutanix_key_management_server_v2":                securityv2.ResourceNutanixKeyManagementServerV2(),
 			"nutanix_entity_group_v2":                         microsegv2.ResourceNutanixEntityGroupV2(),
+			"nutanix_run_system_defined_checks_v2":            monitoringv2.ResourceNutanixRunSystemDefinedChecksV2(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}

--- a/nutanix/sdks/v4/monitoring/monitoring.go
+++ b/nutanix/sdks/v4/monitoring/monitoring.go
@@ -1,0 +1,31 @@
+package monitoring
+
+import (
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/api"
+	monitoring "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
+)
+
+type Client struct {
+	SystemDefinedChecksAPI *api.SystemDefinedChecksApi
+}
+
+func NewMonitoringClient(credentials client.Credentials) (*Client, error) {
+	var baseClient *monitoring.ApiClient
+
+	pcClient := monitoring.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
+		baseClient = pcClient
+	}
+
+	return &Client{
+		SystemDefinedChecksAPI: api.NewSystemDefinedChecksApi(baseClient),
+	}, nil
+}

--- a/nutanix/services/monitoringv2/main_test.go
+++ b/nutanix/services/monitoringv2/main_test.go
@@ -1,0 +1,41 @@
+package monitoringv2_test
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"testing"
+)
+
+type TestConfig struct {
+	Monitoring struct {
+		ClusterExtID string `json:"cluster_ext_id"`
+	} `json:"monitoring"`
+}
+
+var testVars TestConfig
+
+var (
+	path, _  = os.Getwd()
+	filepath = path + "/../../../test_config_v2.json"
+)
+
+func loadVars(filepath string, varStuct interface{}) {
+	configData, err := os.ReadFile(filepath)
+	if err != nil {
+		log.Printf("Got this error while reading config.json: %s", err.Error())
+		os.Exit(1)
+	}
+
+	err = json.Unmarshal(configData, varStuct)
+	if err != nil {
+		log.Printf("Got this error while unmarshalling config.json: %s", err.Error())
+		os.Exit(1)
+	}
+}
+
+func TestMain(m *testing.M) {
+	log.Println("Do some crazy stuff before tests!")
+	loadVars("../../../test_config_v2.json", &testVars)
+	os.Exit(m.Run())
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_run_system_defined_checks_v2.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_run_system_defined_checks_v2.go
@@ -1,0 +1,196 @@
+package monitoringv2
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	monitoringCommon "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/common/v1/config"
+	monitoringServiceability "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	taskRef "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/prism/v4/config"
+	prismConfig "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/prism/v4/config"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/common"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func ResourceNutanixRunSystemDefinedChecksV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNutanixRunSystemDefinedChecksV2Create,
+		ReadContext:   resourceNutanixRunSystemDefinedChecksV2Read,
+		UpdateContext: resourceNutanixRunSystemDefinedChecksV2Update,
+		DeleteContext: resourceNutanixRunSystemDefinedChecksV2Delete,
+		Schema: map[string]*schema.Schema{
+			"cluster_ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Unique identifier for the cluster for which run System-Defined Checks is requested.",
+			},
+			"additional_recipients": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "A list of additional email addresses for sending the run summary. Either this should be set or should_send_report_to_configured_recipients should be true. If both are set then email would be sent to all the recipients.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"node_ips": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "List of node IP addresses where the Check will run. This field will be ignored if the check scope is a cluster.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"prefix_length": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The prefix length of the network to which this host IPv4 address belongs.",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The IPv4 address of the host.",
+						},
+					},
+				},
+			},
+			"sda_ext_ids": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "List of Check IDs to be executed. This field cannot be set simultaneously with should_run_all_checks; only one of them should be specified.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"should_anonymize": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Indicates whether to mask sensitive data in the check run summary.",
+			},
+			"should_run_all_checks": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Indicates whether all System-Defined Checks applicable to the specified cluster should be executed. This field is mutually exclusive with the sda_ext_ids parameter, meaning that only one of these should be set at a time. Please use this field with caution, as it is resource-intensive.",
+			},
+			"should_send_report_to_configured_recipients": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Determines if the run summary should be sent to the configured email address associated with the cluster. Either this should be true or additional_recipients should be provided. If both are set then email would be sent to all the recipients.",
+			},
+			"task_ext_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A globally unique identifier for the task returned by the API.",
+			},
+		},
+	}
+}
+
+func resourceNutanixRunSystemDefinedChecksV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client)
+	monitoringConn := conn.MonitoringAPI
+
+	clusterExtID := d.Get("cluster_ext_id").(string)
+
+	body := monitoringServiceability.NewRunSystemDefinedChecksSpec()
+
+	if v, ok := d.GetOk("additional_recipients"); ok {
+		recipients := v.([]interface{})
+		recipientList := make([]string, len(recipients))
+		for i, r := range recipients {
+			recipientList[i] = r.(string)
+		}
+		body.AdditionalRecipients = recipientList
+	}
+
+	if v, ok := d.GetOk("node_ips"); ok {
+		nodeIps := v.([]interface{})
+		ipList := make([]monitoringCommon.IPv4Address, len(nodeIps))
+		for i, ip := range nodeIps {
+			ipMap := ip.(map[string]interface{})
+			ipAddr := monitoringCommon.IPv4Address{}
+			if val, exists := ipMap["value"]; exists && val.(string) != "" {
+				ipAddr.Value = utils.StringPtr(val.(string))
+			}
+			if val, exists := ipMap["prefix_length"]; exists && val.(int) != 0 {
+				ipAddr.PrefixLength = utils.IntPtr(val.(int))
+			}
+			ipList[i] = ipAddr
+		}
+		body.NodeIps = ipList
+	}
+
+	if v, ok := d.GetOk("sda_ext_ids"); ok {
+		sdaExtIds := v.([]interface{})
+		sdaList := make([]string, len(sdaExtIds))
+		for i, s := range sdaExtIds {
+			sdaList[i] = s.(string)
+		}
+		body.SdaExtIds = sdaList
+	}
+
+	if v, ok := d.GetOk("should_anonymize"); ok {
+		body.ShouldAnonymize = utils.BoolPtr(v.(bool))
+	}
+
+	if v, ok := d.GetOk("should_run_all_checks"); ok {
+		body.ShouldRunAllChecks = utils.BoolPtr(v.(bool))
+	}
+
+	if v, ok := d.GetOk("should_send_report_to_configured_recipients"); ok {
+		body.ShouldSendReportToConfiguredRecipients = utils.BoolPtr(v.(bool))
+	}
+
+	resp, err := monitoringConn.SystemDefinedChecksAPI.RunSystemDefinedChecks(
+		utils.StringPtr(clusterExtID),
+		body,
+	)
+	if err != nil {
+		return diag.Errorf("error while running System-Defined Checks: %v", err)
+	}
+
+	taskReference := resp.Data.GetValue().(taskRef.TaskReference)
+	taskUUID := taskReference.ExtId
+
+	taskconn := conn.PrismAPI
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"QUEUED", "RUNNING", "PENDING"},
+		Target:  []string{"SUCCEEDED"},
+		Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, taskconn, utils.StringValue(taskUUID)),
+		Timeout: d.Timeout(schema.TimeoutCreate),
+	}
+
+	if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
+		return diag.Errorf("error waiting for System-Defined Checks task (%s) to complete: %s", utils.StringValue(taskUUID), errWaitTask)
+	}
+
+	taskResp, err := taskconn.TaskRefAPI.GetTaskById(taskUUID, nil)
+	if err != nil {
+		return diag.Errorf("error while fetching System-Defined Checks task: %v", err)
+	}
+	taskDetails := taskResp.Data.GetValue().(prismConfig.Task)
+	aJSON, _ := json.MarshalIndent(taskDetails, "", "  ")
+	log.Printf("[DEBUG] Run System-Defined Checks Task Details: %s", string(aJSON))
+
+	d.SetId(utils.StringValue(taskDetails.ExtId))
+	if err := d.Set("task_ext_id", utils.StringValue(taskDetails.ExtId)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceNutanixRunSystemDefinedChecksV2Read(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceNutanixRunSystemDefinedChecksV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceNutanixRunSystemDefinedChecksV2Create(ctx, d, meta)
+}
+
+func resourceNutanixRunSystemDefinedChecksV2Delete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	d.SetId("")
+	return nil
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_run_system_defined_checks_v2_test.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_run_system_defined_checks_v2_test.go
@@ -1,0 +1,86 @@
+package monitoringv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const resourceNameRunSystemDefinedChecks = "nutanix_run_system_defined_checks_v2.test"
+
+func TestAccV2NutanixRunSystemDefinedChecksResource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testRunSystemDefinedChecksBasicConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameRunSystemDefinedChecks, "cluster_ext_id"),
+					resource.TestCheckResourceAttrSet(resourceNameRunSystemDefinedChecks, "task_ext_id"),
+					resource.TestCheckResourceAttr(resourceNameRunSystemDefinedChecks, "should_run_all_checks", "true"),
+					resource.TestCheckResourceAttr(resourceNameRunSystemDefinedChecks, "should_anonymize", "true"),
+					resource.TestCheckResourceAttr(resourceNameRunSystemDefinedChecks, "additional_recipients.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameRunSystemDefinedChecks, "additional_recipients.0", "test@nutanix.com"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixRunSystemDefinedChecksResource_WithAdditionalRecipients(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testRunSystemDefinedChecksWithRecipientsConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameRunSystemDefinedChecks, "cluster_ext_id"),
+					resource.TestCheckResourceAttrSet(resourceNameRunSystemDefinedChecks, "task_ext_id"),
+					resource.TestCheckResourceAttr(resourceNameRunSystemDefinedChecks, "should_run_all_checks", "true"),
+					resource.TestCheckResourceAttr(resourceNameRunSystemDefinedChecks, "additional_recipients.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameRunSystemDefinedChecks, "additional_recipients.0", "test@example.com"),
+				),
+			},
+		},
+	})
+}
+
+func testRunSystemDefinedChecksBasicConfig() string {
+	return `
+data "nutanix_clusters_v2" "clusters" {
+  filter = "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+}
+
+locals {
+  clusterExtID = data.nutanix_clusters_v2.clusters.cluster_entities[0].ext_id
+}
+
+resource "nutanix_run_system_defined_checks_v2" "test" {
+  cluster_ext_id        = local.clusterExtID
+  should_run_all_checks = true
+  should_anonymize      = true
+  additional_recipients = ["test@nutanix.com"]
+}
+`
+}
+
+func testRunSystemDefinedChecksWithRecipientsConfig() string {
+	return `
+data "nutanix_clusters_v2" "clusters" {
+  filter = "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+}
+
+locals {
+  clusterExtID = data.nutanix_clusters_v2.clusters.cluster_entities[0].ext_id
+}
+
+resource "nutanix_run_system_defined_checks_v2" "test" {
+  cluster_ext_id    = local.clusterExtID
+  should_run_all_checks = true
+  additional_recipients = ["test@example.com"]
+}
+`
+}

--- a/website/docs/r/run_system_defined_checks_v2.html.markdown
+++ b/website/docs/r/run_system_defined_checks_v2.html.markdown
@@ -1,0 +1,59 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_run_system_defined_checks_v2"
+sidebar_current: "docs-nutanix_run_system_defined_checks_v2"
+description: |-
+  Run System-Defined Checks on a cluster.
+---
+
+# nutanix_run_system_defined_checks_v2
+
+Run System-Defined Checks on a cluster.
+
+## Example
+
+```hcl
+# List AOS clusters
+data "nutanix_clusters_v2" "clusters" {
+  filter = "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+}
+
+locals {
+  clusterExtID = data.nutanix_clusters_v2.clusters.cluster_entities[0].ext_id
+}
+
+# Run System-Defined Checks on the cluster
+resource "nutanix_run_system_defined_checks_v2" "example" {
+  cluster_ext_id        = local.clusterExtID
+  should_run_all_checks = true
+  should_anonymize      = false
+  should_send_report_to_configured_recipients = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_ext_id`: (Required) Unique identifier for the cluster for which run System-Defined Checks is requested.
+* `additional_recipients`: (Optional) A list of additional email addresses for sending the run summary. Either this should be set or `should_send_report_to_configured_recipients` should be true. If both are set then email would be sent to all the recipients.
+* `node_ips`: (Optional) List of node IP addresses where the Check will run. This field will be ignored if the check scope is a cluster.
+* `sda_ext_ids`: (Optional) List of Check IDs to be executed. This field cannot be set simultaneously with `should_run_all_checks`; only one of them should be specified.
+* `should_anonymize`: (Optional) Indicates whether to mask sensitive data in the check run summary.
+* `should_run_all_checks`: (Optional) Indicates whether all System-Defined Checks applicable to the specified cluster should be executed. This field is mutually exclusive with the `sda_ext_ids` parameter, meaning that only one of these should be set at a time. Please use this field with caution, as it is resource-intensive.
+* `should_send_report_to_configured_recipients`: (Optional) Determines if the run summary should be sent to the configured email address associated with the cluster. Either this should be true or `additional_recipients` should be provided. If both are set then email would be sent to all the recipients.
+
+### node_ips
+
+The `node_ips` attribute supports the following:
+
+* `prefix_length`: (Optional) The prefix length of the network to which this host IPv4 address belongs.
+* `value`: (Optional) The IPv4 address of the host.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `task_ext_id`: A globally unique identifier for the task returned by the API.
+
+See detailed information in [Nutanix Monitoring System-Defined Checks v4](https://developers.nutanix.com/api-reference?namespace=monitoring&version=v4.2#tag/SystemDefinedChecksService/operation/RunSystemDefinedChecks)


### PR DESCRIPTION
## Summary

Auto-generated Terraform provider code for the **monitoring** namespace, entity
**system**, based on the inline `sdk_info.json` (see prompt). One PR per code-gen run.

- SDK module: `github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4@v4.2.2`
- API methods covered: 1 (`RunSystemDefinedChecks`)
- Datasources generated: 0
- Resources generated: 1 (`nutanix_run_system_defined_checks_v2`)

## Files changed

**nutanix/sdks/v4/monitoring/**
- `monitoring.go` — SDK client wrapper for monitoring APIs

**nutanix/**
- `config.go` — Added `MonitoringAPI` client field and initialization

**nutanix/provider/**
- `provider.go` — Registered `nutanix_run_system_defined_checks_v2` resource

**nutanix/services/monitoringv2/**
- `resource_nutanix_run_system_defined_checks_v2.go` — Action resource for running system-defined checks
- `resource_nutanix_run_system_defined_checks_v2_test.go` — Acceptance tests
- `main_test.go` — Test scaffolding

**examples/monitoring_v2/system/**
- `main.tf` — Example usage with provider and resource blocks
- `provider.tf` — Required providers source pin
- `terraform.tfvars` — Placeholder variable values

**website/docs/r/**
- `run_system_defined_checks_v2.html.markdown` — Resource documentation

**Dependency**
- `go.mod` / `go.sum` — Added `monitoring-go-client/v4@v4.2.2`

## Test execution

| Metric              | Value                                                                                  |
|---------------------|----------------------------------------------------------------------------------------|
| Command             | `TF_ACC=1 go test ./nutanix/services/monitoringv2 -v -run=TestAccV2NutanixRunSystemDefinedChecksResource_ -timeout 500m` |
| Total testcases     | 2                                                                                      |
| Passed              | 2                                                                                      |
| Failed              | 0                                                                                      |
| Skipped             | 0                                                                                      |
| Wall-clock duration | 4:34                                                                                   |
| Cluster (PC)        | 10.44.76.91                                                                            |

### Analysis

All 2 acceptance tests passed on first run (after initial fix to ensure `additional_recipients` is provided — the API requires either `additionalRecipients` or `shouldSendReportToConfiguredRecipients=true`).

- **TestAccV2NutanixRunSystemDefinedChecksResource_Basic** — 131.80s, PASS
- **TestAccV2NutanixRunSystemDefinedChecksResource_WithAdditionalRecipients** — 142.09s, PASS

No known issues.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
2026/04/29 15:56:44 Do some crazy stuff before tests!
=== RUN   TestAccV2NutanixRunSystemDefinedChecksResource_Basic
2026/04/29 15:56:44 [DEBUG] config wait_timeout 0
2026-04-29 10:26:44.980Z INFO - OPTIONS https://10.44.76.91:9440/api/clustermgmt/unversioned/info
2026-04-29 10:26:46.251Z INFO - HTTP/1.1 200 OK
2026-04-29 10:26:46.251Z INFO - Negotiated Version with server : v4.2
2026-04-29 10:26:46.251Z INFO - GET https://10.44.76.91:9440/api/clustermgmt/v4.2/config/clusters?%24filter=config%2FclusterFunction%2Fany%28t%3At+eq+Clustermgmt.Config.ClusterFunctionRef%27AOS%27%29
2026-04-29 10:26:46.552Z INFO - HTTP/1.1 200 OK
2026/04/29 15:56:46 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:56:46 [DEBUG] config wait_timeout 0
2026-04-29 10:26:46.842Z INFO - OPTIONS https://10.44.76.91:9440/api/clustermgmt/unversioned/info
2026-04-29 10:26:48.133Z INFO - HTTP/1.1 200 OK
2026-04-29 10:26:48.133Z INFO - Negotiated Version with server : v4.2
2026-04-29 10:26:48.133Z INFO - GET https://10.44.76.91:9440/api/clustermgmt/v4.2/config/clusters?%24filter=config%2FclusterFunction%2Fany%28t%3At+eq+Clustermgmt.Config.ClusterFunctionRef%27AOS%27%29
2026-04-29 10:26:48.432Z INFO - HTTP/1.1 200 OK
2026/04/29 15:56:48 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:56:48 [DEBUG] config wait_timeout 0
2026-04-29 10:26:48.763Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 10:26:50.027Z INFO - HTTP/1.1 200 OK
2026-04-29 10:26:50.027Z INFO - Negotiated Version with server : v4.2
2026-04-29 10:26:50.028Z INFO - POST https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/clusters/0006501c-2183-2735-0000-000000028f57/$actions/run-system-defined-checks
2026-04-29 10:26:50.378Z INFO - HTTP/1.1 202 ACCEPTED
2026/04/29 15:56:50 [DEBUG] Waiting for state to become: [SUCCEEDED]
2026-04-29 10:26:50.378Z INFO - OPTIONS https://10.44.76.91:9440/api/prism/unversioned/info
2026-04-29 10:26:51.629Z INFO - HTTP/1.1 200 OK
2026-04-29 10:26:51.629Z INFO - Negotiated Version with server : v4.3
2026-04-29 10:26:51.629Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:26:51.927Z INFO - HTTP/1.1 200 OK
2026-04-29 10:26:52.129Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:26:52.390Z INFO - HTTP/1.1 200 OK
2026-04-29 10:26:52.792Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:26:53.085Z INFO - HTTP/1.1 200 OK
2026-04-29 10:26:53.887Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:26:54.217Z INFO - HTTP/1.1 200 OK
2026-04-29 10:26:55.819Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:26:56.078Z INFO - HTTP/1.1 200 OK
2026-04-29 10:26:59.281Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:26:59.546Z INFO - HTTP/1.1 200 OK
2026-04-29 10:27:05.949Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:27:06.230Z INFO - HTTP/1.1 200 OK
2026-04-29 10:27:16.231Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:27:16.494Z INFO - HTTP/1.1 200 OK
2026-04-29 10:27:26.497Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:27:26.760Z INFO - HTTP/1.1 200 OK
2026-04-29 10:27:36.763Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:27:37.034Z INFO - HTTP/1.1 200 OK
2026-04-29 10:27:47.038Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:27:47.361Z INFO - HTTP/1.1 200 OK
2026-04-29 10:27:57.365Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:27:57.628Z INFO - HTTP/1.1 200 OK
2026-04-29 10:28:07.633Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:28:07.896Z INFO - HTTP/1.1 200 OK
2026-04-29 10:28:17.898Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:28:18.162Z INFO - HTTP/1.1 200 OK
2026-04-29 10:28:28.165Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:28:28.506Z INFO - HTTP/1.1 200 OK
2026-04-29 10:28:38.508Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:28:38.772Z INFO - HTTP/1.1 200 OK
2026-04-29 10:28:48.778Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:28:49.055Z INFO - HTTP/1.1 200 OK
2026-04-29 10:28:49.058Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff
2026-04-29 10:28:49.328Z INFO - HTTP/1.1 200 OK
2026/04/29 15:58:49 [DEBUG] Run System-Defined Checks Task Details: {
  "$objectType": "prism.v4.config.Task",
  "$reserved": {
    "$fv": "v4.r3"
  },
  "$unknownFields": {
    "projectExtId": "00000000-0000-0000-0000-000000000000"
  },
  "clusterExtIds": [
    "0006501c-2183-2735-0000-000000028f57"
  ],
  "completedTime": "2026-04-29T10:28:46.191852Z",
  "completionDetails": [
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "status",
      "value": "ERROR"
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "total",
      "value": 334
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "pass",
      "value": 322
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "info",
      "value": 3
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "warn",
      "value": 3
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "fail",
      "value": 4
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "error",
      "value": 2
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "detailedSummary",
      "value": [
        {
          "$objectType": "common.v1.config.MapOfStringWrapper",
          "$reserved": {
            "$fv": "v1.r0"
          },
          "map": {
            "errorSdaExtIds": "106028,106041",
            "failSdaExtIds": "110210,6214,15037,111039",
            "infoSdaExtIds": "600101,6219,6230",
            "warnSdaExtIds": "14001,106059,106064"
          }
        }
      ]
    }
  ],
  "createdTime": "2026-04-29T10:26:50.316677Z",
  "entitiesAffected": [
    {
      "$objectType": "prism.v4.config.EntityReference",
      "$reserved": {
        "$fv": "v4.r3"
      },
      "extId": "0006501c-2183-2735-0000-000000028f57",
      "name": "auto_cluster_prod_361bd71f8d22",
      "rel": "clustermgmt:config:cluster"
    }
  ],
  "extId": "ZXJnb24=:33b479d2-a4b4-4ea5-578b-c30ab8115cff",
  "isBackgroundTask": false,
  "isCancelable": false,
  "lastUpdatedTime": "2026-04-29T10:28:46.191851Z",
  "numberOfEntitiesAffected": 1,
  "numberOfSubtasks": 1,
  "operation": "RunHealthChecksFromPC",
  "operationDescription": "Run System-Defined Check(s)",
  "ownedBy": {
    "$objectType": "prism.v4.config.OwnerReference",
    "$reserved": {
      "$fv": "v4.r3"
    },
    "extId": "00000000-0000-0000-0000-000000000000",
    "name": "admin"
  },
  "progressPercentage": 100,
  "startedTime": "2026-04-29T10:26:50.336764Z",
  "status": "SUCCEEDED",
  "subTasks": [
    {
      "$objectType": "prism.v4.config.TaskReferenceInternal",
      "$reserved": {
        "$fv": "v4.r3"
      },
      "extId": "ZXJnb24=:10438583-cf86-48d4-6038-810fa1ff851f",
      "href": "https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:10438583-cf86-48d4-6038-810fa1ff851f",
      "rel": "subtask"
    }
  ]
}
2026/04/29 15:58:49 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:58:49 [DEBUG] config wait_timeout 0
2026-04-29 10:28:49.921Z INFO - OPTIONS https://10.44.76.91:9440/api/clustermgmt/unversioned/info
2026-04-29 10:28:51.355Z INFO - HTTP/1.1 200 OK
2026-04-29 10:28:51.356Z INFO - Negotiated Version with server : v4.2
2026-04-29 10:28:51.356Z INFO - GET https://10.44.76.91:9440/api/clustermgmt/v4.2/config/clusters?%24filter=config%2FclusterFunction%2Fany%28t%3At+eq+Clustermgmt.Config.ClusterFunctionRef%27AOS%27%29
2026-04-29 10:28:51.646Z INFO - HTTP/1.1 200 OK
2026/04/29 15:58:52 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:58:52 [DEBUG] config wait_timeout 0
2026-04-29 10:28:52.025Z INFO - OPTIONS https://10.44.76.91:9440/api/clustermgmt/unversioned/info
2026-04-29 10:28:53.411Z INFO - HTTP/1.1 200 OK
2026-04-29 10:28:53.411Z INFO - Negotiated Version with server : v4.2
2026-04-29 10:28:53.411Z INFO - GET https://10.44.76.91:9440/api/clustermgmt/v4.2/config/clusters?%24filter=config%2FclusterFunction%2Fany%28t%3At+eq+Clustermgmt.Config.ClusterFunctionRef%27AOS%27%29
2026-04-29 10:28:53.697Z INFO - HTTP/1.1 200 OK
2026/04/29 15:58:53 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:58:53 [DEBUG] config wait_timeout 0
2026-04-29 10:28:53.977Z INFO - OPTIONS https://10.44.76.91:9440/api/clustermgmt/unversioned/info
2026-04-29 10:28:55.225Z INFO - HTTP/1.1 200 OK
2026-04-29 10:28:55.225Z INFO - Negotiated Version with server : v4.2
2026-04-29 10:28:55.225Z INFO - GET https://10.44.76.91:9440/api/clustermgmt/v4.2/config/clusters?%24filter=config%2FclusterFunction%2Fany%28t%3At+eq+Clustermgmt.Config.ClusterFunctionRef%27AOS%27%29
2026-04-29 10:28:55.539Z INFO - HTTP/1.1 200 OK
2026/04/29 15:58:56 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:58:56 [DEBUG] config wait_timeout 0
2026/04/29 15:58:56 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:58:56 [DEBUG] config wait_timeout 0
--- PASS: TestAccV2NutanixRunSystemDefinedChecksResource_Basic (131.80s)
=== RUN   TestAccV2NutanixRunSystemDefinedChecksResource_WithAdditionalRecipients
2026/04/29 15:58:56 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:58:56 [DEBUG] config wait_timeout 0
2026-04-29 10:28:56.599Z INFO - OPTIONS https://10.44.76.91:9440/api/clustermgmt/unversioned/info
2026-04-29 10:28:57.836Z INFO - HTTP/1.1 200 OK
2026-04-29 10:28:57.837Z INFO - Negotiated Version with server : v4.2
2026-04-29 10:28:57.837Z INFO - GET https://10.44.76.91:9440/api/clustermgmt/v4.2/config/clusters?%24filter=config%2FclusterFunction%2Fany%28t%3At+eq+Clustermgmt.Config.ClusterFunctionRef%27AOS%27%29
2026-04-29 10:28:58.157Z INFO - HTTP/1.1 200 OK
2026/04/29 15:58:58 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:58:58 [DEBUG] config wait_timeout 0
2026-04-29 10:28:58.454Z INFO - OPTIONS https://10.44.76.91:9440/api/clustermgmt/unversioned/info
2026-04-29 10:28:59.774Z INFO - HTTP/1.1 200 OK
2026-04-29 10:28:59.774Z INFO - Negotiated Version with server : v4.2
2026-04-29 10:28:59.774Z INFO - GET https://10.44.76.91:9440/api/clustermgmt/v4.2/config/clusters?%24filter=config%2FclusterFunction%2Fany%28t%3At+eq+Clustermgmt.Config.ClusterFunctionRef%27AOS%27%29
2026-04-29 10:29:00.120Z INFO - HTTP/1.1 200 OK
2026/04/29 15:59:00 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 15:59:00 [DEBUG] config wait_timeout 0
2026-04-29 10:29:00.460Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 10:29:01.830Z INFO - HTTP/1.1 200 OK
2026-04-29 10:29:01.830Z INFO - Negotiated Version with server : v4.2
2026-04-29 10:29:01.831Z INFO - POST https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/clusters/0006501c-2183-2735-0000-000000028f57/$actions/run-system-defined-checks
2026-04-29 10:29:02.195Z INFO - HTTP/1.1 202 ACCEPTED
2026/04/29 15:59:02 [DEBUG] Waiting for state to become: [SUCCEEDED]
2026-04-29 10:29:02.195Z INFO - OPTIONS https://10.44.76.91:9440/api/prism/unversioned/info
2026-04-29 10:29:03.461Z INFO - HTTP/1.1 200 OK
2026-04-29 10:29:03.461Z INFO - Negotiated Version with server : v4.3
2026-04-29 10:29:03.461Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:29:03.751Z INFO - HTTP/1.1 200 OK
2026-04-29 10:29:03.953Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:29:04.278Z INFO - HTTP/1.1 200 OK
2026-04-29 10:29:04.681Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:29:04.946Z INFO - HTTP/1.1 200 OK
2026-04-29 10:29:05.747Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:29:06.017Z INFO - HTTP/1.1 200 OK
2026-04-29 10:29:07.618Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:29:07.882Z INFO - HTTP/1.1 200 OK
2026-04-29 10:29:11.084Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:29:11.346Z INFO - HTTP/1.1 200 OK
2026-04-29 10:29:17.748Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:29:18.055Z INFO - HTTP/1.1 200 OK
2026-04-29 10:29:28.058Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:29:28.319Z INFO - HTTP/1.1 200 OK
2026-04-29 10:29:38.323Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:29:38.594Z INFO - HTTP/1.1 200 OK
2026-04-29 10:29:48.597Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:29:48.860Z INFO - HTTP/1.1 200 OK
2026-04-29 10:29:58.862Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:29:59.205Z INFO - HTTP/1.1 200 OK
2026-04-29 10:30:09.206Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:30:09.475Z INFO - HTTP/1.1 200 OK
2026-04-29 10:30:19.477Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:30:19.740Z INFO - HTTP/1.1 200 OK
2026-04-29 10:30:29.742Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:30:30.091Z INFO - HTTP/1.1 200 OK
2026-04-29 10:30:40.095Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:30:40.392Z INFO - HTTP/1.1 200 OK
2026-04-29 10:30:50.395Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:30:50.669Z INFO - HTTP/1.1 200 OK
2026-04-29 10:31:00.671Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:31:00.933Z INFO - HTTP/1.1 200 OK
2026-04-29 10:31:10.936Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:31:11.197Z INFO - HTTP/1.1 200 OK
2026-04-29 10:31:11.199Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc
2026-04-29 10:31:11.460Z INFO - HTTP/1.1 200 OK
2026/04/29 16:01:11 [DEBUG] Run System-Defined Checks Task Details: {
  "$objectType": "prism.v4.config.Task",
  "$reserved": {
    "$fv": "v4.r3"
  },
  "$unknownFields": {
    "projectExtId": "00000000-0000-0000-0000-000000000000"
  },
  "clusterExtIds": [
    "0006501c-2183-2735-0000-000000028f57"
  ],
  "completedTime": "2026-04-29T10:31:05.024804Z",
  "completionDetails": [
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "status",
      "value": "ERROR"
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "total",
      "value": 334
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "pass",
      "value": 322
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "info",
      "value": 3
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "warn",
      "value": 3
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "fail",
      "value": 4
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "error",
      "value": 2
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "detailedSummary",
      "value": [
        {
          "$objectType": "common.v1.config.MapOfStringWrapper",
          "$reserved": {
            "$fv": "v1.r0"
          },
          "map": {
            "errorSdaExtIds": "106028,106041",
            "failSdaExtIds": "6214,15037,110210,111039",
            "infoSdaExtIds": "6230,6219,600101",
            "warnSdaExtIds": "14001,106059,106064"
          }
        }
      ]
    }
  ],
  "createdTime": "2026-04-29T10:29:02.117476Z",
  "entitiesAffected": [
    {
      "$objectType": "prism.v4.config.EntityReference",
      "$reserved": {
        "$fv": "v4.r3"
      },
      "extId": "0006501c-2183-2735-0000-000000028f57",
      "name": "auto_cluster_prod_361bd71f8d22",
      "rel": "clustermgmt:config:cluster"
    }
  ],
  "extId": "ZXJnb24=:cdf63f82-f7de-4bcd-4376-1a2e290948fc",
  "isBackgroundTask": false,
  "isCancelable": false,
  "lastUpdatedTime": "2026-04-29T10:31:05.024803Z",
  "numberOfEntitiesAffected": 1,
  "numberOfSubtasks": 1,
  "operation": "RunHealthChecksFromPC",
  "operationDescription": "Run System-Defined Check(s)",
  "ownedBy": {
    "$objectType": "prism.v4.config.OwnerReference",
    "$reserved": {
      "$fv": "v4.r3"
    },
    "extId": "00000000-0000-0000-0000-000000000000",
    "name": "admin"
  },
  "progressPercentage": 100,
  "startedTime": "2026-04-29T10:29:02.1395Z",
  "status": "SUCCEEDED",
  "subTasks": [
    {
      "$objectType": "prism.v4.config.TaskReferenceInternal",
      "$reserved": {
        "$fv": "v4.r3"
      },
      "extId": "ZXJnb24=:b8172447-6d78-4490-4cb8-470bf7a2ed2d",
      "href": "https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:b8172447-6d78-4490-4cb8-470bf7a2ed2d",
      "rel": "subtask"
    }
  ]
}
2026/04/29 16:01:12 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 16:01:12 [DEBUG] config wait_timeout 0
2026-04-29 10:31:12.056Z INFO - OPTIONS https://10.44.76.91:9440/api/clustermgmt/unversioned/info
2026-04-29 10:31:13.396Z INFO - HTTP/1.1 200 OK
2026-04-29 10:31:13.397Z INFO - Negotiated Version with server : v4.2
2026-04-29 10:31:13.397Z INFO - GET https://10.44.76.91:9440/api/clustermgmt/v4.2/config/clusters?%24filter=config%2FclusterFunction%2Fany%28t%3At+eq+Clustermgmt.Config.ClusterFunctionRef%27AOS%27%29
2026-04-29 10:31:13.713Z INFO - HTTP/1.1 200 OK
2026/04/29 16:01:14 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 16:01:14 [DEBUG] config wait_timeout 0
2026-04-29 10:31:14.108Z INFO - OPTIONS https://10.44.76.91:9440/api/clustermgmt/unversioned/info
2026-04-29 10:31:15.493Z INFO - HTTP/1.1 200 OK
2026-04-29 10:31:15.494Z INFO - Negotiated Version with server : v4.2
2026-04-29 10:31:15.494Z INFO - GET https://10.44.76.91:9440/api/clustermgmt/v4.2/config/clusters?%24filter=config%2FclusterFunction%2Fany%28t%3At+eq+Clustermgmt.Config.ClusterFunctionRef%27AOS%27%29
2026-04-29 10:31:15.782Z INFO - HTTP/1.1 200 OK
2026/04/29 16:01:16 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 16:01:16 [DEBUG] config wait_timeout 0
2026-04-29 10:31:16.083Z INFO - OPTIONS https://10.44.76.91:9440/api/clustermgmt/unversioned/info
2026-04-29 10:31:17.353Z INFO - HTTP/1.1 200 OK
2026-04-29 10:31:17.354Z INFO - Negotiated Version with server : v4.2
2026-04-29 10:31:17.354Z INFO - GET https://10.44.76.91:9440/api/clustermgmt/v4.2/config/clusters?%24filter=config%2FclusterFunction%2Fany%28t%3At+eq+Clustermgmt.Config.ClusterFunctionRef%27AOS%27%29
2026-04-29 10:31:17.638Z INFO - HTTP/1.1 200 OK
2026/04/29 16:01:18 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 16:01:18 [DEBUG] config wait_timeout 0
2026/04/29 16:01:18 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 16:01:18 [DEBUG] config wait_timeout 0
--- PASS: TestAccV2NutanixRunSystemDefinedChecksResource_WithAdditionalRecipients (142.09s)
PASS
coverage: 62.1% of statements
ok  	github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/monitoringv2	274.977s	coverage: 62.1% of statements
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` are stored only in the agent transcript;
  no `sdk_info.json` is committed to this branch.
