### PR TITLE
code-gen(monitoring/syst): terraform v2 provider code

### DIFF
--- a/examples/monitoring_v2/syst/main.tf
+++ b/examples/monitoring_v2/syst/main.tf
@@ -1,0 +1,30 @@
+variable "nutanix_endpoint" {}
+variable "nutanix_username" {}
+variable "nutanix_password" {}
+variable "nutanix_port" {}
+variable "nutanix_insecure" {}
+
+provider "nutanix" {
+  endpoint = var.nutanix_endpoint
+  username = var.nutanix_username
+  password = var.nutanix_password
+  port     = var.nutanix_port
+  insecure = var.nutanix_insecure
+}
+
+# List clusters to find AOS cluster ext_id
+data "nutanix_clusters_v2" "clusters" {
+  filter = "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+}
+
+locals {
+  clusterExtID = data.nutanix_clusters_v2.clusters.cluster_entities[0].ext_id
+}
+
+# Run System-Defined Checks on a cluster
+resource "nutanix_run_system_defined_checks_v2" "example" {
+  cluster_ext_id                              = local.clusterExtID
+  should_run_all_checks                       = true
+  should_send_report_to_configured_recipients = true
+  should_anonymize                            = false
+}

--- a/examples/monitoring_v2/syst/provider.tf
+++ b/examples/monitoring_v2/syst/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = ">= 2.0.0"
+    }
+  }
+}

--- a/examples/monitoring_v2/syst/terraform.tfvars
+++ b/examples/monitoring_v2/syst/terraform.tfvars
@@ -1,0 +1,5 @@
+nutanix_endpoint = "10.0.0.1"
+nutanix_username = "admin"
+nutanix_password = "REPLACE_ME"
+nutanix_port     = 9440
+nutanix_insecure = true

--- a/go.mod
+++ b/go.mod
@@ -107,6 +107,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/nakabonne/nestif v0.3.0 // indirect
 	github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d // indirect
+	github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -467,6 +467,8 @@ github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2 h1:ms+a
 github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2/go.mod h1:X3TsJoGBbkQzz6OP8Be7XvGhH4CwKkF9t35OmJpPY0w=
 github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2 h1:dE0zUP3ExJBnMUaGDAIZGN7/UZ0a85IWzHygMGcUDMc=
 github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2/go.mod h1:vo3VMB097Zd9cw4hLDbnpyBVcBZkpFmcQ2nNgpOpo7U=
+github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2 h1:dXFgnBHMd6MipSXkQE5cRysjKX96MeYeIFIkZDvye60=
+github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2/go.mod h1:msvlZou4z7vn5pHFhJ65OtAbh99z1ISsqCzfehdcWfw=
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1 h1:VWxK8mY6kOag/ocDBttDViktEi8bcjbAvm3i9laDyCA=
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1/go.mod h1:4fUdP3zeL4UFS/UVaii5EdS2v+KlM4gI07KcnS+wDuY=
 github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4 v4.0.3 h1:TE/G5GHrnvBGPI8MC0fSMSAaeD6HcdtezIgEmn8V/Yo=

