### PR TITLE
Add Terraform provider support for monitoring/v4 system-defined alerts

### DIFF
--- a/examples/monitoring_v2/system/main.tf
+++ b/examples/monitoring_v2/system/main.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = "2.0.0"
+    }
+  }
+}
+
+#defining nutanix configuration
+provider "nutanix" {
+  username = var.nutanix_username
+  password = var.nutanix_password
+  endpoint = var.nutanix_endpoint
+  port     = 9440
+  insecure = true
+}
+
+# Run System-Defined Checks on a cluster
+resource "nutanix_run_system_defined_checks_v2" "example" {
+  cluster_ext_id                              = "00000000-0000-0000-0000-000000000000"
+  should_run_all_checks                       = true
+  should_send_report_to_configured_recipients = false
+}
+
+# Manage cluster-specific configuration for a System-Defined Alert Policy
+resource "nutanix_sda_cluster_config_v2" "example" {
+  system_defined_policy_ext_id = "00000000-0000-0000-0000-000000000000"
+  ext_id                       = "00000000-0000-0000-0000-000000000000"
+}
+
+# Get a list of all System-Defined Alert Policies
+data "nutanix_sda_policies_v2" "policies-list" {}
+
+# Get details of a specific System-Defined Alert Policy
+data "nutanix_sda_policy_v2" "get-policy" {
+  ext_id = "00000000-0000-0000-0000-000000000000"
+}
+
+# Get cluster configs for a System-Defined Alert Policy
+data "nutanix_sda_cluster_configs_v2" "cluster-configs-list" {
+  system_defined_policy_ext_id = "00000000-0000-0000-0000-000000000000"
+}
+
+# Get a specific cluster config for a System-Defined Alert Policy
+data "nutanix_sda_cluster_config_v2" "get-cluster-config" {
+  system_defined_policy_ext_id = "00000000-0000-0000-0000-000000000000"
+  ext_id                       = "00000000-0000-0000-0000-000000000000"
+}

--- a/examples/monitoring_v2/system/terraform.tfvars
+++ b/examples/monitoring_v2/system/terraform.tfvars
@@ -1,0 +1,4 @@
+#define values to the variables to be used in terraform file
+nutanix_username = "admin"
+nutanix_password = "password"
+nutanix_endpoint = "10.xx.xx.xx"

--- a/examples/monitoring_v2/system/variables.tf
+++ b/examples/monitoring_v2/system/variables.tf
@@ -1,0 +1,10 @@
+#define the type of variables to be used in terraform file
+variable "nutanix_username" {
+  type = string
+}
+variable "nutanix_password" {
+  type = string
+}
+variable "nutanix_endpoint" {
+  type = string
+}

--- a/go.mod
+++ b/go.mod
@@ -107,6 +107,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/nakabonne/nestif v0.3.0 // indirect
 	github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d // indirect
+	github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -467,6 +467,8 @@ github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2 h1:ms+a
 github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2/go.mod h1:X3TsJoGBbkQzz6OP8Be7XvGhH4CwKkF9t35OmJpPY0w=
 github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2 h1:dE0zUP3ExJBnMUaGDAIZGN7/UZ0a85IWzHygMGcUDMc=
 github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2/go.mod h1:vo3VMB097Zd9cw4hLDbnpyBVcBZkpFmcQ2nNgpOpo7U=
+github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2 h1:dXFgnBHMd6MipSXkQE5cRysjKX96MeYeIFIkZDvye60=
+github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2/go.mod h1:msvlZou4z7vn5pHFhJ65OtAbh99z1ISsqCzfehdcWfw=
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1 h1:VWxK8mY6kOag/ocDBttDViktEi8bcjbAvm3i9laDyCA=
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1/go.mod h1:4fUdP3zeL4UFS/UVaii5EdS2v+KlM4gI07KcnS+wDuY=
 github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4 v4.0.3 h1:TE/G5GHrnvBGPI8MC0fSMSAaeD6HcdtezIgEmn8V/Yo=

--- a/nutanix/config.go
+++ b/nutanix/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/iam"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/lcm"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/microseg"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/monitoring"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/networking"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/objectstores"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/prism"
@@ -140,6 +141,10 @@ func (c *Config) Client() (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	MonitoringClient, err := monitoring.NewMonitoringClient(configCreds)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Client{
 		WaitTimeout:         c.WaitTimeout,
@@ -161,6 +166,7 @@ func (c *Config) Client() (*Client, error) {
 		CalmAPI:             calmClient,
 		ObjectStoreAPI:      ObjectStoreClient,
 		SecurityAPI:         SecurityClient,
+		MonitoringAPI:       MonitoringClient,
 	}, nil
 }
 
@@ -185,4 +191,5 @@ type Client struct {
 	CalmAPI             *selfservice.Client
 	ObjectStoreAPI      *objectstores.Client
 	SecurityAPI         *security.Client
+	MonitoringAPI       *monitoring.Client
 }

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/iamv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/lcmv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/microsegv2"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/monitoringv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/ndb"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/networking"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/networkingv2"
@@ -370,6 +371,10 @@ func Provider() *schema.Provider {
 			"nutanix_stigs_v2":                                securityv2.DatasourceNutanixStigsControlsV2(),
 			"nutanix_entity_group_v2":                         microsegv2.DatasourceNutanixEntityGroupV2(),
 			"nutanix_entity_groups_v2":                        microsegv2.DatasourceNutanixEntityGroupsV2(),
+			"nutanix_sda_policy_v2":                           monitoringv2.DatasourceNutanixSdaPolicyV2(),
+			"nutanix_sda_policies_v2":                         monitoringv2.DatasourceNutanixSdaPoliciesV2(),
+			"nutanix_sda_cluster_config_v2":                   monitoringv2.DatasourceNutanixSdaClusterConfigV2(),
+			"nutanix_sda_cluster_configs_v2":                  monitoringv2.DatasourceNutanixSdaClusterConfigsV2(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"nutanix_virtual_machine":                         vmm.ResourceNutanixVirtualMachine(),
@@ -501,6 +506,8 @@ func Provider() *schema.Provider {
 			"nutanix_object_store_certificate_v2":             objectstoresv2.ResourceNutanixObjectStoreCertificateV2(),
 			"nutanix_key_management_server_v2":                securityv2.ResourceNutanixKeyManagementServerV2(),
 			"nutanix_entity_group_v2":                         microsegv2.ResourceNutanixEntityGroupV2(),
+			"nutanix_run_system_defined_checks_v2":            monitoringv2.ResourceNutanixRunSystemDefinedChecksV2(),
+			"nutanix_sda_cluster_config_v2":                   monitoringv2.ResourceNutanixSdaClusterConfigV2(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}

--- a/nutanix/sdks/v4/monitoring/monitoring.go
+++ b/nutanix/sdks/v4/monitoring/monitoring.go
@@ -1,0 +1,35 @@
+package monitoring
+
+import (
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/api"
+	monitoring "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
+)
+
+type Client struct {
+	SystemDefinedChecksAPI  *api.SystemDefinedChecksApi
+	SystemDefinedPoliciesAPI *api.SystemDefinedPoliciesApi
+	APIClientInstance        *monitoring.ApiClient
+}
+
+func NewMonitoringClient(credentials client.Credentials) (*Client, error) {
+	var baseClient *monitoring.ApiClient
+
+	pcClient := monitoring.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
+		baseClient = pcClient
+	}
+
+	return &Client{
+		SystemDefinedChecksAPI:  api.NewSystemDefinedChecksApi(baseClient),
+		SystemDefinedPoliciesAPI: api.NewSystemDefinedPoliciesApi(baseClient),
+		APIClientInstance:        baseClient,
+	}, nil
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_config_v2.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_config_v2.go
@@ -1,0 +1,106 @@
+package monitoringv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixSdaClusterConfigV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DatasourceNutanixSdaClusterConfigV2Read,
+		Schema: map[string]*schema.Schema{
+			"system_defined_policy_ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Unique ID of the System-Defined Alert Policy.",
+			},
+			"ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Cluster UUID.",
+			},
+			"alert_config":            schemaForAlertConfig(true),
+			"configurable_parameters": schemaForThresholdParameters(true),
+			"is_enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates whether the SDA policy is enabled or not on the cluster.",
+			},
+			"last_modified_by_user": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Name of the user who made the latest update to this policy.",
+			},
+			"last_modified_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Time in ISO 8601 format when the SDA policy was last modified.",
+			},
+			"links": linksSchema(),
+			"schedule_interval_seconds": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Interval in seconds for periodically executing the SDA policy.",
+			},
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func DatasourceNutanixSdaClusterConfigV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	sdaPolicyExtID := d.Get("system_defined_policy_ext_id").(string)
+	extID := d.Get("ext_id").(string)
+
+	resp, err := conn.SystemDefinedPoliciesAPI.GetClusterConfigById(utils.StringPtr(sdaPolicyExtID), utils.StringPtr(extID))
+	if err != nil {
+		return diag.Errorf("error while fetching cluster config for SDA policy: %v", err)
+	}
+
+	getResp, ok := resp.Data.GetValue().(serviceability.ClusterConfig)
+	if !ok {
+		return diag.Errorf("error: unexpected response type from GetClusterConfigById, expected ClusterConfig")
+	}
+
+	if err := d.Set("alert_config", flattenAlertConfig(getResp.AlertConfig)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("configurable_parameters", flattenAlertPolicyConfigurableParameters(getResp.ConfigurableParameters)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("ext_id", getResp.ExtId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_enabled", getResp.IsEnabled); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("last_modified_by_user", getResp.LastModifiedByUser); err != nil {
+		return diag.FromErr(err)
+	}
+	if getResp.LastModifiedTime != nil {
+		if err := d.Set("last_modified_time", getResp.LastModifiedTime.String()); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err := d.Set("links", flattenLinks(getResp.Links)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("schedule_interval_seconds", getResp.ScheduleIntervalSeconds); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("tenant_id", getResp.TenantId); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(utils.StringValue(getResp.ExtId))
+	return nil
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_config_v2_test.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_config_v2_test.go
@@ -1,0 +1,42 @@
+package monitoringv2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const datasourceNameSdaClusterConfig = "data.nutanix_sda_cluster_config_v2.test"
+
+func TestAccV2NutanixSdaClusterConfigDatasource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testSdaClusterConfigDatasourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameSdaClusterConfig, "ext_id"),
+					resource.TestCheckResourceAttrSet(datasourceNameSdaClusterConfig, "system_defined_policy_ext_id"),
+				),
+			},
+		},
+	})
+}
+
+func testSdaClusterConfigDatasourceConfig() string {
+	return fmt.Sprintf(`
+data "nutanix_sda_policies_v2" "list" {}
+
+data "nutanix_sda_cluster_configs_v2" "list_configs" {
+  system_defined_policy_ext_id = data.nutanix_sda_policies_v2.list.sda_policies.0.ext_id
+}
+
+data "nutanix_sda_cluster_config_v2" "test" {
+  system_defined_policy_ext_id = data.nutanix_sda_policies_v2.list.sda_policies.0.ext_id
+  ext_id                       = data.nutanix_sda_cluster_configs_v2.list_configs.cluster_configs.0.ext_id
+}
+`)
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_configs_v2.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_configs_v2.go
@@ -1,0 +1,63 @@
+package monitoringv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixSdaClusterConfigsV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DatasourceNutanixSdaClusterConfigsV2Read,
+		Schema: map[string]*schema.Schema{
+			"system_defined_policy_ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Unique ID of the System-Defined Alert Policy.",
+			},
+			"cluster_configs": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of cluster-specific configurations for the SDA policy.",
+				Elem: &schema.Resource{
+					Schema: clusterConfigSchemaMap(),
+				},
+			},
+		},
+	}
+}
+
+func DatasourceNutanixSdaClusterConfigsV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	sdaPolicyExtID := d.Get("system_defined_policy_ext_id").(string)
+
+	resp, err := conn.SystemDefinedPoliciesAPI.ListClusterConfigsBySdaId(utils.StringPtr(sdaPolicyExtID), nil, nil, nil, nil, nil)
+	if err != nil {
+		return diag.Errorf("error while listing cluster configs for SDA policy: %v", err)
+	}
+
+	if resp.Data == nil {
+		if setErr := d.Set("cluster_configs", []map[string]interface{}{}); setErr != nil {
+			return diag.FromErr(setErr)
+		}
+		d.SetId(utils.GenUUID())
+		return nil
+	}
+
+	listResp, ok := resp.Data.GetValue().([]serviceability.ClusterConfig)
+	if !ok {
+		return diag.Errorf("error: unexpected response type from ListClusterConfigsBySdaId, expected []ClusterConfig")
+	}
+
+	if err := d.Set("cluster_configs", flattenClusterConfigs(listResp)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(utils.GenUUID())
+	return nil
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_configs_v2_test.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_sda_cluster_configs_v2_test.go
@@ -1,0 +1,37 @@
+package monitoringv2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const datasourceNameSdaClusterConfigs = "data.nutanix_sda_cluster_configs_v2.test"
+
+func TestAccV2NutanixSdaClusterConfigsDatasource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testSdaClusterConfigsDatasourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameSdaClusterConfigs, "cluster_configs.#"),
+					resource.TestCheckResourceAttrSet(datasourceNameSdaClusterConfigs, "system_defined_policy_ext_id"),
+				),
+			},
+		},
+	})
+}
+
+func testSdaClusterConfigsDatasourceConfig() string {
+	return fmt.Sprintf(`
+data "nutanix_sda_policies_v2" "list" {}
+
+data "nutanix_sda_cluster_configs_v2" "test" {
+  system_defined_policy_ext_id = data.nutanix_sda_policies_v2.list.sda_policies.0.ext_id
+}
+`)
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_sda_policies_v2.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_sda_policies_v2.go
@@ -1,0 +1,134 @@
+package monitoringv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixSdaPoliciesV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DatasourceNutanixSdaPoliciesV2Read,
+		Schema: map[string]*schema.Schema{
+			"sda_policies": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of System-Defined Alert Policies.",
+				Elem:        DatasourceNutanixSdaPolicyV2(),
+			},
+		},
+	}
+}
+
+func DatasourceNutanixSdaPoliciesV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	resp, err := conn.SystemDefinedPoliciesAPI.ListSdaPolicies(nil, nil, nil, nil, nil)
+	if err != nil {
+		return diag.Errorf("error while listing System-Defined Alert Policies: %v", err)
+	}
+
+	if resp.Data == nil {
+		if setErr := d.Set("sda_policies", []map[string]interface{}{}); setErr != nil {
+			return diag.FromErr(setErr)
+		}
+		d.SetId(utils.GenUUID())
+		return nil
+	}
+
+	listResp, ok := resp.Data.GetValue().([]serviceability.SystemDefinedPolicy)
+	if !ok {
+		return diag.Errorf("error: unexpected response type from ListSdaPolicies, expected []SystemDefinedPolicy")
+	}
+
+	if len(listResp) == 0 {
+		if setErr := d.Set("sda_policies", []map[string]interface{}{}); setErr != nil {
+			return diag.FromErr(setErr)
+		}
+		d.SetId(utils.GenUUID())
+		return nil
+	}
+
+	policies := make([]map[string]interface{}, len(listResp))
+	for i, p := range listResp {
+		policy := flattenSdaPolicyToMap(&p)
+		policies[i] = policy
+	}
+
+	if err := d.Set("sda_policies", policies); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(utils.GenUUID())
+	return nil
+}
+
+func flattenSdaPolicyToMap(p *serviceability.SystemDefinedPolicy) map[string]interface{} {
+	m := map[string]interface{}{}
+	if p.ExtId != nil {
+		m["ext_id"] = utils.StringValue(p.ExtId)
+	}
+	if p.Name != nil {
+		m["name"] = utils.StringValue(p.Name)
+	}
+	if p.Description != nil {
+		m["description"] = utils.StringValue(p.Description)
+	}
+	if p.Title != nil {
+		m["title"] = utils.StringValue(p.Title)
+	}
+	if p.PolicyId != nil {
+		m["policy_id"] = utils.StringValue(p.PolicyId)
+	}
+	if p.Publisher != nil {
+		m["publisher"] = utils.StringValue(p.Publisher)
+	}
+	if p.TenantId != nil {
+		m["tenant_id"] = utils.StringValue(p.TenantId)
+	}
+	if p.EntityType != nil {
+		m["entity_type"] = p.EntityType.GetName()
+	}
+	if p.Scope != nil {
+		m["scope"] = p.Scope.GetName()
+	}
+	if p.SubType != nil {
+		m["sub_type"] = p.SubType.GetName()
+	}
+	if p.Type != nil {
+		m["sda_type"] = p.Type.GetName()
+	}
+
+	classifications := make([]string, 0)
+	for _, c := range p.Classifications {
+		classifications = append(classifications, c)
+	}
+	m["classifications"] = classifications
+
+	kbArticles := make([]string, 0)
+	for _, k := range p.KbArticles {
+		kbArticles = append(kbArticles, k)
+	}
+	m["kb_articles"] = kbArticles
+
+	impactTypes := make([]string, 0)
+	for _, it := range p.ImpactTypes {
+		impactTypes = append(impactTypes, it.GetName())
+	}
+	m["impact_types"] = impactTypes
+
+	targetClusters := make([]string, 0)
+	for _, tc := range p.TargetClusters {
+		targetClusters = append(targetClusters, tc.GetName())
+	}
+	m["target_clusters"] = targetClusters
+
+	m["links"] = flattenLinks(p.Links)
+	m["cluster_configs"] = flattenClusterConfigs(p.ClusterConfigs)
+
+	return m
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_sda_policies_v2_test.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_sda_policies_v2_test.go
@@ -1,0 +1,31 @@
+package monitoringv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const datasourceNameSdaPolicies = "data.nutanix_sda_policies_v2.test"
+
+func TestAccV2NutanixSdaPoliciesDatasource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testSdaPoliciesDatasourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameSdaPolicies, "sda_policies.#"),
+				),
+			},
+		},
+	})
+}
+
+func testSdaPoliciesDatasourceConfig() string {
+	return `
+data "nutanix_sda_policies_v2" "test" {}
+`
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_sda_policy_v2.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_sda_policy_v2.go
@@ -1,0 +1,202 @@
+package monitoringv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixSdaPolicyV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DatasourceNutanixSdaPolicyV2Read,
+		Schema: map[string]*schema.Schema{
+			"ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Unique ID of the System-Defined Alert Policy.",
+			},
+			"classifications": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Various categories into which this alert type can be classified.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"cluster_configs": schemaForClusterConfig(),
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "System-defined alert policy description.",
+			},
+			"entity_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"impact_types": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Impact types to which this rule applies.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"kb_articles": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of knowledge base article links.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"links": linksSchema(),
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Name of the System-Defined Alert Policy.",
+			},
+			"policy_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Unique ID associated with the policy.",
+			},
+			"publisher": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Publisher of the policy.",
+			},
+			"scope": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sub_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_clusters": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Indicates the cluster type against which this policy can be executed.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"title": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Title of a System-Defined Alert Policy.",
+			},
+			"sda_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func DatasourceNutanixSdaPolicyV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	extID := d.Get("ext_id").(string)
+
+	resp, err := conn.SystemDefinedPoliciesAPI.GetSdaPolicyById(utils.StringPtr(extID))
+	if err != nil {
+		return diag.Errorf("error while fetching System-Defined Alert Policy: %v", err)
+	}
+
+	getResp, ok := resp.Data.GetValue().(serviceability.SystemDefinedPolicy)
+	if !ok {
+		return diag.Errorf("error: unexpected response type from GetSdaPolicyById, expected SystemDefinedPolicy")
+	}
+
+	if err := flattenSdaPolicy(d, &getResp); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(utils.StringValue(getResp.ExtId))
+	return nil
+}
+
+func flattenSdaPolicy(d *schema.ResourceData, p *serviceability.SystemDefinedPolicy) error {
+	if err := d.Set("ext_id", p.ExtId); err != nil {
+		return err
+	}
+	if err := d.Set("name", p.Name); err != nil {
+		return err
+	}
+	if err := d.Set("description", p.Description); err != nil {
+		return err
+	}
+	if err := d.Set("title", p.Title); err != nil {
+		return err
+	}
+	if err := d.Set("policy_id", p.PolicyId); err != nil {
+		return err
+	}
+	if err := d.Set("publisher", p.Publisher); err != nil {
+		return err
+	}
+	if err := d.Set("tenant_id", p.TenantId); err != nil {
+		return err
+	}
+	if p.EntityType != nil {
+		if err := d.Set("entity_type", p.EntityType.GetName()); err != nil {
+			return err
+		}
+	}
+	if p.Scope != nil {
+		if err := d.Set("scope", p.Scope.GetName()); err != nil {
+			return err
+		}
+	}
+	if p.SubType != nil {
+		if err := d.Set("sub_type", p.SubType.GetName()); err != nil {
+			return err
+		}
+	}
+	if p.Type != nil {
+		if err := d.Set("sda_type", p.Type.GetName()); err != nil {
+			return err
+		}
+	}
+
+	classifications := make([]string, 0)
+	for _, c := range p.Classifications {
+		classifications = append(classifications, c)
+	}
+	if err := d.Set("classifications", classifications); err != nil {
+		return err
+	}
+
+	kbArticles := make([]string, 0)
+	for _, k := range p.KbArticles {
+		kbArticles = append(kbArticles, k)
+	}
+	if err := d.Set("kb_articles", kbArticles); err != nil {
+		return err
+	}
+
+	impactTypes := make([]string, 0)
+	for _, it := range p.ImpactTypes {
+		impactTypes = append(impactTypes, it.GetName())
+	}
+	if err := d.Set("impact_types", impactTypes); err != nil {
+		return err
+	}
+
+	targetClusters := make([]string, 0)
+	for _, tc := range p.TargetClusters {
+		targetClusters = append(targetClusters, tc.GetName())
+	}
+	if err := d.Set("target_clusters", targetClusters); err != nil {
+		return err
+	}
+
+	if err := d.Set("links", flattenLinks(p.Links)); err != nil {
+		return err
+	}
+	if err := d.Set("cluster_configs", flattenClusterConfigs(p.ClusterConfigs)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_sda_policy_v2_test.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_sda_policy_v2_test.go
@@ -1,0 +1,38 @@
+package monitoringv2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const datasourceNameSdaPolicy = "data.nutanix_sda_policy_v2.test"
+
+func TestAccV2NutanixSdaPolicyDatasource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testSdaPolicyDatasourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameSdaPolicy, "ext_id"),
+					resource.TestCheckResourceAttrSet(datasourceNameSdaPolicy, "name"),
+					resource.TestCheckResourceAttrSet(datasourceNameSdaPolicy, "title"),
+				),
+			},
+		},
+	})
+}
+
+func testSdaPolicyDatasourceConfig() string {
+	return fmt.Sprintf(`
+data "nutanix_sda_policies_v2" "list" {}
+
+data "nutanix_sda_policy_v2" "test" {
+  ext_id = data.nutanix_sda_policies_v2.list.sda_policies.0.ext_id
+}
+`)
+}