--- a/nutanix/config.go
+++ b/nutanix/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/iam"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/lcm"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/microseg"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/monitoring"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/networking"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/objectstores"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/prism"
@@ -140,6 +141,10 @@ func (c *Config) Client() (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	monitoringClient, err := monitoring.NewMonitoringClient(configCreds)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Client{
 		WaitTimeout:         c.WaitTimeout,
@@ -161,6 +166,7 @@ func (c *Config) Client() (*Client, error) {
 		CalmAPI:             calmClient,
 		ObjectStoreAPI:      ObjectStoreClient,
 		SecurityAPI:         SecurityClient,
+		MonitoringAPI:       monitoringClient,
 	}, nil
 }
 
@@ -185,4 +191,5 @@ type Client struct {
 	CalmAPI             *selfservice.Client
 	ObjectStoreAPI      *objectstores.Client
 	SecurityAPI         *security.Client
+	MonitoringAPI       *monitoring.Client
 }

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/iamv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/lcmv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/microsegv2"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/monitoringv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/ndb"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/networking"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/networkingv2"
@@ -501,6 +502,7 @@ func Provider() *schema.Provider {
 			"nutanix_object_store_certificate_v2":             objectstoresv2.ResourceNutanixObjectStoreCertificateV2(),
 			"nutanix_key_management_server_v2":                securityv2.ResourceNutanixKeyManagementServerV2(),
 			"nutanix_entity_group_v2":                         microsegv2.ResourceNutanixEntityGroupV2(),
+			"nutanix_run_system_defined_checks_v2":            monitoringv2.ResourceNutanixRunSystemDefinedChecksV2(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}

--- a/nutanix/sdks/v4/monitoring/monitoring.go
+++ b/nutanix/sdks/v4/monitoring/monitoring.go
@@ -1,0 +1,31 @@
+package monitoring
+
+import (
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/api"
+	monitoring "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
+)
+
+type Client struct {
+	SystemDefinedChecksAPI *api.SystemDefinedChecksServiceApi
+}
+
+func NewMonitoringClient(credentials client.Credentials) (*Client, error) {
+	var baseClient *monitoring.ApiClient
+
+	pcClient := monitoring.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
+		baseClient = pcClient
+	}
+
+	return &Client{
+		SystemDefinedChecksAPI: api.NewSystemDefinedChecksServiceApi(baseClient),
+	}, nil
+}

--- a/nutanix/services/monitoringv2/main_test.go
+++ b/nutanix/services/monitoringv2/main_test.go
@@ -1,0 +1,41 @@
+package monitoringv2_test
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"testing"
+)
+
+type TestConfig struct {
+	Monitoring struct {
+		ClusterExtID string `json:"cluster_ext_id"`
+	} `json:"monitoring"`
+}
+
+var testVars TestConfig
+
+var (
+	path, _  = os.Getwd()
+	filepath = path + "/../../../test_config_v2.json"
+)
+
+func loadVars(filepath string, varStuct interface{}) {
+	configData, err := os.ReadFile(filepath)
+	if err != nil {
+		log.Printf("Got this error while reading config.json: %s", err.Error())
+		os.Exit(1)
+	}
+
+	err = json.Unmarshal(configData, varStuct)
+	if err != nil {
+		log.Printf("Got this error while unmarshalling config.json: %s", err.Error())
+		os.Exit(1)
+	}
+}
+
+func TestMain(m *testing.M) {
+	log.Println("Do some crazy stuff before tests!")
+	loadVars("../../../test_config_v2.json", &testVars)
+	os.Exit(m.Run())
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_run_system_defined_checks_v2.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_run_system_defined_checks_v2.go
@@ -1,0 +1,204 @@
+package monitoringv2
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	commonConfig "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/common/v1/config"
+	monitoringRequest "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/request/systemdefinedchecks"
+	monitoringServiceability "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	monitoringTaskRef "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/prism/v4/config"
+	prismConfig "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/prism/v4/config"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/common"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func ResourceNutanixRunSystemDefinedChecksV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNutanixRunSystemDefinedChecksV2Create,
+		ReadContext:   resourceNutanixRunSystemDefinedChecksV2Read,
+		UpdateContext: resourceNutanixRunSystemDefinedChecksV2Update,
+		DeleteContext: resourceNutanixRunSystemDefinedChecksV2Delete,
+		Schema: map[string]*schema.Schema{
+			"cluster_ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Unique identifier for the cluster for which run System-Defined Checks is requested.",
+			},
+			"additional_recipients": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "A list of additional email addresses for sending the run summary. Either this should be set or should_send_report_to_configured_recipients should be true. If both are set then email would be sent to all the recipients.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"node_ips": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "List of node IP addresses where the Check will run. This field will be ignored if the check scope is a cluster.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"prefix_length": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The prefix length of the network to which this host IPv4 address belongs.",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The IPv4 address of the host.",
+						},
+					},
+				},
+			},
+			"sda_ext_ids": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "List of Check IDs to be executed. This field cannot be set simultaneously with should_run_all_checks; only one of them should be specified.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"should_anonymize": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Indicates whether to mask sensitive data in the check run summary.",
+			},
+			"should_run_all_checks": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Indicates whether all System-Defined Checks applicable to the specified cluster should be executed. This field is mutually exclusive with the sda_ext_ids parameter, meaning that only one of these should be set at a time. Please use this field with caution, as it is resource-intensive.",
+			},
+			"should_send_report_to_configured_recipients": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Determines if the run summary should be sent to the configured email address associated with the cluster. Either this should be true or additional_recipients should be provided. If both are set then email would be sent to all the recipients.",
+			},
+			"task_ext_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A globally unique identifier for the task created by running system-defined checks.",
+			},
+		},
+	}
+}
+
+func resourceNutanixRunSystemDefinedChecksV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	clusterExtID := d.Get("cluster_ext_id").(string)
+
+	body := monitoringServiceability.NewRunSystemDefinedChecksSpec()
+
+	if v, ok := d.GetOk("additional_recipients"); ok {
+		body.AdditionalRecipients = common.ExpandListOfString(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("node_ips"); ok {
+		body.NodeIps = expandNodeIps(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("sda_ext_ids"); ok {
+		body.SdaExtIds = common.ExpandListOfString(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("should_anonymize"); ok {
+		body.ShouldAnonymize = utils.BoolPtr(v.(bool))
+	}
+
+	if v, ok := d.GetOk("should_run_all_checks"); ok {
+		body.ShouldRunAllChecks = utils.BoolPtr(v.(bool))
+	}
+
+	if v, ok := d.GetOk("should_send_report_to_configured_recipients"); ok {
+		body.ShouldSendReportToConfiguredRecipients = utils.BoolPtr(v.(bool))
+	}
+
+	request := &monitoringRequest.RunSystemDefinedChecksRequest{
+		ClusterExtId: utils.StringPtr(clusterExtID),
+		Body:         body,
+	}
+
+	resp, err := conn.SystemDefinedChecksAPI.RunSystemDefinedChecks(ctx, request)
+	if err != nil {
+		return diag.Errorf("error while running System-Defined Checks: %v", err)
+	}
+
+	if resp.Data == nil {
+		return diag.Errorf("error: empty response data from RunSystemDefinedChecks API")
+	}
+
+	TaskRef := resp.Data.GetValue().(monitoringTaskRef.TaskReference)
+	taskUUID := TaskRef.ExtId
+
+	aJSON, _ := json.MarshalIndent(TaskRef, "", "  ")
+	log.Printf("[DEBUG] RunSystemDefinedChecks TaskReference: %s", string(aJSON))
+
+	taskconn := meta.(*conns.Client).PrismAPI
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"QUEUED", "RUNNING", "PENDING"},
+		Target:  []string{"SUCCEEDED"},
+		Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, taskconn, utils.StringValue(taskUUID)),
+		Timeout: d.Timeout(schema.TimeoutCreate),
+	}
+
+	if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
+		return diag.Errorf("error waiting for System-Defined Checks task (%s) to complete: %s", utils.StringValue(taskUUID), errWaitTask)
+	}
+
+	taskResp, err := taskconn.TaskRefAPI.GetTaskById(taskUUID, nil)
+	if err != nil {
+		return diag.Errorf("error while fetching System-Defined Checks task: %v", err)
+	}
+	taskDetails := taskResp.Data.GetValue().(prismConfig.Task)
+	aJSON, _ = json.MarshalIndent(taskDetails, "", "  ")
+	log.Printf("[DEBUG] Run System-Defined Checks Task Details: %s", string(aJSON))
+
+	d.SetId(utils.StringValue(taskDetails.ExtId))
+	if err := d.Set("task_ext_id", utils.StringValue(taskDetails.ExtId)); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourceNutanixRunSystemDefinedChecksV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceNutanixRunSystemDefinedChecksV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceNutanixRunSystemDefinedChecksV2Create(ctx, d, meta)
+}
+
+func resourceNutanixRunSystemDefinedChecksV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func expandNodeIps(input []interface{}) []commonConfig.IPv4Address {
+	if len(input) == 0 {
+		return nil
+	}
+	nodeIps := make([]commonConfig.IPv4Address, 0, len(input))
+	for _, v := range input {
+		if v == nil {
+			continue
+		}
+		item := v.(map[string]interface{})
+		ipAddr := commonConfig.IPv4Address{}
+		if val, ok := item["prefix_length"]; ok && val.(int) != 0 {
+			ipAddr.PrefixLength = utils.IntPtr(val.(int))
+		}
+		if val, ok := item["value"]; ok && val.(string) != "" {
+			ipAddr.Value = utils.StringPtr(val.(string))
+		}
+		nodeIps = append(nodeIps, ipAddr)
+	}
+	return nodeIps
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_run_system_defined_checks_v2_test.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_run_system_defined_checks_v2_test.go
@@ -1,0 +1,84 @@
+package monitoringv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const resourceNameRunSystemDefinedChecks = "nutanix_run_system_defined_checks_v2.test"
+
+func TestAccV2NutanixRunSystemDefinedChecksResource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testRunSystemDefinedChecksConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameRunSystemDefinedChecks, "cluster_ext_id"),
+					resource.TestCheckResourceAttrSet(resourceNameRunSystemDefinedChecks, "task_ext_id"),
+					resource.TestCheckResourceAttr(resourceNameRunSystemDefinedChecks, "should_run_all_checks", "true"),
+					resource.TestCheckResourceAttr(resourceNameRunSystemDefinedChecks, "additional_recipients.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameRunSystemDefinedChecks, "additional_recipients.0", "test@nutanix.com"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixRunSystemDefinedChecksResource_WithAdditionalRecipients(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testRunSystemDefinedChecksConfigWithRecipients(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameRunSystemDefinedChecks, "cluster_ext_id"),
+					resource.TestCheckResourceAttrSet(resourceNameRunSystemDefinedChecks, "task_ext_id"),
+					resource.TestCheckResourceAttr(resourceNameRunSystemDefinedChecks, "should_run_all_checks", "true"),
+					resource.TestCheckResourceAttr(resourceNameRunSystemDefinedChecks, "additional_recipients.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameRunSystemDefinedChecks, "additional_recipients.0", "test@example.com"),
+				),
+			},
+		},
+	})
+}
+
+func testRunSystemDefinedChecksConfigBasic() string {
+	return `
+data "nutanix_clusters_v2" "clusters" {
+  filter = "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+}
+
+locals {
+  clusterExtID = data.nutanix_clusters_v2.clusters.cluster_entities[0].ext_id
+}
+
+resource "nutanix_run_system_defined_checks_v2" "test" {
+  cluster_ext_id                                = local.clusterExtID
+  should_run_all_checks                         = true
+  additional_recipients                         = ["test@nutanix.com"]
+}
+`
+}
+
+func testRunSystemDefinedChecksConfigWithRecipients() string {
+	return `
+data "nutanix_clusters_v2" "clusters" {
+  filter = "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+}
+
+locals {
+  clusterExtID = data.nutanix_clusters_v2.clusters.cluster_entities[0].ext_id
+}
+
+resource "nutanix_run_system_defined_checks_v2" "test" {
+  cluster_ext_id                                = local.clusterExtID
+  should_run_all_checks                         = true
+  additional_recipients                         = ["test@example.com"]
+}
+`
+}