--- a/nutanix/services/monitoringv2/helper.go
+++ b/nutanix/services/monitoringv2/helper.go
@@ -1,0 +1,210 @@
+package monitoringv2
+
+import (
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/common/v1/response"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+const (
+	DEFAULTWAITTIMEOUT = 15
+)
+
+func autoResolveStateFromString(s string) serviceability.AutoResolveState {
+	switch s {
+	case "ENABLED":
+		return serviceability.AUTORESOLVESTATE_ENABLED
+	case "DISABLED":
+		return serviceability.AUTORESOLVESTATE_DISABLED
+	case "NOT_SUPPORTED":
+		return serviceability.AUTORESOLVESTATE_NOT_SUPPORTED
+	default:
+		return serviceability.AUTORESOLVESTATE_UNKNOWN
+	}
+}
+
+func propertyStateFromString(s string) serviceability.PropertyState {
+	switch s {
+	case "ENABLED":
+		return serviceability.PROPERTYSTATE_ENABLED
+	case "DISABLED":
+		return serviceability.PROPERTYSTATE_DISABLED
+	case "NOT_SUPPORTED":
+		return serviceability.PROPERTYSTATE_NOT_SUPPORTED
+	default:
+		return serviceability.PROPERTYSTATE_UNKNOWN
+	}
+}
+
+func flattenLinks(links []response.ApiLink) []map[string]interface{} {
+	if len(links) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(links))
+	for i, v := range links {
+		link := map[string]interface{}{}
+		if v.Href != nil {
+			link["href"] = utils.StringValue(v.Href)
+		}
+		if v.Rel != nil {
+			link["rel"] = utils.StringValue(v.Rel)
+		}
+		result[i] = link
+	}
+	return result
+}
+
+func flattenSeverityConfig(cfg *serviceability.SeverityConfig) []map[string]interface{} {
+	if cfg == nil {
+		return nil
+	}
+	m := map[string]interface{}{}
+	if cfg.State != nil {
+		m["state"] = cfg.State.GetName()
+	}
+	if cfg.ThresholdParameters != nil {
+		m["threshold_parameters"] = flattenAlertPolicyConfigurableParameters(cfg.ThresholdParameters)
+	}
+	return []map[string]interface{}{m}
+}
+
+func flattenAlertPolicyConfigurableParameters(params []serviceability.AlertPolicyConfigurableParameter) []map[string]interface{} {
+	if len(params) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(params))
+	for i, p := range params {
+		m := map[string]interface{}{}
+		if p.DisplayName != nil {
+			m["display_name"] = utils.StringValue(p.DisplayName)
+		}
+		if p.Name != nil {
+			m["name"] = utils.StringValue(p.Name)
+		}
+		if p.Unit != nil {
+			m["unit"] = utils.StringValue(p.Unit)
+		}
+		if p.ParamValue != nil {
+			m["param_value"] = flattenParamValue(p.ParamValue)
+		}
+		result[i] = m
+	}
+	return result
+}
+
+func flattenParamValue(pv *serviceability.OneOfAlertPolicyConfigurableParameterParamValue) []map[string]interface{} {
+	if pv == nil || pv.ObjectType_ == nil {
+		return nil
+	}
+	m := map[string]interface{}{}
+	val := pv.GetValue()
+	if val == nil {
+		return nil
+	}
+	switch v := val.(type) {
+	case serviceability.IntConfigurableParamValue:
+		intMap := map[string]interface{}{}
+		if v.CurrentIntValue != nil {
+			intMap["current_int_value"] = *v.CurrentIntValue
+		}
+		if v.DefaultIntValue != nil {
+			intMap["default_int_value"] = *v.DefaultIntValue
+		}
+		m["int_value"] = []map[string]interface{}{intMap}
+	case serviceability.FloatConfigurableParamValue:
+		floatMap := map[string]interface{}{}
+		if v.CurrentFloatValue != nil {
+			floatMap["current_float_value"] = float64(*v.CurrentFloatValue)
+		}
+		if v.DefaultFloatValue != nil {
+			floatMap["default_float_value"] = float64(*v.DefaultFloatValue)
+		}
+		m["float_value"] = []map[string]interface{}{floatMap}
+	case serviceability.BooleanConfigurableParamValue:
+		boolMap := map[string]interface{}{}
+		if v.CurrentBoolValue != nil {
+			boolMap["current_bool_value"] = *v.CurrentBoolValue
+		}
+		if v.DefaultBoolValue != nil {
+			boolMap["default_bool_value"] = *v.DefaultBoolValue
+		}
+		m["bool_value"] = []map[string]interface{}{boolMap}
+	case serviceability.StringConfigurableParamValue:
+		strMap := map[string]interface{}{}
+		if v.CurrentStrValue != nil {
+			strMap["current_str_value"] = utils.StringValue(v.CurrentStrValue)
+		}
+		if v.DefaultStrValue != nil {
+			strMap["default_str_value"] = utils.StringValue(v.DefaultStrValue)
+		}
+		m["str_value"] = []map[string]interface{}{strMap}
+	}
+	return []map[string]interface{}{m}
+}
+
+func flattenAlertConfig(cfg *serviceability.AlertConfig) []map[string]interface{} {
+	if cfg == nil {
+		return nil
+	}
+	m := map[string]interface{}{}
+	if cfg.AutoResolve != nil {
+		m["auto_resolve"] = cfg.AutoResolve.GetName()
+	}
+	if cfg.CriticalSeverity != nil {
+		m["critical_severity"] = flattenSeverityConfig(cfg.CriticalSeverity)
+	}
+	if cfg.InfoSeverity != nil {
+		m["info_severity"] = flattenSeverityConfig(cfg.InfoSeverity)
+	}
+	if cfg.WarningSeverity != nil {
+		m["warning_severity"] = flattenSeverityConfig(cfg.WarningSeverity)
+	}
+	return []map[string]interface{}{m}
+}
+
+func flattenClusterConfigs(configs []serviceability.ClusterConfig) []map[string]interface{} {
+	if len(configs) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(configs))
+	for i, c := range configs {
+		result[i] = flattenClusterConfig(&c)
+	}
+	return result
+}
+
+func flattenClusterConfig(c *serviceability.ClusterConfig) map[string]interface{} {
+	if c == nil {
+		return nil
+	}
+	m := map[string]interface{}{}
+	if c.AlertConfig != nil {
+		m["alert_config"] = flattenAlertConfig(c.AlertConfig)
+	}
+	if c.ConfigurableParameters != nil {
+		m["configurable_parameters"] = flattenAlertPolicyConfigurableParameters(c.ConfigurableParameters)
+	}
+	if c.ExtId != nil {
+		m["ext_id"] = utils.StringValue(c.ExtId)
+	}
+	if c.IsEnabled != nil {
+		m["is_enabled"] = *c.IsEnabled
+	}
+	if c.LastModifiedByUser != nil {
+		m["last_modified_by_user"] = utils.StringValue(c.LastModifiedByUser)
+	}
+	if c.LastModifiedTime != nil {
+		m["last_modified_time"] = c.LastModifiedTime.String()
+	}
+	if c.Links != nil {
+		m["links"] = flattenLinks(c.Links)
+	}
+	if c.ScheduleIntervalSeconds != nil {
+		m["schedule_interval_seconds"] = utils.IntValue(c.ScheduleIntervalSeconds)
+	}
+	if c.TenantId != nil {
+		m["tenant_id"] = utils.StringValue(c.TenantId)
+	}
+	return m
+}

--- a/nutanix/services/monitoringv2/main_test.go
+++ b/nutanix/services/monitoringv2/main_test.go
@@ -1,0 +1,41 @@
+package monitoringv2_test
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"testing"
+)
+
+type TestConfig struct {
+	Monitoring struct {
+		SdaPolicyExtID string `json:"sda_policy_ext_id"`
+		ClusterExtID   string `json:"cluster_ext_id"`
+	} `json:"monitoring"`
+}
+
+var (
+	testVars TestConfig
+	path, _  = os.Getwd()
+	filepath = path + "/../../../test_config_v2.json"
+)
+
+func loadVars(filepath string, varStuct interface{}) {
+	configData, err := os.ReadFile(filepath)
+	if err != nil {
+		log.Printf("Got this error while reading config.json: %s", err.Error())
+		os.Exit(1)
+	}
+
+	err = json.Unmarshal(configData, varStuct)
+	if err != nil {
+		log.Printf("Got this error while unmarshalling config.json: %s", err.Error())
+		os.Exit(1)
+	}
+}
+
+func TestMain(m *testing.M) {
+	log.Println("Do some crazy stuff before tests!")
+	loadVars("../../../test_config_v2.json", &testVars)
+	os.Exit(m.Run())
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_run_system_defined_checks_v2.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_run_system_defined_checks_v2.go
@@ -1,0 +1,208 @@
+package monitoringv2
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	commonCfg "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/common/v1/config"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	monitoringPrism "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/prism/v4/config"
+	prismConfig "github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4/models/prism/v4/config"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/common"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func ResourceNutanixRunSystemDefinedChecksV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: ResourceNutanixRunSystemDefinedChecksV2Create,
+		ReadContext:   ResourceNutanixRunSystemDefinedChecksV2Read,
+		DeleteContext: ResourceNutanixRunSystemDefinedChecksV2Delete,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(DEFAULTWAITTIMEOUT * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"cluster_ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Unique identifier for the cluster for which run System-Defined Checks is requested.",
+			},
+			"additional_recipients": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "A list of additional email addresses for sending the run summary.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"node_ips": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "List of node IP addresses where the Check will run.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"prefix_length": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Description: "The prefix length of the network to which this host IPv4 address belongs.",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Description: "The IPv4 address of the host.",
+						},
+					},
+				},
+			},
+			"sda_ext_ids": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "List of Check IDs to be executed.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"should_anonymize": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Indicates whether to mask sensitive data in the check run summary.",
+			},
+			"should_run_all_checks": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Indicates whether all System-Defined Checks applicable to the specified cluster should be executed.",
+			},
+			"should_send_report_to_configured_recipients": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Determines if the run summary should be sent to the configured email address associated with the cluster.",
+			},
+			"task_ext_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func ResourceNutanixRunSystemDefinedChecksV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	clusterExtID := d.Get("cluster_ext_id").(string)
+
+	body := serviceability.NewRunSystemDefinedChecksSpec()
+
+	if v, ok := d.GetOk("additional_recipients"); ok {
+		recipients := make([]string, 0)
+		for _, r := range v.([]interface{}) {
+			recipients = append(recipients, r.(string))
+		}
+		body.AdditionalRecipients = recipients
+	}
+
+	if v, ok := d.GetOk("node_ips"); ok {
+		nodeIps := expandIPv4Addresses(v.([]interface{}))
+		body.NodeIps = nodeIps
+	}
+
+	if v, ok := d.GetOk("sda_ext_ids"); ok {
+		sdaExtIds := make([]string, 0)
+		for _, s := range v.([]interface{}) {
+			sdaExtIds = append(sdaExtIds, s.(string))
+		}
+		body.SdaExtIds = sdaExtIds
+	}
+
+	if v, ok := d.GetOk("should_anonymize"); ok {
+		body.ShouldAnonymize = utils.BoolPtr(v.(bool))
+	}
+
+	if v, ok := d.GetOk("should_run_all_checks"); ok {
+		body.ShouldRunAllChecks = utils.BoolPtr(v.(bool))
+	}
+
+	if v, ok := d.GetOk("should_send_report_to_configured_recipients"); ok {
+		body.ShouldSendReportToConfiguredRecipients = utils.BoolPtr(v.(bool))
+	}
+
+	aJSON, _ := json.MarshalIndent(body, "", "  ")
+	log.Printf("[DEBUG] RunSystemDefinedChecks payload: %s", aJSON)
+
+	resp, err := conn.SystemDefinedChecksAPI.RunSystemDefinedChecks(utils.StringPtr(clusterExtID), body)
+	if err != nil {
+		return diag.Errorf("error while running System-Defined Checks: %v", err)
+	}
+
+	taskRefValue, ok := resp.Data.GetValue().(monitoringPrism.TaskReference)
+	if !ok {
+		return diag.Errorf("error: unexpected response type, expected TaskReference")
+	}
+	taskUUID := taskRefValue.ExtId
+
+	taskconn := meta.(*conns.Client).PrismAPI
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING", "RUNNING", "QUEUED"},
+		Target:  []string{"SUCCEEDED"},
+		Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, taskconn, utils.StringValue(taskUUID)),
+		Timeout: d.Timeout(schema.TimeoutCreate),
+	}
+
+	if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
+		return diag.Errorf("error waiting for System-Defined Checks task (%s) to complete: %s", utils.StringValue(taskUUID), errWaitTask)
+	}
+
+	taskResp, err := taskconn.TaskRefAPI.GetTaskById(taskUUID, nil)
+	if err != nil {
+		return diag.Errorf("error while fetching System-Defined Checks task (%s): %v", utils.StringValue(taskUUID), err)
+	}
+	taskDetails := taskResp.Data.GetValue().(prismConfig.Task)
+	aJSON, _ = json.MarshalIndent(taskDetails, "", "  ")
+	log.Printf("[DEBUG] RunSystemDefinedChecks Task Details: %s", string(aJSON))
+
+	d.SetId(utils.StringValue(taskUUID))
+	if err := d.Set("task_ext_id", utils.StringValue(taskUUID)); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func ResourceNutanixRunSystemDefinedChecksV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func ResourceNutanixRunSystemDefinedChecksV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	d.SetId("")
+	return nil
+}
+
+func expandIPv4Addresses(pr []interface{}) []commonCfg.IPv4Address {
+	if len(pr) == 0 {
+		return nil
+	}
+	result := make([]commonCfg.IPv4Address, 0, len(pr))
+	for _, item := range pr {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		ip := commonCfg.IPv4Address{}
+		if v, ok := m["value"].(string); ok && v != "" {
+			ip.Value = utils.StringPtr(v)
+		}
+		if v, ok := m["prefix_length"].(int); ok && v != 0 {
+			ip.PrefixLength = utils.IntPtr(v)
+		}
+		result = append(result, ip)
+	}
+	return result
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_run_system_defined_checks_v2_test.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_run_system_defined_checks_v2_test.go
@@ -1,0 +1,49 @@
+package monitoringv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const resourceNameRunChecks = "nutanix_run_system_defined_checks_v2.test"
+
+func TestAccV2NutanixRunSystemDefinedChecksResource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testRunSystemDefinedChecksResourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameRunChecks, "id"),
+					resource.TestCheckResourceAttrSet(resourceNameRunChecks, "task_ext_id"),
+					resource.TestCheckResourceAttrSet(resourceNameRunChecks, "cluster_ext_id"),
+					resource.TestCheckResourceAttr(resourceNameRunChecks, "should_run_all_checks", "true"),
+					resource.TestCheckResourceAttr(resourceNameRunChecks, "should_send_report_to_configured_recipients", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testRunSystemDefinedChecksResourceConfig() string {
+	return `
+data "nutanix_clusters_v2" "clusters" {}
+
+locals {
+  cluster_ext_id = [
+    for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+    cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+  ][0]
+}
+
+resource "nutanix_run_system_defined_checks_v2" "test" {
+  cluster_ext_id                              = local.cluster_ext_id
+  should_run_all_checks                       = true
+  should_send_report_to_configured_recipients = false
+  additional_recipients                       = ["noreply@nutanix.com"]
+}
+`
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_sda_cluster_config_v2.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_sda_cluster_config_v2.go
@@ -1,0 +1,350 @@
+package monitoringv2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func ResourceNutanixSdaClusterConfigV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: ResourceNutanixSdaClusterConfigV2Create,
+		ReadContext:   ResourceNutanixSdaClusterConfigV2Read,
+		UpdateContext: ResourceNutanixSdaClusterConfigV2Update,
+		DeleteContext: ResourceNutanixSdaClusterConfigV2Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(DEFAULTWAITTIMEOUT * time.Minute),
+			Update: schema.DefaultTimeout(DEFAULTWAITTIMEOUT * time.Minute),
+			Delete: schema.DefaultTimeout(DEFAULTWAITTIMEOUT * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"system_defined_policy_ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Unique ID of the System-Defined Alert Policy.",
+			},
+			"ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Cluster UUID.",
+			},
+			"alert_config": schemaForAlertConfig(false),
+			"configurable_parameters": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"display_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"unit": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"param_value": schemaForParamValue(),
+					},
+				},
+			},
+			"is_enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates whether the SDA policy is enabled or not on the cluster.",
+			},
+			"last_modified_by_user": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Name of the user who made the latest update to this policy.",
+			},
+			"last_modified_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Time in ISO 8601 format when the SDA policy was last modified.",
+			},
+			"links": linksSchema(),
+			"schedule_interval_seconds": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Interval in seconds for periodically executing the SDA policy.",
+			},
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func ResourceNutanixSdaClusterConfigV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sdaPolicyExtID := d.Get("system_defined_policy_ext_id").(string)
+	extID := d.Get("ext_id").(string)
+
+	d.SetId(fmt.Sprintf("%s/%s", sdaPolicyExtID, extID))
+
+	if d.HasChange("alert_config") {
+		return ResourceNutanixSdaClusterConfigV2Update(ctx, d, meta)
+	}
+
+	return ResourceNutanixSdaClusterConfigV2Read(ctx, d, meta)
+}
+
+func ResourceNutanixSdaClusterConfigV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	idParts := strings.Split(d.Id(), "/")
+	if len(idParts) != 2 {
+		return diag.Errorf("invalid resource ID format, expected <system_defined_policy_ext_id>/<ext_id>")
+	}
+	sdaPolicyExtID := idParts[0]
+	extID := idParts[1]
+
+	if err := d.Set("system_defined_policy_ext_id", sdaPolicyExtID); err != nil {
+		return diag.FromErr(err)
+	}
+
+	resp, err := conn.SystemDefinedPoliciesAPI.GetClusterConfigById(utils.StringPtr(sdaPolicyExtID), utils.StringPtr(extID))
+	if err != nil {
+		return diag.Errorf("error while fetching cluster config: %v", err)
+	}
+
+	getResp, ok := resp.Data.GetValue().(serviceability.ClusterConfig)
+	if !ok {
+		return diag.Errorf("error: unexpected response type, expected ClusterConfig")
+	}
+
+	if err := d.Set("ext_id", getResp.ExtId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("alert_config", flattenAlertConfig(getResp.AlertConfig)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("configurable_parameters", flattenAlertPolicyConfigurableParameters(getResp.ConfigurableParameters)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_enabled", getResp.IsEnabled); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("last_modified_by_user", getResp.LastModifiedByUser); err != nil {
+		return diag.FromErr(err)
+	}
+	if getResp.LastModifiedTime != nil {
+		if err := d.Set("last_modified_time", getResp.LastModifiedTime.String()); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err := d.Set("links", flattenLinks(getResp.Links)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("schedule_interval_seconds", getResp.ScheduleIntervalSeconds); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("tenant_id", getResp.TenantId); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func ResourceNutanixSdaClusterConfigV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	idParts := strings.Split(d.Id(), "/")
+	if len(idParts) != 2 {
+		return diag.Errorf("invalid resource ID format, expected <system_defined_policy_ext_id>/<ext_id>")
+	}
+	sdaPolicyExtID := idParts[0]
+	extID := idParts[1]
+
+	getResp, err := conn.SystemDefinedPoliciesAPI.GetClusterConfigById(utils.StringPtr(sdaPolicyExtID), utils.StringPtr(extID))
+	if err != nil {
+		return diag.Errorf("error while fetching cluster config for update: %v", err)
+	}
+
+	etagValue := conn.SystemDefinedPoliciesAPI.ApiClient.GetEtag(getResp)
+	args := make(map[string]interface{})
+	args["If-Match"] = utils.StringPtr(etagValue)
+
+	updateSpec, ok := getResp.Data.GetValue().(serviceability.ClusterConfig)
+	if !ok {
+		return diag.Errorf("error: unexpected response type, expected ClusterConfig")
+	}
+
+	if d.HasChange("alert_config") {
+		if v, ok := d.GetOk("alert_config"); ok {
+			alertConfig := expandAlertConfig(v.([]interface{}))
+			updateSpec.AlertConfig = alertConfig
+		}
+	}
+
+	aJSON, _ := json.MarshalIndent(updateSpec, "", "  ")
+	log.Printf("[DEBUG] UpdateClusterConfigById payload: %s", aJSON)
+
+	_, err = conn.SystemDefinedPoliciesAPI.UpdateClusterConfigById(utils.StringPtr(sdaPolicyExtID), utils.StringPtr(extID), &updateSpec, args)
+	if err != nil {
+		return diag.Errorf("error while updating cluster config: %v", err)
+	}
+
+	return ResourceNutanixSdaClusterConfigV2Read(ctx, d, meta)
+}
+
+func ResourceNutanixSdaClusterConfigV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	d.SetId("")
+	return nil
+}
+
+func expandAlertConfig(pr []interface{}) *serviceability.AlertConfig {
+	if len(pr) == 0 {
+		return nil
+	}
+	m, ok := pr[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	cfg := serviceability.NewAlertConfig()
+
+	if v, ok := m["auto_resolve"].(string); ok && v != "" {
+		autoResolve := autoResolveStateFromString(v)
+		cfg.AutoResolve = &autoResolve
+	}
+	if v, ok := m["critical_severity"].([]interface{}); ok && len(v) > 0 {
+		cfg.CriticalSeverity = expandSeverityConfig(v)
+	}
+	if v, ok := m["info_severity"].([]interface{}); ok && len(v) > 0 {
+		cfg.InfoSeverity = expandSeverityConfig(v)
+	}
+	if v, ok := m["warning_severity"].([]interface{}); ok && len(v) > 0 {
+		cfg.WarningSeverity = expandSeverityConfig(v)
+	}
+	return cfg
+}
+
+func expandSeverityConfig(pr []interface{}) *serviceability.SeverityConfig {
+	if len(pr) == 0 {
+		return nil
+	}
+	m, ok := pr[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	cfg := serviceability.NewSeverityConfig()
+
+	if v, ok := m["state"].(string); ok && v != "" {
+		state := propertyStateFromString(v)
+		cfg.State = &state
+	}
+	if v, ok := m["threshold_parameters"].([]interface{}); ok && len(v) > 0 {
+		cfg.ThresholdParameters = expandThresholdParameters(v)
+	}
+	return cfg
+}
+
+func expandThresholdParameters(pr []interface{}) []serviceability.AlertPolicyConfigurableParameter {
+	if len(pr) == 0 {
+		return nil
+	}
+	result := make([]serviceability.AlertPolicyConfigurableParameter, 0, len(pr))
+	for _, item := range pr {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		param := serviceability.AlertPolicyConfigurableParameter{}
+		if v, ok := m["name"].(string); ok && v != "" {
+			param.Name = utils.StringPtr(v)
+		}
+		if v, ok := m["display_name"].(string); ok && v != "" {
+			param.DisplayName = utils.StringPtr(v)
+		}
+		if v, ok := m["unit"].(string); ok && v != "" {
+			param.Unit = utils.StringPtr(v)
+		}
+		if v, ok := m["param_value"].([]interface{}); ok && len(v) > 0 {
+			pv := expandParamValue(v)
+			if pv != nil {
+				param.ParamValue = pv
+			}
+		}
+		result = append(result, param)
+	}
+	return result
+}
+
+func expandParamValue(pr []interface{}) *serviceability.OneOfAlertPolicyConfigurableParameterParamValue {
+	if len(pr) == 0 {
+		return nil
+	}
+	m, ok := pr[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	pv := serviceability.NewOneOfAlertPolicyConfigurableParameterParamValue()
+
+	if v, ok := m["int_value"].([]interface{}); ok && len(v) > 0 {
+		intM, ok := v[0].(map[string]interface{})
+		if ok {
+			intVal := serviceability.IntConfigurableParamValue{}
+			if cv, ok := intM["current_int_value"].(int); ok {
+				val := int64(cv)
+				intVal.CurrentIntValue = &val
+			}
+			if err := pv.SetValue(intVal); err != nil {
+				log.Printf("[WARN] failed to set int param value: %v", err)
+			}
+		}
+	} else if v, ok := m["float_value"].([]interface{}); ok && len(v) > 0 {
+		floatM, ok := v[0].(map[string]interface{})
+		if ok {
+			floatVal := serviceability.FloatConfigurableParamValue{}
+			if cv, ok := floatM["current_float_value"].(float64); ok {
+				fv := float32(cv)
+				floatVal.CurrentFloatValue = &fv
+			}
+			if err := pv.SetValue(floatVal); err != nil {
+				log.Printf("[WARN] failed to set float param value: %v", err)
+			}
+		}
+	} else if v, ok := m["bool_value"].([]interface{}); ok && len(v) > 0 {
+		boolM, ok := v[0].(map[string]interface{})
+		if ok {
+			boolVal := serviceability.BooleanConfigurableParamValue{}
+			if cv, ok := boolM["current_bool_value"].(bool); ok {
+				boolVal.CurrentBoolValue = &cv
+			}
+			if err := pv.SetValue(boolVal); err != nil {
+				log.Printf("[WARN] failed to set bool param value: %v", err)
+			}
+		}
+	} else if v, ok := m["str_value"].([]interface{}); ok && len(v) > 0 {
+		strM, ok := v[0].(map[string]interface{})
+		if ok {
+			strVal := serviceability.StringConfigurableParamValue{}
+			if cv, ok := strM["current_str_value"].(string); ok {
+				strVal.CurrentStrValue = utils.StringPtr(cv)
+			}
+			if err := pv.SetValue(strVal); err != nil {
+				log.Printf("[WARN] failed to set str param value: %v", err)
+			}
+		}
+	}
+
+	return pv
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_sda_cluster_config_v2_test.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_sda_cluster_config_v2_test.go
@@ -1,0 +1,44 @@
+package monitoringv2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const resourceNameSdaClusterConfig = "nutanix_sda_cluster_config_v2.test"
+
+func TestAccV2NutanixSdaClusterConfigResource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testSdaClusterConfigResourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameSdaClusterConfig, "id"),
+					resource.TestCheckResourceAttrSet(resourceNameSdaClusterConfig, "ext_id"),
+					resource.TestCheckResourceAttrSet(resourceNameSdaClusterConfig, "system_defined_policy_ext_id"),
+					resource.TestCheckResourceAttrSet(resourceNameSdaClusterConfig, "alert_config.#"),
+				),
+			},
+		},
+	})
+}
+
+func testSdaClusterConfigResourceConfig() string {
+	return fmt.Sprintf(`
+data "nutanix_sda_policies_v2" "list" {}
+
+data "nutanix_sda_cluster_configs_v2" "list_configs" {
+  system_defined_policy_ext_id = data.nutanix_sda_policies_v2.list.sda_policies.0.ext_id
+}
+
+resource "nutanix_sda_cluster_config_v2" "test" {
+  system_defined_policy_ext_id = data.nutanix_sda_policies_v2.list.sda_policies.0.ext_id
+  ext_id                       = data.nutanix_sda_cluster_configs_v2.list_configs.cluster_configs.0.ext_id
+}
+`)
+}