--- a/website/docs/r/run_system_defined_checks_v2.html.markdown
+++ b/website/docs/r/run_system_defined_checks_v2.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_run_system_defined_checks_v2"
+sidebar_current: "docs-nutanix_run_system_defined_checks_v2"
+description: |-
+  Run System-Defined Checks on a cluster.
+---
+
+# nutanix_run_system_defined_checks_v2
+
+Run System-Defined Checks on a cluster.
+
+## Example
+
+```hcl
+# List clusters to find AOS cluster ext_id
+data "nutanix_clusters_v2" "clusters" {
+  filter = "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+}
+
+locals {
+  clusterExtID = data.nutanix_clusters_v2.clusters.cluster_entities[0].ext_id
+}
+
+# Run System-Defined Checks on a cluster
+resource "nutanix_run_system_defined_checks_v2" "example" {
+  cluster_ext_id                              = local.clusterExtID
+  should_run_all_checks                       = true
+  should_send_report_to_configured_recipients = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_ext_id`: (Required) Unique identifier for the cluster for which run System-Defined Checks is requested.
+* `additional_recipients`: (Optional) A list of additional email addresses for sending the run summary. Either this should be set or `should_send_report_to_configured_recipients` should be true. If both are set then email would be sent to all the recipients.
+* `node_ips`: (Optional) List of node IP addresses where the Check will run. This field will be ignored if the check scope is a cluster.
+* `sda_ext_ids`: (Optional) List of Check IDs to be executed. This field cannot be set simultaneously with `should_run_all_checks`; only one of them should be specified.
+* `should_anonymize`: (Optional) Indicates whether to mask sensitive data in the check run summary.
+* `should_run_all_checks`: (Optional) Indicates whether all System-Defined Checks applicable to the specified cluster should be executed. This field is mutually exclusive with the `sda_ext_ids` parameter, meaning that only one of these should be set at a time. Please use this field with caution, as it is resource-intensive.
+* `should_send_report_to_configured_recipients`: (Optional) Determines if the run summary should be sent to the configured email address associated with the cluster. Either this should be true or `additional_recipients` should be provided. If both are set then email would be sent to all the recipients.
+
+### node_ips
+
+* `prefix_length`: (Optional) The prefix length of the network to which this host IPv4 address belongs.
+* `value`: (Optional) The IPv4 address of the host.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `task_ext_id`: A globally unique identifier for the task created by running system-defined checks.
+
+See detailed information in [Nutanix Monitoring Run System-Defined Checks v4](https://developers.nutanix.com/api-reference?namespace=monitoring&version=v4.2#tag/SystemDefinedChecksService/operation/RunSystemDefinedChecks)


### PR DESCRIPTION
## Summary

Auto-generated Terraform provider code for the **monitoring** namespace, entity
**syst**, based on the inline `sdk_info.json` (see prompt). One PR per code-gen run.

- SDK module: `github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4@v4.2.2`
- API methods covered: 1
  - `RunSystemDefinedChecks` (receiver: `*SystemDefinedChecksServiceApi`)
- Datasources generated: 0 (N/A for this entity)
- Resources generated: 1
  - `nutanix_run_system_defined_checks_v2`

## Files changed

- **nutanix/sdks/v4/monitoring/**
  - `monitoring.go` — SDK client wrapper for monitoring namespace
- **nutanix/services/monitoringv2/**
  - `resource_nutanix_run_system_defined_checks_v2.go` — Action resource
  - `resource_nutanix_run_system_defined_checks_v2_test.go` — Acceptance tests
  - `main_test.go` — Test setup
- **nutanix/config.go** — Added `MonitoringAPI` client field
- **nutanix/provider/provider.go** — Registered `nutanix_run_system_defined_checks_v2`
- **go.mod / go.sum** — Added `monitoring-go-client/v4@v4.2.2`
- **examples/monitoring_v2/syst/**
  - `main.tf`, `provider.tf`, `terraform.tfvars`
- **website/docs/r/**
  - `run_system_defined_checks_v2.html.markdown`

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `TF_ACC=1 go test ./nutanix/services/monitoringv2 -v -run=TestAccV2NutanixRunSystemDefinedChecksResource_Basic -timeout 500m` |
| Total testcases     | 1                                              |
| Passed              | 1                                              |
| Failed              | 0                                              |
| Skipped             | 0                                              |
| Wall-clock duration | 0:02:26                                        |
| Cluster (PC)        | `10.44.76.91`                                 |

### Analysis

All tests passed. The `TestAccV2NutanixRunSystemDefinedChecksResource_Basic` test:
1. Listed AOS clusters via `nutanix_clusters_v2` data source
2. Called `RunSystemDefinedChecks` API on the discovered cluster
3. Polled the Prism task until SUCCEEDED (took ~130s)
4. Verified all resource attributes (`cluster_ext_id`, `task_ext_id`, `should_run_all_checks`, `additional_recipients`)

Initial run failed because the cluster had no email configuration and the test used `should_send_report_to_configured_recipients = false` without providing `additional_recipients`. Fixed by adding `additional_recipients = ["test@nutanix.com"]`.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
2026/04/29 20:38:43 Do some crazy stuff before tests!
=== RUN   TestAccV2NutanixRunSystemDefinedChecksResource_Basic
2026/04/29 20:38:43 [DEBUG] config wait_timeout 0
2026-04-29 15:08:43.937Z INFO - OPTIONS https://10.44.76.91:9440/api/clustermgmt/unversioned/info
2026-04-29 15:08:45.405Z INFO - HTTP/1.1 200 OK
2026-04-29 15:08:45.405Z INFO - Negotiated Version with server : v4.2
2026-04-29 15:08:45.405Z INFO - GET https://10.44.76.91:9440/api/clustermgmt/v4.2/config/clusters?%24filter=config%2FclusterFunction%2Fany%28t%3At+eq+Clustermgmt.Config.ClusterFunctionRef%27AOS%27%29
2026-04-29 15:08:45.765Z INFO - HTTP/1.1 200 OK
2026/04/29 20:38:46 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 20:38:46 [DEBUG] config wait_timeout 0
2026-04-29 15:08:46.078Z INFO - OPTIONS https://10.44.76.91:9440/api/clustermgmt/unversioned/info
2026-04-29 15:08:47.620Z INFO - HTTP/1.1 200 OK
2026-04-29 15:08:47.620Z INFO - Negotiated Version with server : v4.2
2026-04-29 15:08:47.620Z INFO - GET https://10.44.76.91:9440/api/clustermgmt/v4.2/config/clusters?%24filter=config%2FclusterFunction%2Fany%28t%3At+eq+Clustermgmt.Config.ClusterFunctionRef%27AOS%27%29
2026-04-29 15:08:47.962Z INFO - HTTP/1.1 200 OK
2026/04/29 20:38:48 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 20:38:48 [DEBUG] config wait_timeout 0
2026-04-29 15:08:48.469Z INFO - OPTIONS https://10.44.76.91:9440/api/monitoring/unversioned/info
2026-04-29 15:08:49.994Z INFO - HTTP/1.1 200 OK
2026-04-29 15:08:49.994Z INFO - Negotiated Version with server : v4.2
2026-04-29 15:08:49.994Z INFO - POST https://10.44.76.91:9440/api/monitoring/v4.2/serviceability/clusters/0006501c-2183-2735-0000-000000028f57/$actions/run-system-defined-checks
2026-04-29 15:08:50.390Z INFO - HTTP/1.1 202 ACCEPTED
2026/04/29 20:38:50 [DEBUG] RunSystemDefinedChecks TaskReference: {
  "$objectType": "prism.v4.config.TaskReference",
  "$reserved": {
    "$fv": "v4.r2"
  },
  "extId": "ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94"
}
2026/04/29 20:38:50 [DEBUG] Waiting for state to become: [SUCCEEDED]
2026-04-29 15:08:50.390Z INFO - OPTIONS https://10.44.76.91:9440/api/prism/unversioned/info
2026-04-29 15:08:51.967Z INFO - HTTP/1.1 200 OK
2026-04-29 15:08:51.968Z INFO - Negotiated Version with server : v4.3
2026-04-29 15:08:51.968Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:08:52.334Z INFO - HTTP/1.1 200 OK
2026-04-29 15:08:52.536Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:08:52.874Z INFO - HTTP/1.1 200 OK
2026-04-29 15:08:53.276Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:08:53.697Z INFO - HTTP/1.1 200 OK
2026-04-29 15:08:54.500Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:08:54.854Z INFO - HTTP/1.1 200 OK
2026-04-29 15:08:56.456Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:08:56.787Z INFO - HTTP/1.1 200 OK
2026-04-29 15:08:59.990Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:09:00.349Z INFO - HTTP/1.1 200 OK
2026-04-29 15:09:06.751Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:09:07.112Z INFO - HTTP/1.1 200 OK
2026-04-29 15:09:17.114Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:09:17.449Z INFO - HTTP/1.1 200 OK
2026-04-29 15:09:27.451Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:09:27.791Z INFO - HTTP/1.1 200 OK
2026-04-29 15:09:37.793Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:09:38.105Z INFO - HTTP/1.1 200 OK
2026-04-29 15:09:48.107Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:09:48.439Z INFO - HTTP/1.1 200 OK
2026-04-29 15:09:58.442Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:09:58.778Z INFO - HTTP/1.1 200 OK
2026-04-29 15:10:08.782Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:10:09.108Z INFO - HTTP/1.1 200 OK
2026-04-29 15:10:19.110Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:10:19.437Z INFO - HTTP/1.1 200 OK
2026-04-29 15:10:29.440Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:10:29.771Z INFO - HTTP/1.1 200 OK
2026-04-29 15:10:39.774Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:10:40.107Z INFO - HTTP/1.1 200 OK
2026-04-29 15:10:50.110Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:10:50.439Z INFO - HTTP/1.1 200 OK
2026-04-29 15:11:00.442Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:11:00.739Z INFO - HTTP/1.1 200 OK
2026-04-29 15:11:00.741Z INFO - GET https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94
2026-04-29 15:11:01.083Z INFO - HTTP/1.1 200 OK
2026/04/29 20:41:01 [DEBUG] Run System-Defined Checks Task Details: {
  "$objectType": "prism.v4.config.Task",
  "$reserved": {
    "$fv": "v4.r3"
  },
  "$unknownFields": {
    "projectExtId": "00000000-0000-0000-0000-000000000000"
  },
  "clusterExtIds": [
    "0006501c-2183-2735-0000-000000028f57"
  ],
  "completedTime": "2026-04-29T15:10:58.545324Z",
  "completionDetails": [
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "status",
      "value": "ERROR"
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "total",
      "value": 334
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "pass",
      "value": 322
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "info",
      "value": 3
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "warn",
      "value": 3
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "fail",
      "value": 4
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "error",
      "value": 2
    },
    {
      "$objectType": "common.v1.config.KVPair",
      "$reserved": {
        "$fv": "v1.r0"
      },
      "name": "detailedSummary",
      "value": [
        {
          "$objectType": "common.v1.config.MapOfStringWrapper",
          "$reserved": {
            "$fv": "v1.r0"
          },
          "map": {
            "errorSdaExtIds": "106028,106041",
            "failSdaExtIds": "6214,15037,111039,110210",
            "infoSdaExtIds": "6219,600101,6230",
            "warnSdaExtIds": "106059,106064,14001"
          }
        }
      ]
    }
  ],
  "createdTime": "2026-04-29T15:08:50.200035Z",
  "entitiesAffected": [
    {
      "$objectType": "prism.v4.config.EntityReference",
      "$reserved": {
        "$fv": "v4.r3"
      },
      "extId": "0006501c-2183-2735-0000-000000028f57",
      "name": "auto_cluster_prod_361bd71f8d22",
      "rel": "clustermgmt:config:cluster"
    }
  ],
  "extId": "ZXJnb24=:d47681d6-7452-4304-588f-6c981b6f7f94",
  "isBackgroundTask": false,
  "isCancelable": false,
  "lastUpdatedTime": "2026-04-29T15:10:58.545323Z",
  "numberOfEntitiesAffected": 1,
  "numberOfSubtasks": 1,
  "operation": "RunHealthChecksFromPC",
  "operationDescription": "Run System-Defined Check(s)",
  "ownedBy": {
    "$objectType": "prism.v4.config.OwnerReference",
    "$reserved": {
      "$fv": "v4.r3"
    },
    "extId": "00000000-0000-0000-0000-000000000000",
    "name": "admin"
  },
  "progressPercentage": 100,
  "startedTime": "2026-04-29T15:08:50.220185Z",
  "status": "SUCCEEDED",
  "subTasks": [
    {
      "$objectType": "prism.v4.config.TaskReferenceInternal",
      "$reserved": {
        "$fv": "v4.r3"
      },
      "extId": "ZXJnb24=:0ac8d66b-a550-423b-616e-d39e75c3c81c",
      "href": "https://10.44.76.91:9440/api/prism/v4.3/config/tasks/ZXJnb24=:0ac8d66b-a550-423b-616e-d39e75c3c81c",
      "rel": "subtask"
    }
  ]
}
2026/04/29 20:41:01 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 20:41:01 [DEBUG] config wait_timeout 0
2026-04-29 15:11:01.481Z INFO - OPTIONS https://10.44.76.91:9440/api/clustermgmt/unversioned/info
2026-04-29 15:11:02.999Z INFO - HTTP/1.1 200 OK
2026-04-29 15:11:03.000Z INFO - Negotiated Version with server : v4.2
2026-04-29 15:11:03.000Z INFO - GET https://10.44.76.91:9440/api/clustermgmt/v4.2/config/clusters?%24filter=config%2FclusterFunction%2Fany%28t%3At+eq+Clustermgmt.Config.ClusterFunctionRef%27AOS%27%29
2026-04-29 15:11:03.306Z INFO - HTTP/1.1 200 OK
2026/04/29 20:41:03 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 20:41:03 [DEBUG] config wait_timeout 0
2026-04-29 15:11:03.709Z INFO - OPTIONS https://10.44.76.91:9440/api/clustermgmt/unversioned/info
2026-04-29 15:11:05.215Z INFO - HTTP/1.1 200 OK
2026-04-29 15:11:05.215Z INFO - Negotiated Version with server : v4.2
2026-04-29 15:11:05.215Z INFO - GET https://10.44.76.91:9440/api/clustermgmt/v4.2/config/clusters?%24filter=config%2FclusterFunction%2Fany%28t%3At+eq+Clustermgmt.Config.ClusterFunctionRef%27AOS%27%29
2026-04-29 15:11:05.582Z INFO - HTTP/1.1 200 OK
2026/04/29 20:41:05 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 20:41:05 [DEBUG] config wait_timeout 0
2026-04-29 15:11:05.876Z INFO - OPTIONS https://10.44.76.91:9440/api/clustermgmt/unversioned/info
2026-04-29 15:11:07.428Z INFO - HTTP/1.1 200 OK
2026-04-29 15:11:07.428Z INFO - Negotiated Version with server : v4.2
2026-04-29 15:11:07.428Z INFO - GET https://10.44.76.91:9440/api/clustermgmt/v4.2/config/clusters?%24filter=config%2FclusterFunction%2Fany%28t%3At+eq+Clustermgmt.Config.ClusterFunctionRef%27AOS%27%29
2026-04-29 15:11:07.787Z INFO - HTTP/1.1 200 OK
2026/04/29 20:41:08 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 20:41:08 [DEBUG] config wait_timeout 0
2026/04/29 20:41:08 [WARN] Previously configured provider being re-configured. This can cause issues in concurrent testing if the configurations are not equal.
2026/04/29 20:41:08 [DEBUG] config wait_timeout 0
--- PASS: TestAccV2NutanixRunSystemDefinedChecksResource_Basic (145.30s)
PASS
coverage: 57.9% of statements
ok  	github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/monitoringv2	146.400s	coverage: 57.9% of statements
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` are stored only in the agent transcript;
  no `sdk_info.json` is committed to this branch.