--- a/nutanix/services/monitoringv2/schema.go
+++ b/nutanix/services/monitoringv2/schema.go
@@ -1,0 +1,229 @@
+package monitoringv2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func schemaForParamValue() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"int_value": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"current_int_value": {
+								Type:     schema.TypeInt,
+								Computed: true,
+								Optional: true,
+							},
+							"default_int_value": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"float_value": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"current_float_value": {
+								Type:     schema.TypeFloat,
+								Computed: true,
+								Optional: true,
+							},
+							"default_float_value": {
+								Type:     schema.TypeFloat,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"bool_value": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"current_bool_value": {
+								Type:     schema.TypeBool,
+								Computed: true,
+								Optional: true,
+							},
+							"default_bool_value": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"str_value": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"current_str_value": {
+								Type:     schema.TypeString,
+								Computed: true,
+								Optional: true,
+							},
+							"default_str_value": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemaForThresholdParameters(computed bool) *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Optional: !computed,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"display_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"name": {
+					Type:     schema.TypeString,
+					Computed: true,
+					Optional: !computed,
+				},
+				"unit": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"param_value": schemaForParamValue(),
+			},
+		},
+	}
+}
+
+func schemaForSeverityConfig(computed bool) *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Optional: !computed,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"state": {
+					Type:     schema.TypeString,
+					Computed: true,
+					Optional: !computed,
+				},
+				"threshold_parameters": schemaForThresholdParameters(computed),
+			},
+		},
+	}
+}
+
+func schemaForAlertConfig(computed bool) *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Optional: !computed,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"auto_resolve": {
+					Type:     schema.TypeString,
+					Computed: true,
+					Optional: !computed,
+				},
+				"critical_severity": schemaForSeverityConfig(computed),
+				"info_severity":     schemaForSeverityConfig(computed),
+				"warning_severity":  schemaForSeverityConfig(computed),
+			},
+		},
+	}
+}
+
+func schemaForClusterConfig() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: clusterConfigSchemaMap(),
+		},
+	}
+}
+
+func clusterConfigSchemaMap() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"alert_config":              schemaForAlertConfig(true),
+		"configurable_parameters":   schemaForThresholdParameters(true),
+		"ext_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"is_enabled": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"last_modified_by_user": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"last_modified_time": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"links": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"href": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"rel": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+		"schedule_interval_seconds": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		"tenant_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func linksSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"href": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"rel": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}

--- a/website/docs/d/sda_cluster_config_v2.html.markdown
+++ b/website/docs/d/sda_cluster_config_v2.html.markdown
@@ -1,0 +1,81 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_sda_cluster_config_v2"
+sidebar_current: "docs-nutanix-datasource-sda-cluster-config-v2"
+description: |-
+  Retrieves the cluster specific configuration associated with a System-Defined Alert Policy identified by external identifier of the System-Defined Alert Policy for a cluster identified by cluster identifier.
+---
+
+# nutanix_sda_cluster_config_v2
+
+Retrieves the cluster specific configuration associated with a System-Defined Alert Policy identified by external identifier of the System-Defined Alert Policy for a cluster identified by cluster identifier.
+
+## Example
+
+```hcl
+data "nutanix_sda_cluster_config_v2" "example" {
+  system_defined_policy_ext_id = "00000000-0000-0000-0000-000000000000"
+  ext_id                       = "00000000-0000-0000-0000-000000000000"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `system_defined_policy_ext_id`: (Required) Unique ID of the System-Defined Alert Policy.
+- `ext_id`: (Required) Cluster UUID.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+- `alert_config`: Alert configuration for this cluster.
+- `configurable_parameters`: Parameters of the SDA that are configurable by a user.
+- `is_enabled`: Indicates whether the SDA policy is enabled or not on the cluster.
+- `last_modified_by_user`: Name of the user who made the latest update to this policy. Its value will be Nutanix if the last update is due to an upgrade event.
+- `last_modified_time`: Time in ISO 8601 format when the SDA policy was last modified.
+- `links`: A HATEOAS style link for the response.
+- `schedule_interval_seconds`: Interval in seconds for periodically executing the SDA policy. This will not be set for policies with the type NOT_SCHEDULED & EVENT_DRIVEN.
+- `tenant_id`: A globally unique identifier that represents the tenant that owns this entity.
+
+### alert_config
+
+- `auto_resolve`: Auto resolve state (ENABLED, DISABLED, NOT_SUPPORTED).
+- `critical_severity`: Critical severity configuration.
+- `info_severity`: Info severity configuration.
+- `warning_severity`: Warning severity configuration.
+
+### severity_config (critical_severity, info_severity, warning_severity)
+
+- `state`: Property state (ENABLED, DISABLED, NOT_SUPPORTED).
+- `threshold_parameters`: Captures alert-related thresholds that correspond to a particular severity.
+
+### threshold_parameters / configurable_parameters
+
+- `display_name`: Equivalent name for the parameter used to display it on Prism UI.
+- `name`: Unique identifier name for the parameter.
+- `unit`: Unit for the parameter. For example, sec, %, MB, GB, and so on.
+- `param_value`: Captures the parameter value.
+
+### param_value
+
+The param_value contains one of the following:
+
+- `int_value`: Integer parameter value.
+  - `current_int_value`: Captures the current value of the parameter.
+  - `default_int_value`: Captures the default value of the parameter.
+- `float_value`: Float parameter value.
+  - `current_float_value`: Captures the current value of the parameter.
+  - `default_float_value`: Captures the default value of the parameter.
+- `bool_value`: Boolean parameter value.
+  - `current_bool_value`: Captures the current value of the parameter.
+  - `default_bool_value`: Captures the default value of the parameter.
+- `str_value`: String parameter value.
+  - `current_str_value`: Captures the current value of the parameter.
+  - `default_str_value`: Captures the default value of the parameter.
+
+### links
+
+- `href`: The URL at which the entity described by the link can be accessed.
+- `rel`: A name that identifies the relationship of the link to the object that is returned by the URL.

--- a/website/docs/d/sda_cluster_configs_v2.html.markdown
+++ b/website/docs/d/sda_cluster_configs_v2.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_sda_cluster_configs_v2"
+sidebar_current: "docs-nutanix-datasource-sda-cluster-configs-v2"
+description: |-
+  Retrieves cluster specific configurations associated with a System-Defined Alert Policy identified by the external identifier of the System-Defined Alert Policy.
+---
+
+# nutanix_sda_cluster_configs_v2
+
+Retrieves cluster specific configurations associated with a System-Defined Alert Policy identified by the external identifier of the System-Defined Alert Policy.
+
+## Example
+
+```hcl
+data "nutanix_sda_cluster_configs_v2" "example" {
+  system_defined_policy_ext_id = "00000000-0000-0000-0000-000000000000"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `system_defined_policy_ext_id`: (Required) Unique ID of the System-Defined Alert Policy.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+- `cluster_configs`: List of cluster-specific configurations for the SDA policy. Each entry has the same attributes as `nutanix_sda_cluster_config_v2`.
+
+See `nutanix_sda_cluster_config_v2` datasource documentation for the full attribute reference of each cluster config.

--- a/website/docs/d/sda_policies_v2.html.markdown
+++ b/website/docs/d/sda_policies_v2.html.markdown
@@ -1,0 +1,29 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_sda_policies_v2"
+sidebar_current: "docs-nutanix-datasource-sda-policies-v2"
+description: |-
+  Retrieves a list of all System-Defined Alert Policies.
+---
+
+# nutanix_sda_policies_v2
+
+Retrieves a list of all System-Defined Alert Policies.
+
+## Example
+
+```hcl
+data "nutanix_sda_policies_v2" "example" {}
+```
+
+## Argument Reference
+
+No arguments are required.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+- `sda_policies`: List of System-Defined Alert Policies. Each entry has the same attributes as `nutanix_sda_policy_v2`.
+
+See `nutanix_sda_policy_v2` datasource documentation for the full attribute reference of each policy.

--- a/website/docs/d/sda_policy_v2.html.markdown
+++ b/website/docs/d/sda_policy_v2.html.markdown
@@ -1,0 +1,65 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_sda_policy_v2"
+sidebar_current: "docs-nutanix-datasource-sda-policy-v2"
+description: |-
+  Get details of a System-Defined Alert Policy identified by external identifier.
+---
+
+# nutanix_sda_policy_v2
+
+Get details of a System-Defined Alert Policy identified by external identifier.
+
+## Example
+
+```hcl
+data "nutanix_sda_policy_v2" "example" {
+  ext_id = "00000000-0000-0000-0000-000000000000"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `ext_id`: (Required) Unique ID of the System-Defined Alert Policy.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+- `name`: Name of the System-Defined Alert Policy.
+- `description`: System-defined alert policy description.
+- `title`: Title of a System-Defined Alert Policy.
+- `policy_id`: Unique ID associated with the policy.
+- `publisher`: Publisher of the policy. For example, NCC for all health check policies.
+- `entity_type`: Entity type of the policy.
+- `scope`: Scope of the policy.
+- `sub_type`: Sub type of the policy.
+- `sda_type`: Type of the policy.
+- `classifications`: Various categories into which this alert type can be classified. For example, hardware, storage, or license.
+- `impact_types`: Impact types to which this rule applies.
+- `kb_articles`: List of knowledge base article links.
+- `target_clusters`: Indicates the cluster type against which this policy can be executed.
+- `tenant_id`: A globally unique identifier that represents the tenant that owns this entity.
+- `links`: A HATEOAS style link for the response.
+- `cluster_configs`: SDA policy parameters that may differ across clusters since each cluster can run on different NCC versions.
+
+### links
+
+- `href`: The URL at which the entity described by the link can be accessed.
+- `rel`: A name that identifies the relationship of the link to the object that is returned by the URL.
+
+### cluster_configs
+
+- `alert_config`: Alert configuration for this cluster.
+- `configurable_parameters`: Parameters of the SDA that are configurable by a user.
+- `ext_id`: A globally unique identifier of an instance that is suitable for external consumption.
+- `is_enabled`: Indicates whether the SDA policy is enabled or not on the cluster.
+- `last_modified_by_user`: Name of the user who made the latest update to this policy.
+- `last_modified_time`: Time in ISO 8601 format when the SDA policy was last modified.
+- `links`: A HATEOAS style link for the response.
+- `schedule_interval_seconds`: Interval in seconds for periodically executing the SDA policy.
+- `tenant_id`: A globally unique identifier that represents the tenant that owns this entity.
+
+See detailed attribute reference for `alert_config` and `configurable_parameters` in the `nutanix_sda_cluster_config_v2` datasource documentation.

--- a/website/docs/r/run_system_defined_checks_v2.html.markdown
+++ b/website/docs/r/run_system_defined_checks_v2.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_run_system_defined_checks_v2"
+sidebar_current: "docs-nutanix-resource-run-system-defined-checks-v2"
+description: |-
+  Run System-Defined Checks on a cluster.
+---
+
+# nutanix_run_system_defined_checks_v2
+
+Run System-Defined Checks on a cluster. This is an action resource that triggers a run of System-Defined Checks. It creates a task and waits for completion.
+
+## Example
+
+```hcl
+resource "nutanix_run_system_defined_checks_v2" "example" {
+  cluster_ext_id                              = "00000000-0000-0000-0000-000000000000"
+  should_run_all_checks                       = true
+  should_send_report_to_configured_recipients = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `cluster_ext_id`: (Required) Unique identifier for the cluster for which run System-Defined Checks is requested.
+- `additional_recipients`: (Optional) A list of additional email addresses for sending the run summary. Either this should be set or should_send_report_to_configured_recipients should be true. If both are set then email would be sent to all the recipients.
+- `node_ips`: (Optional) List of node IP addresses where the Check will run. This field will be ignored if the check scope is a cluster.
+- `sda_ext_ids`: (Optional) List of Check IDs to be executed. This field cannot be set simultaneously with should_run_all_checks; only one of them should be specified.
+- `should_anonymize`: (Optional) Indicates whether to mask sensitive data in the check run summary.
+- `should_run_all_checks`: (Optional) Indicates whether all System-Defined Checks applicable to the specified cluster should be executed. This field is mutually exclusive with the sda_ext_ids parameter.
+- `should_send_report_to_configured_recipients`: (Optional) Determines if the run summary should be sent to the configured email address associated with the cluster.
+
+### node_ips
+
+- `prefix_length`: (Optional) The prefix length of the network to which this host IPv4 address belongs.
+- `value`: (Optional) The IPv4 address of the host.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+- `task_ext_id`: A globally unique identifier for the task created by this action.

--- a/website/docs/r/sda_cluster_config_v2.html.markdown
+++ b/website/docs/r/sda_cluster_config_v2.html.markdown
@@ -1,0 +1,80 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_sda_cluster_config_v2"
+sidebar_current: "docs-nutanix-resource-sda-cluster-config-v2"
+description: |-
+  Modifies cluster-specific configuration associated with a System-Defined Alert Policy identified by external identifier of the System-Defined Alert Policy for a cluster identified by cluster identifier.
+---
+
+# nutanix_sda_cluster_config_v2
+
+Modifies cluster-specific configuration associated with a System-Defined Alert Policy identified by external identifier of the System-Defined Alert Policy for a cluster identified by cluster identifier.
+
+## Example
+
+```hcl
+resource "nutanix_sda_cluster_config_v2" "example" {
+  system_defined_policy_ext_id = "00000000-0000-0000-0000-000000000000"
+  ext_id                       = "00000000-0000-0000-0000-000000000000"
+
+  alert_config {
+    auto_resolve = "ENABLED"
+    critical_severity {
+      state = "ENABLED"
+    }
+    warning_severity {
+      state = "ENABLED"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `system_defined_policy_ext_id`: (Required) Unique ID of the System-Defined Alert Policy.
+- `ext_id`: (Required) Cluster UUID.
+- `alert_config`: (Optional) Alert configuration for this cluster.
+
+### alert_config
+
+- `auto_resolve`: (Optional) Auto resolve state (ENABLED, DISABLED, NOT_SUPPORTED).
+- `critical_severity`: (Optional) Critical severity configuration.
+- `info_severity`: (Optional) Info severity configuration.
+- `warning_severity`: (Optional) Warning severity configuration.
+
+### severity_config (critical_severity, info_severity, warning_severity)
+
+- `state`: (Optional) Property state (ENABLED, DISABLED, NOT_SUPPORTED).
+- `threshold_parameters`: (Optional) Captures alert-related thresholds that correspond to a particular severity.
+
+### threshold_parameters
+
+- `name`: (Optional) Unique identifier name for the parameter.
+- `param_value`: (Optional) Captures the parameter value.
+
+### param_value
+
+- `int_value`: (Optional) Integer parameter value.
+  - `current_int_value`: (Optional) Captures the current value of the parameter.
+- `float_value`: (Optional) Float parameter value.
+  - `current_float_value`: (Optional) Captures the current value of the parameter.
+- `bool_value`: (Optional) Boolean parameter value.
+  - `current_bool_value`: (Optional) Captures the current value of the parameter.
+- `str_value`: (Optional) String parameter value.
+  - `current_str_value`: (Optional) Captures the current value of the parameter.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+- `configurable_parameters`: Parameters of the SDA that are configurable by a user.
+- `is_enabled`: Indicates whether the SDA policy is enabled or not on the cluster.
+- `last_modified_by_user`: Name of the user who made the latest update to this policy.
+- `last_modified_time`: Time in ISO 8601 format when the SDA policy was last modified.
+- `links`: A HATEOAS style link for the response.
+- `schedule_interval_seconds`: Interval in seconds for periodically executing the SDA policy.
+- `tenant_id`: A globally unique identifier that represents the tenant that owns this entity.
+
+See `nutanix_sda_cluster_config_v2` datasource documentation for the full attribute reference of computed fields.


### PR DESCRIPTION
## Summary

- Adds monitoring SDK client integration (`monitoring-go-client/v4`) with datasources and resources for the system-defined alerts (SDA) entity
- Implements 4 datasources (`nutanix_sda_policy_v2`, `nutanix_sda_policies_v2`, `nutanix_sda_cluster_config_v2`, `nutanix_sda_cluster_configs_v2`) and 2 resources (`nutanix_run_system_defined_checks_v2`, `nutanix_sda_cluster_config_v2`)
- Includes acceptance tests (all passing), example Terraform configurations, and documentation

## Test plan

- [x] All 6 acceptance tests pass (`go test ./nutanix/services/monitoringv2/... -v`)
  - `TestAccV2NutanixSdaPolicyDatasource_Basic`
  - `TestAccV2NutanixSdaPoliciesDatasource_Basic`
  - `TestAccV2NutanixSdaClusterConfigDatasource_Basic`
  - `TestAccV2NutanixSdaClusterConfigsDatasource_Basic`
  - `TestAccV2NutanixRunSystemDefinedChecksResource_Basic`
  - `TestAccV2NutanixSdaClusterConfigResource_Basic`
- [x] `go vet ./nutanix/services/monitoringv2/...` passes cleanly
- [x] Code compiles with no errors
- [ ] Review generated documentation for accuracy
- [ ] Verify example configurations work in a real environment


Made with [Cursor](https://cursor.com)