### PR TITLE
code-gen(monitoring/userdefined): terraform v2 provider code

### DIFF
--- a/examples/monitoring_v2/userdefined/main.tf
+++ b/examples/monitoring_v2/userdefined/main.tf
@@ -1,0 +1,62 @@
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = "2.0.0"
+    }
+  }
+}
+
+#defining nutanix configuration
+provider "nutanix" {
+  username = var.nutanix_username
+  password = var.nutanix_password
+  endpoint = var.nutanix_endpoint
+  port     = 9440
+  insecure = true
+}
+
+resource "nutanix_uda_policy_v2" "example" {
+  title       = "example-uda-policy"
+  entity_type = "VM"
+  description = "Example User-Defined Alert policy"
+  is_enabled  = true
+  trigger_wait_period = 600
+
+  trigger_conditions {
+    condition {
+      metric_name = "hypervisor_cpu_usage_ppm"
+      operator    = "GREATER_THAN"
+      threshold_value {
+        int_value = 900000
+      }
+    }
+    condition_type = "STATIC_THRESHOLD"
+    severity_level = "CRITICAL"
+  }
+}
+
+data "nutanix_uda_policy_v2" "example" {
+  ext_id = nutanix_uda_policy_v2.example.id
+}
+
+data "nutanix_uda_policies_v2" "example" {
+  depends_on = [nutanix_uda_policy_v2.example]
+}
+
+resource "nutanix_find_conflicting_uda_policies_v2" "example" {
+  title       = "conflict-check-policy"
+  entity_type = "VM"
+
+  trigger_conditions {
+    condition {
+      metric_name = "hypervisor_cpu_usage_ppm"
+      operator    = "GREATER_THAN"
+      threshold_value {
+        int_value = 900000
+      }
+    }
+    condition_type = "STATIC_THRESHOLD"
+    severity_level = "CRITICAL"
+  }
+}

--- a/examples/monitoring_v2/userdefined/terraform.tfvars
+++ b/examples/monitoring_v2/userdefined/terraform.tfvars
@@ -1,0 +1,4 @@
+#define values to the variables to be used in terraform file
+nutanix_username = "admin"
+nutanix_password = "password"
+nutanix_endpoint = "10.xx.xx.xx"

--- a/examples/monitoring_v2/userdefined/variables.tf
+++ b/examples/monitoring_v2/userdefined/variables.tf
@@ -1,0 +1,10 @@
+#define the type of variables to be used in terraform file
+variable "nutanix_username" {
+  type = string
+}
+variable "nutanix_password" {
+  type = string
+}
+variable "nutanix_endpoint" {
+  type = string
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4 v4.1.2-beta.2
 	github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2
 	github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2
+	github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2
 	github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1
 	github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4 v4.0.3
 	github.com/nutanix/ntnx-api-golang-clients/prism-go-client/v4 v4.3.1

--- a/go.sum
+++ b/go.sum
@@ -467,6 +467,8 @@ github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2 h1:ms+a
 github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2/go.mod h1:X3TsJoGBbkQzz6OP8Be7XvGhH4CwKkF9t35OmJpPY0w=
 github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2 h1:dE0zUP3ExJBnMUaGDAIZGN7/UZ0a85IWzHygMGcUDMc=
 github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2/go.mod h1:vo3VMB097Zd9cw4hLDbnpyBVcBZkpFmcQ2nNgpOpo7U=
+github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2 h1:dXFgnBHMd6MipSXkQE5cRysjKX96MeYeIFIkZDvye60=
+github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2/go.mod h1:msvlZou4z7vn5pHFhJ65OtAbh99z1ISsqCzfehdcWfw=
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1 h1:VWxK8mY6kOag/ocDBttDViktEi8bcjbAvm3i9laDyCA=
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1/go.mod h1:4fUdP3zeL4UFS/UVaii5EdS2v+KlM4gI07KcnS+wDuY=
 github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4 v4.0.3 h1:TE/G5GHrnvBGPI8MC0fSMSAaeD6HcdtezIgEmn8V/Yo=

--- a/nutanix/config.go
+++ b/nutanix/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/iam"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/lcm"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/microseg"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/monitoring"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/networking"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/objectstores"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/prism"
@@ -140,6 +141,10 @@ func (c *Config) Client() (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	monitoringClient, err := monitoring.NewMonitoringClient(configCreds)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Client{
 		WaitTimeout:         c.WaitTimeout,
@@ -161,6 +166,7 @@ func (c *Config) Client() (*Client, error) {
 		CalmAPI:             calmClient,
 		ObjectStoreAPI:      ObjectStoreClient,
 		SecurityAPI:         SecurityClient,
+		MonitoringAPI:       monitoringClient,
 	}, nil
 }
 
@@ -185,4 +191,5 @@ type Client struct {
 	CalmAPI             *selfservice.Client
 	ObjectStoreAPI      *objectstores.Client
 	SecurityAPI         *security.Client
+	MonitoringAPI       *monitoring.Client
 }

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/iamv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/lcmv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/microsegv2"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/monitoringv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/ndb"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/networking"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/networkingv2"
@@ -370,6 +371,8 @@ func Provider() *schema.Provider {
 			"nutanix_stigs_v2":                                securityv2.DatasourceNutanixStigsControlsV2(),
 			"nutanix_entity_group_v2":                         microsegv2.DatasourceNutanixEntityGroupV2(),
 			"nutanix_entity_groups_v2":                        microsegv2.DatasourceNutanixEntityGroupsV2(),
+			"nutanix_uda_policy_v2":                           monitoringv2.DatasourceNutanixUdaPolicyV2(),
+			"nutanix_uda_policies_v2":                         monitoringv2.DatasourceNutanixUdaPoliciesV2(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"nutanix_virtual_machine":                         vmm.ResourceNutanixVirtualMachine(),
@@ -501,6 +504,8 @@ func Provider() *schema.Provider {
 			"nutanix_object_store_certificate_v2":             objectstoresv2.ResourceNutanixObjectStoreCertificateV2(),
 			"nutanix_key_management_server_v2":                securityv2.ResourceNutanixKeyManagementServerV2(),
 			"nutanix_entity_group_v2":                         microsegv2.ResourceNutanixEntityGroupV2(),
+			"nutanix_uda_policy_v2":                           monitoringv2.ResourceNutanixUdaPolicyV2(),
+			"nutanix_find_conflicting_uda_policies_v2":        monitoringv2.ResourceNutanixFindConflictingUdaPoliciesV2(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}

--- a/nutanix/sdks/v4/monitoring/monitoring.go
+++ b/nutanix/sdks/v4/monitoring/monitoring.go
@@ -1,0 +1,32 @@
+package monitoring
+
+import (
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/api"
+	monitoring "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
+)
+
+type Client struct {
+	UserDefinedPolicies *api.UserDefinedPoliciesApi
+	APIClientInstance   *monitoring.ApiClient
+}
+
+func NewMonitoringClient(credentials client.Credentials) (*Client, error) {
+	var baseClient *monitoring.ApiClient
+
+	pcClient := monitoring.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
+		baseClient = pcClient
+	}
+
+	return &Client{
+		UserDefinedPolicies: api.NewUserDefinedPoliciesApi(baseClient),
+	}, nil
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_uda_policies_v2.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_uda_policies_v2.go
@@ -1,0 +1,128 @@
+package monitoringv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixUdaPoliciesV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DatasourceNutanixUdaPoliciesV2Read,
+		Schema: map[string]*schema.Schema{
+			"uda_policies": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ext_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "A globally unique identifier of an instance that is suitable for external consumption.",
+						},
+						"tenant_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "A globally unique identifier that represents the tenant that owns this entity.",
+						},
+						"links": schemaForLinks(),
+						"title": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Title of the policy.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Description of the policy.",
+						},
+						"entity_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Entity type associated with the User-Defined Alert policy. Allowed values are VM, node and cluster.",
+						},
+						"trigger_conditions": schemaForTriggerConditionsComputed(),
+						"filters": schemaForFiltersComputed(),
+						"impact_types": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "Impact types for the associated resulting alert.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"is_auto_resolved": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether the auto-resolve feature is enabled for this policy.",
+						},
+						"is_enabled": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Enable/Disable flag for the policy.",
+						},
+						"trigger_wait_period": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Waiting duration in seconds before triggering the alert, when the specified condition is met.",
+						},
+						"created_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Username of the user who created the policy.",
+						},
+						"last_updated_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Last updated time of the policy in ISO 8601 format.",
+						},
+						"policies_to_override": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "List of IDs of the alert policies that should be overridden.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"related_policies": schemaForRelatedPoliciesComputed(),
+						"is_expected_to_error_on_conflict": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Error when conflicting alert policies are found.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func DatasourceNutanixUdaPoliciesV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	resp, err := conn.UserDefinedPolicies.ListUdaPolicies(nil, nil, nil, nil, nil)
+	if err != nil {
+		return diag.Errorf("error while listing User-Defined Alert policies: %s", err)
+	}
+
+	if resp.Data == nil {
+		if err := d.Set("uda_policies", []map[string]interface{}{}); err != nil {
+			return diag.Errorf("error setting User-Defined Alert policies: %s", err)
+		}
+		d.SetId(utils.GenUUID())
+		return nil
+	}
+
+	getResp := resp.Data.GetValue().([]serviceability.UserDefinedPolicy)
+
+	if err := d.Set("uda_policies", flattenUdaPolicies(getResp)); err != nil {
+		return diag.Errorf("error setting User-Defined Alert policies: %s", err)
+	}
+
+	d.SetId(utils.GenUUID())
+	return nil
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_uda_policies_v2_test.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_uda_policies_v2_test.go
@@ -1,0 +1,57 @@
+package monitoringv2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const datasourceNameUdaPolicies = "data.nutanix_uda_policies_v2.test"
+
+func TestAccV2NutanixUdaPoliciesDatasource_Basic(t *testing.T) {
+	r := acctest.RandInt()
+	title := fmt.Sprintf("tf-test-uda-policy-list-%d", r)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testUdaPoliciesDatasourceConfig(title),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameUdaPolicies, "uda_policies.#"),
+				),
+			},
+		},
+	})
+}
+
+func testUdaPoliciesDatasourceConfig(title string) string {
+	return fmt.Sprintf(`
+resource "nutanix_uda_policy_v2" "list_test" {
+  title       = "%s"
+  entity_type = "vm"
+  is_enabled  = true
+  trigger_wait_period = 600
+
+  trigger_conditions {
+    condition {
+      metric_name = "hypervisor_cpu_usage_ppm"
+      operator    = "GREATER_THAN"
+      threshold_value {
+        int_value = 900000
+      }
+    }
+    condition_type = "STATIC_THRESHOLD"
+    severity_level = "CRITICAL"
+  }
+}
+
+data "nutanix_uda_policies_v2" "test" {
+  depends_on = [nutanix_uda_policy_v2.list_test]
+}
+`, title)
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_uda_policy_v2.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_uda_policy_v2.go
@@ -1,0 +1,161 @@
+package monitoringv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixUdaPolicyV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DatasourceNutanixUdaPolicyV2Read,
+		Schema: map[string]*schema.Schema{
+			"ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "A globally unique identifier of an instance that is suitable for external consumption.",
+			},
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A globally unique identifier that represents the tenant that owns this entity.",
+			},
+			"links": schemaForLinks(),
+			"title": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Title of the policy.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Description of the policy.",
+			},
+			"entity_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Entity type associated with the User-Defined Alert policy. Allowed values are VM, node and cluster.",
+			},
+			"trigger_conditions": schemaForTriggerConditionsComputed(),
+			"filters": schemaForFiltersComputed(),
+			"impact_types": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Impact types for the associated resulting alert.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"is_auto_resolved": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates whether the auto-resolve feature is enabled for this policy.",
+			},
+			"is_enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Enable/Disable flag for the policy.",
+			},
+			"trigger_wait_period": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Waiting duration in seconds before triggering the alert, when the specified condition is met.",
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Username of the user who created the policy.",
+			},
+			"last_updated_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Last updated time of the policy in ISO 8601 format.",
+			},
+			"policies_to_override": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of IDs of the alert policies that should be overridden.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"related_policies": schemaForRelatedPoliciesComputed(),
+			"is_expected_to_error_on_conflict": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Error when conflicting alert policies are found.",
+			},
+		},
+	}
+}
+
+func DatasourceNutanixUdaPolicyV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	extID := d.Get("ext_id").(string)
+
+	resp, err := conn.UserDefinedPolicies.GetUdaPolicyById(utils.StringPtr(extID))
+	if err != nil {
+		return diag.Errorf("error while fetching User-Defined Alert policy: %s", err)
+	}
+
+	getResp := resp.Data.GetValue().(serviceability.UserDefinedPolicy)
+
+	if err := d.Set("tenant_id", getResp.TenantId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("links", flattenLinks(getResp.Links)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("title", getResp.Title); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("description", getResp.Description); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("entity_type", getResp.EntityType); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("trigger_conditions", flattenTriggerConditions(getResp.TriggerConditions)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("filters", flattenFilters(getResp.Filters)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("impact_types", flattenImpactTypes(getResp.ImpactTypes)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_auto_resolved", getResp.IsAutoResolved); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_enabled", getResp.IsEnabled); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("trigger_wait_period", getResp.TriggerWaitPeriod); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("created_by", getResp.CreatedBy); err != nil {
+		return diag.FromErr(err)
+	}
+	if getResp.LastUpdatedTime != nil {
+		if err := d.Set("last_updated_time", getResp.LastUpdatedTime.String()); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err := d.Set("policies_to_override", getResp.PoliciesToOverride); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("related_policies", flattenRelatedPolicies(getResp.RelatedPolicies)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_expected_to_error_on_conflict", getResp.IsExpectedToErrorOnConflict); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(extID)
+	return nil
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_uda_policy_v2_test.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_uda_policy_v2_test.go
@@ -1,0 +1,63 @@
+package monitoringv2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const datasourceNameUdaPolicy = "data.nutanix_uda_policy_v2.test"
+
+func TestAccV2NutanixUdaPolicyDatasource_Basic(t *testing.T) {
+	r := acctest.RandInt()
+	title := fmt.Sprintf("tf-test-uda-policy-ds-%d", r)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testUdaPolicyDatasourceConfig(title),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameUdaPolicy, "ext_id"),
+					resource.TestCheckResourceAttr(datasourceNameUdaPolicy, "title", title),
+					resource.TestCheckResourceAttr(datasourceNameUdaPolicy, "entity_type", "vm"),
+					resource.TestCheckResourceAttr(datasourceNameUdaPolicy, "trigger_conditions.0.condition.0.metric_name", "hypervisor_cpu_usage_ppm"),
+					resource.TestCheckResourceAttr(datasourceNameUdaPolicy, "trigger_conditions.0.condition.0.operator", "GREATER_THAN"),
+					resource.TestCheckResourceAttr(datasourceNameUdaPolicy, "trigger_conditions.0.condition_type", "STATIC_THRESHOLD"),
+					resource.TestCheckResourceAttr(datasourceNameUdaPolicy, "trigger_conditions.0.severity_level", "CRITICAL"),
+				),
+			},
+		},
+	})
+}
+
+func testUdaPolicyDatasourceConfig(title string) string {
+	return fmt.Sprintf(`
+resource "nutanix_uda_policy_v2" "ds_test" {
+  title       = "%s"
+  entity_type = "vm"
+  is_enabled  = true
+  trigger_wait_period = 600
+
+  trigger_conditions {
+    condition {
+      metric_name = "hypervisor_cpu_usage_ppm"
+      operator    = "GREATER_THAN"
+      threshold_value {
+        int_value = 900000
+      }
+    }
+    condition_type = "STATIC_THRESHOLD"
+    severity_level = "CRITICAL"
+  }
+}
+
+data "nutanix_uda_policy_v2" "test" {
+  ext_id = nutanix_uda_policy_v2.ds_test.id
+}
+`, title)
+}

--- a/nutanix/services/monitoringv2/helpers.go
+++ b/nutanix/services/monitoringv2/helpers.go
@@ -1,0 +1,628 @@
+package monitoringv2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/common/v1/response"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/common"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func schemaForLinks() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"href": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The URL at which the entity described by the link can be accessed.",
+				},
+				"rel": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "A name that identifies the relationship of the link to the object that is returned by the URL.",
+				},
+			},
+		},
+	}
+}
+
+func schemaForTriggerConditionsComputed() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Computed:    true,
+		Description: "Trigger conditions for the policy.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"condition": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"metric_name": {
+								Type:        schema.TypeString,
+								Computed:    true,
+								Description: "The metric key.",
+							},
+							"operator": {
+								Type:        schema.TypeString,
+								Computed:    true,
+								Description: "Comparison operator.",
+							},
+							"threshold_value": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"int_value": {
+											Type:        schema.TypeInt,
+											Computed:    true,
+											Description: "Denotes a value of type integer.",
+										},
+										"double_value": {
+											Type:        schema.TypeFloat,
+											Computed:    true,
+											Description: "Denotes a value of type double.",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"condition_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"severity_level": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+func schemaForTriggerConditionsInput() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Required:    true,
+		Description: "Trigger conditions for the policy. If there are multiple trigger conditions, all of them will be considered during the operation.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"condition": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"metric_name": {
+								Type:        schema.TypeString,
+								Required:    true,
+								Description: "The metric key.",
+							},
+							"operator": {
+								Type:        schema.TypeString,
+								Required:    true,
+								Description: "Comparison operator.",
+							},
+							"threshold_value": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"int_value": {
+											Type:        schema.TypeInt,
+											Optional:    true,
+											Description: "Denotes a value of type integer.",
+										},
+										"double_value": {
+											Type:        schema.TypeFloat,
+											Optional:    true,
+											Description: "Denotes a value of type double.",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"condition_type": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "Condition type.",
+				},
+				"severity_level": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "Severity level.",
+				},
+			},
+		},
+	}
+}
+
+func schemaForFiltersComputed() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Computed:    true,
+		Description: "Filter criteria for narrowing down the entities on which User-Defined Alert policies can be set up.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"entity_filter": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"ext_id": {
+								Type:        schema.TypeString,
+								Computed:    true,
+								Description: "Entity UUID on which the User-Defined Alert policy should be set up.",
+							},
+						},
+					},
+				},
+				"group_filter": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"ext_id": {
+								Type:        schema.TypeString,
+								Computed:    true,
+								Description: "Entity UUID of the group entity type on which the User-Defined Alert policy should be set up.",
+							},
+							"type": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemaForFiltersInput() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		Computed:    true,
+		MaxItems:    1,
+		Description: "Filter criteria for narrowing down the entities on which User-Defined Alert policies can be set up.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"entity_filter": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"ext_id": {
+								Type:        schema.TypeString,
+								Required:    true,
+								Description: "Entity UUID on which the User-Defined Alert policy should be set up.",
+							},
+						},
+					},
+				},
+				"group_filter": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"ext_id": {
+								Type:        schema.TypeString,
+								Required:    true,
+								Description: "Entity UUID of the group entity type on which the User-Defined Alert policy should be set up.",
+							},
+							"type": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemaForRelatedPoliciesComputed() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Computed:    true,
+		Description: "List of alert policies that are related to the entities of the current policy.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"entity_uuid": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "UUID of the entity the User-Defined Alert policy is associated with.",
+				},
+				"policy_ids": {
+					Type:        schema.TypeList,
+					Computed:    true,
+					Description: "Policy IDs associated with the specified entity.",
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+			},
+		},
+	}
+}
+
+// Flatten functions
+
+func flattenLinks(links []response.ApiLink) []map[string]interface{} {
+	if links == nil {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(links))
+	for i, link := range links {
+		result[i] = map[string]interface{}{
+			"href": link.Href,
+			"rel":  link.Rel,
+		}
+	}
+	return result
+}
+
+func flattenTriggerConditions(conditions []serviceability.TriggerCondition) []map[string]interface{} {
+	if conditions == nil {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(conditions))
+	for i, tc := range conditions {
+		condMap := map[string]interface{}{}
+
+		if tc.Condition != nil {
+			conditionList := []map[string]interface{}{flattenCondition(tc.Condition)}
+			condMap["condition"] = conditionList
+		} else {
+			condMap["condition"] = []map[string]interface{}{}
+		}
+
+		if tc.ConditionType != nil {
+			condMap["condition_type"] = tc.ConditionType.GetName()
+		} else {
+			condMap["condition_type"] = ""
+		}
+
+		if tc.SeverityLevel != nil {
+			condMap["severity_level"] = tc.SeverityLevel.GetName()
+		} else {
+			condMap["severity_level"] = ""
+		}
+
+		result[i] = condMap
+	}
+	return result
+}
+
+func flattenCondition(cond *serviceability.Condition) map[string]interface{} {
+	condMap := map[string]interface{}{
+		"metric_name": "",
+		"operator":    "",
+	}
+
+	if cond.MetricName != nil {
+		condMap["metric_name"] = utils.StringValue(cond.MetricName)
+	}
+	if cond.Operator != nil {
+		condMap["operator"] = cond.Operator.GetName()
+	}
+
+	condMap["threshold_value"] = flattenThresholdValue(cond.ThresholdValue)
+	return condMap
+}
+
+func flattenThresholdValue(tv *serviceability.OneOfConditionThresholdValue) []map[string]interface{} {
+	if tv == nil || tv.ObjectType_ == nil {
+		return []map[string]interface{}{}
+	}
+
+	valueMap := map[string]interface{}{
+		"int_value":    0,
+		"double_value": 0.0,
+	}
+
+	val := tv.GetValue()
+	if val != nil {
+		switch *tv.ObjectType_ {
+		case "monitoring.v4.common.IntValue":
+			if intVal, ok := val.(common.IntValue); ok && intVal.IntValue != nil {
+				valueMap["int_value"] = int(utils.Int64Value(intVal.IntValue))
+			}
+		case "monitoring.v4.common.DoubleValue":
+			if doubleVal, ok := val.(common.DoubleValue); ok && doubleVal.DoubleValue != nil {
+				valueMap["double_value"] = utils.Float64Value(doubleVal.DoubleValue)
+			}
+		}
+	}
+
+	return []map[string]interface{}{valueMap}
+}
+
+func flattenFilters(filters *serviceability.OneOfUserDefinedPolicyFilters) []map[string]interface{} {
+	if filters == nil || filters.ObjectType_ == nil {
+		return []map[string]interface{}{}
+	}
+
+	filterMap := map[string]interface{}{
+		"entity_filter": []map[string]interface{}{},
+		"group_filter":  []map[string]interface{}{},
+	}
+
+	val := filters.GetValue()
+	if val != nil {
+		switch v := val.(type) {
+		case []serviceability.EntityFilter:
+			entityFilters := make([]map[string]interface{}, len(v))
+			for i, ef := range v {
+				entityFilters[i] = map[string]interface{}{
+					"ext_id": utils.StringValue(ef.ExtId),
+				}
+			}
+			filterMap["entity_filter"] = entityFilters
+		case []serviceability.GroupFilter:
+			groupFilters := make([]map[string]interface{}, len(v))
+			for i, gf := range v {
+				gfMap := map[string]interface{}{
+					"ext_id": utils.StringValue(gf.ExtId),
+					"type":   "",
+				}
+				if gf.Type != nil {
+					gfMap["type"] = gf.Type.GetName()
+				}
+				groupFilters[i] = gfMap
+			}
+			filterMap["group_filter"] = groupFilters
+		}
+	}
+
+	return []map[string]interface{}{filterMap}
+}
+
+func flattenImpactTypes(impactTypes []common.ImpactType) []string {
+	if impactTypes == nil {
+		return nil
+	}
+	result := make([]string, len(impactTypes))
+	for i, it := range impactTypes {
+		result[i] = it.GetName()
+	}
+	return result
+}
+
+func flattenRelatedPolicies(policies []serviceability.RelatedPolicy) []map[string]interface{} {
+	if policies == nil {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(policies))
+	for i, rp := range policies {
+		result[i] = map[string]interface{}{
+			"entity_uuid": utils.StringValue(rp.EntityUuid),
+			"policy_ids":  rp.PolicyIds,
+		}
+	}
+	return result
+}
+
+func flattenUdaPolicies(policies []serviceability.UserDefinedPolicy) []map[string]interface{} {
+	if policies == nil {
+		return []map[string]interface{}{}
+	}
+	result := make([]map[string]interface{}, len(policies))
+	for i, policy := range policies {
+		pMap := map[string]interface{}{
+			"ext_id":                           utils.StringValue(policy.ExtId),
+			"tenant_id":                        policy.TenantId,
+			"links":                            flattenLinks(policy.Links),
+			"title":                            policy.Title,
+			"description":                      policy.Description,
+			"entity_type":                      policy.EntityType,
+			"trigger_conditions":               flattenTriggerConditions(policy.TriggerConditions),
+			"filters":                          flattenFilters(policy.Filters),
+			"impact_types":                     flattenImpactTypes(policy.ImpactTypes),
+			"is_auto_resolved":                 policy.IsAutoResolved,
+			"is_enabled":                       policy.IsEnabled,
+			"trigger_wait_period":              policy.TriggerWaitPeriod,
+			"created_by":                       policy.CreatedBy,
+			"policies_to_override":             policy.PoliciesToOverride,
+			"related_policies":                 flattenRelatedPolicies(policy.RelatedPolicies),
+			"is_expected_to_error_on_conflict": policy.IsExpectedToErrorOnConflict,
+		}
+		if policy.LastUpdatedTime != nil {
+			pMap["last_updated_time"] = policy.LastUpdatedTime.String()
+		} else {
+			pMap["last_updated_time"] = ""
+		}
+		result[i] = pMap
+	}
+	return result
+}
+
+// Expand functions
+
+func expandTriggerConditions(tcList []interface{}) []serviceability.TriggerCondition {
+	if len(tcList) == 0 {
+		return nil
+	}
+	result := make([]serviceability.TriggerCondition, len(tcList))
+	for i, v := range tcList {
+		tcMap := v.(map[string]interface{})
+		tc := *serviceability.NewTriggerCondition()
+
+		if condList, ok := tcMap["condition"].([]interface{}); ok && len(condList) > 0 {
+			tc.Condition = expandCondition(condList[0].(map[string]interface{}))
+		}
+
+		if ct, ok := tcMap["condition_type"].(string); ok && ct != "" {
+			ctVal := conditionTypeFromString(ct)
+			tc.ConditionType = ctVal.Ref()
+		}
+
+		if sl, ok := tcMap["severity_level"].(string); ok && sl != "" {
+			slVal := policySeverityLevelFromString(sl)
+			tc.SeverityLevel = slVal.Ref()
+		}
+
+		result[i] = tc
+	}
+	return result
+}
+
+func expandCondition(condMap map[string]interface{}) *serviceability.Condition {
+	cond := serviceability.NewCondition()
+
+	if mn, ok := condMap["metric_name"].(string); ok && mn != "" {
+		cond.MetricName = utils.StringPtr(mn)
+	}
+
+	if op, ok := condMap["operator"].(string); ok && op != "" {
+		opVal := comparisonOperatorFromString(op)
+		cond.Operator = opVal.Ref()
+	}
+
+	if tvList, ok := condMap["threshold_value"].([]interface{}); ok && len(tvList) > 0 {
+		cond.ThresholdValue = expandThresholdValue(tvList[0].(map[string]interface{}))
+	}
+
+	return cond
+}
+
+func expandThresholdValue(tvMap map[string]interface{}) *serviceability.OneOfConditionThresholdValue {
+	tv := serviceability.NewOneOfConditionThresholdValue()
+
+	if intVal, ok := tvMap["int_value"].(int); ok && intVal != 0 {
+		intV := common.NewIntValue()
+		intV.IntValue = utils.Int64Ptr(int64(intVal))
+		tv.SetValue(*intV)
+	} else if doubleVal, ok := tvMap["double_value"].(float64); ok && doubleVal != 0 {
+		doubleV := common.NewDoubleValue()
+		doubleV.DoubleValue = utils.Float64Ptr(doubleVal)
+		tv.SetValue(*doubleV)
+	}
+
+	return tv
+}
+
+func expandFilters(filterList []interface{}) *serviceability.OneOfUserDefinedPolicyFilters {
+	if len(filterList) == 0 {
+		return nil
+	}
+
+	filterMap := filterList[0].(map[string]interface{})
+	filters := serviceability.NewOneOfUserDefinedPolicyFilters()
+
+	if entityFilters, ok := filterMap["entity_filter"].([]interface{}); ok && len(entityFilters) > 0 {
+		efs := make([]serviceability.EntityFilter, len(entityFilters))
+		for i, ef := range entityFilters {
+			efMap := ef.(map[string]interface{})
+			efs[i] = serviceability.EntityFilter{
+				ExtId: utils.StringPtr(efMap["ext_id"].(string)),
+			}
+		}
+		filters.SetValue(efs)
+	} else if groupFilters, ok := filterMap["group_filter"].([]interface{}); ok && len(groupFilters) > 0 {
+		gfs := make([]serviceability.GroupFilter, len(groupFilters))
+		for i, gf := range groupFilters {
+			gfMap := gf.(map[string]interface{})
+			gfs[i] = serviceability.GroupFilter{
+				ExtId: utils.StringPtr(gfMap["ext_id"].(string)),
+			}
+			if t, tok := gfMap["type"].(string); tok && t != "" {
+				getVal := groupEntityTypeFromString(t)
+				gfs[i].Type = getVal.Ref()
+			}
+		}
+		filters.SetValue(gfs)
+	}
+
+	return filters
+}
+
+func expandImpactTypes(impactList []interface{}) []common.ImpactType {
+	if len(impactList) == 0 {
+		return nil
+	}
+	result := make([]common.ImpactType, len(impactList))
+	for i, v := range impactList {
+		result[i] = impactTypeFromString(v.(string))
+	}
+	return result
+}
+
+// Enum conversion helpers
+
+func conditionTypeFromString(s string) common.ConditionType {
+	switch s {
+	case "STATIC_THRESHOLD":
+		return common.CONDITIONTYPE_STATIC_THRESHOLD
+	default:
+		return common.CONDITIONTYPE_UNKNOWN
+	}
+}
+
+func policySeverityLevelFromString(s string) serviceability.PolicySeverityLevel {
+	switch s {
+	case "WARNING":
+		return serviceability.POLICYSEVERITYLEVEL_WARNING
+	case "CRITICAL":
+		return serviceability.POLICYSEVERITYLEVEL_CRITICAL
+	default:
+		return serviceability.POLICYSEVERITYLEVEL_UNKNOWN
+	}
+}
+
+func comparisonOperatorFromString(s string) common.ComparisonOperator {
+	switch s {
+	case "EQUAL_TO":
+		return common.COMPARISONOPERATOR_EQUAL_TO
+	case "GREATER_THAN":
+		return common.COMPARISONOPERATOR_GREATER_THAN
+	case "GREATER_THAN_OR_EQUAL_TO":
+		return common.COMPARISONOPERATOR_GREATER_THAN_OR_EQUAL_TO
+	case "LESS_THAN":
+		return common.COMPARISONOPERATOR_LESS_THAN
+	case "LESS_THAN_OR_EQUAL_TO":
+		return common.COMPARISONOPERATOR_LESS_THAN_OR_EQUAL_TO
+	default:
+		return common.COMPARISONOPERATOR_UNKNOWN
+	}
+}
+
+func groupEntityTypeFromString(s string) serviceability.GroupEntityType {
+	switch s {
+	case "CATEGORY":
+		return serviceability.GROUPENTITYTYPE_CATEGORY
+	case "CLUSTER":
+		return serviceability.GROUPENTITYTYPE_CLUSTER
+	default:
+		return serviceability.GROUPENTITYTYPE_UNKNOWN
+	}
+}
+
+func impactTypeFromString(s string) common.ImpactType {
+	switch s {
+	case "AVAILABILITY":
+		return common.IMPACTTYPE_AVAILABILITY
+	case "CAPACITY":
+		return common.IMPACTTYPE_CAPACITY
+	case "CONFIGURATION":
+		return common.IMPACTTYPE_CONFIGURATION
+	case "PERFORMANCE":
+		return common.IMPACTTYPE_PERFORMANCE
+	case "SYSTEM_INDICATOR":
+		return common.IMPACTTYPE_SYSTEM_INDICATOR
+	case "CPU_CAPACITY":
+		return common.IMPACTTYPE_CPU_CAPACITY
+	default:
+		return common.IMPACTTYPE_UNKNOWN
+	}
+}

--- a/nutanix/services/monitoringv2/main_test.go
+++ b/nutanix/services/monitoringv2/main_test.go
@@ -1,0 +1,38 @@
+package monitoringv2_test
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"testing"
+)
+
+type TestConfig struct {
+}
+
+var testVars TestConfig
+
+var (
+	path, _  = os.Getwd()
+	filepath = path + "/../../../test_config_v2.json"
+)
+
+func loadVars(filepath string, varStruct interface{}) {
+	configData, err := os.ReadFile(filepath)
+	if err != nil {
+		log.Printf("Got this error while reading config.json: %s", err.Error())
+		os.Exit(1)
+	}
+
+	err = json.Unmarshal(configData, varStruct)
+	if err != nil {
+		log.Printf("Got this error while unmarshalling config.json: %s", err.Error())
+		os.Exit(1)
+	}
+}
+
+func TestMain(m *testing.M) {
+	log.Println("Setting up monitoring v2 tests")
+	loadVars("../../../test_config_v2.json", &testVars)
+	os.Exit(m.Run())
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_find_conflicting_uda_policies_v2.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_find_conflicting_uda_policies_v2.go
@@ -1,0 +1,234 @@
+package monitoringv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func ResourceNutanixFindConflictingUdaPoliciesV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: ResourceNutanixFindConflictingUdaPoliciesV2Create,
+		ReadContext:   ResourceNutanixFindConflictingUdaPoliciesV2Read,
+		DeleteContext: ResourceNutanixFindConflictingUdaPoliciesV2Delete,
+		Schema: map[string]*schema.Schema{
+			"title": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Title of the policy.",
+			},
+			"entity_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Entity type associated with the User-Defined Alert policy. Allowed values are VM, node and cluster.",
+			},
+			"trigger_conditions": {
+				Type:        schema.TypeList,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Trigger conditions for the policy.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"condition": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"metric_name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"operator": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"threshold_value": {
+										Type:     schema.TypeList,
+										Required: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"int_value": {
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+												"double_value": {
+													Type:     schema.TypeFloat,
+													Optional: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"condition_type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"severity_level": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Description of the policy.",
+			},
+			"filters": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"entity_filter": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ext_id": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"group_filter": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ext_id": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"impact_types": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"is_auto_resolved": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"is_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"trigger_wait_period": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+			"conflicting_policies": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of conflicting policies.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ext_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Unique UUID associated with the User-Defined Alert policy, that conflicts with the given policy.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func ResourceNutanixFindConflictingUdaPoliciesV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	body := serviceability.NewUserDefinedPolicy()
+
+	if title, ok := d.GetOk("title"); ok {
+		body.Title = utils.StringPtr(title.(string))
+	}
+	if entityType, ok := d.GetOk("entity_type"); ok {
+		body.EntityType = utils.StringPtr(entityType.(string))
+	}
+	if desc, ok := d.GetOk("description"); ok {
+		body.Description = utils.StringPtr(desc.(string))
+	}
+	if tc, ok := d.GetOk("trigger_conditions"); ok {
+		body.TriggerConditions = expandTriggerConditions(tc.([]interface{}))
+	}
+	if f, ok := d.GetOk("filters"); ok {
+		body.Filters = expandFilters(f.([]interface{}))
+	}
+	if it, ok := d.GetOk("impact_types"); ok {
+		body.ImpactTypes = expandImpactTypes(it.([]interface{}))
+	}
+	if iar, ok := d.GetOk("is_auto_resolved"); ok {
+		body.IsAutoResolved = utils.BoolPtr(iar.(bool))
+	}
+	if ie, ok := d.GetOk("is_enabled"); ok {
+		body.IsEnabled = utils.BoolPtr(ie.(bool))
+	}
+	if twp, ok := d.GetOk("trigger_wait_period"); ok {
+		body.TriggerWaitPeriod = utils.Int64Ptr(int64(twp.(int)))
+	}
+
+	resp, err := conn.UserDefinedPolicies.FindConflictingUdaPolicies(body)
+	if err != nil {
+		return diag.Errorf("error while finding conflicting User-Defined Alert policies: %v", err)
+	}
+
+	if resp.Data != nil {
+		conflicts := resp.Data.GetValue().([]serviceability.ConflictingPolicy)
+		conflictList := make([]map[string]interface{}, len(conflicts))
+		for i, cp := range conflicts {
+			conflictList[i] = map[string]interface{}{
+				"ext_id": utils.StringValue(cp.ExtId),
+			}
+		}
+		if err := d.Set("conflicting_policies", conflictList); err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		if err := d.Set("conflicting_policies", []map[string]interface{}{}); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	d.SetId(utils.GenUUID())
+	return nil
+}
+
+func ResourceNutanixFindConflictingUdaPoliciesV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func ResourceNutanixFindConflictingUdaPoliciesV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	d.SetId("")
+	return nil
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_find_conflicting_uda_policies_v2_test.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_find_conflicting_uda_policies_v2_test.go
@@ -1,0 +1,51 @@
+package monitoringv2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const resourceNameFindConflicting = "nutanix_find_conflicting_uda_policies_v2.test"
+
+func TestAccV2NutanixFindConflictingUdaPoliciesResource_Basic(t *testing.T) {
+	r := acctest.RandInt()
+	title := fmt.Sprintf("tf-test-uda-conflict-%d", r)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testFindConflictingUdaPoliciesResourceConfig(title),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameFindConflicting, "conflicting_policies.#"),
+				),
+			},
+		},
+	})
+}
+
+func testFindConflictingUdaPoliciesResourceConfig(title string) string {
+	return fmt.Sprintf(`
+resource "nutanix_find_conflicting_uda_policies_v2" "test" {
+  title       = "%s"
+  entity_type = "vm"
+
+  trigger_conditions {
+    condition {
+      metric_name = "hypervisor_cpu_usage_ppm"
+      operator    = "GREATER_THAN"
+      threshold_value {
+        int_value = 900000
+      }
+    }
+    condition_type = "STATIC_THRESHOLD"
+    severity_level = "CRITICAL"
+  }
+}
+`, title)
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_uda_policy_v2.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_uda_policy_v2.go
@@ -1,0 +1,305 @@
+package monitoringv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func ResourceNutanixUdaPolicyV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: ResourceNutanixUdaPolicyV2Create,
+		ReadContext:   ResourceNutanixUdaPolicyV2Read,
+		UpdateContext: ResourceNutanixUdaPolicyV2Update,
+		DeleteContext: ResourceNutanixUdaPolicyV2Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"ext_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A globally unique identifier of an instance that is suitable for external consumption.",
+			},
+			"title": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Title of the policy.",
+			},
+			"entity_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Entity type associated with the User-Defined Alert policy. Allowed values are VM, node and cluster.",
+			},
+			"trigger_conditions": schemaForTriggerConditionsInput(),
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Description of the policy.",
+			},
+			"filters": schemaForFiltersInput(),
+			"impact_types": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Description: "Impact types for the associated resulting alert.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"is_auto_resolved": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Indicates whether the auto-resolve feature is enabled for this policy.",
+			},
+			"is_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Enable/Disable flag for the policy.",
+			},
+			"is_expected_to_error_on_conflict": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Error when conflicting alert policies are found.",
+			},
+			"trigger_wait_period": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "Waiting duration in seconds before triggering the alert, when the specified condition is met. It is set to 600s by default.",
+			},
+			"policies_to_override": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Description: "List of IDs of the alert policies that should be overridden.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A globally unique identifier that represents the tenant that owns this entity.",
+			},
+			"links": schemaForLinks(),
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Username of the user who created the policy.",
+			},
+			"last_updated_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Last updated time of the policy in ISO 8601 format.",
+			},
+			"related_policies": schemaForRelatedPoliciesComputed(),
+		},
+	}
+}
+
+func ResourceNutanixUdaPolicyV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	body := serviceability.NewUserDefinedPolicy()
+
+	if title, ok := d.GetOk("title"); ok {
+		body.Title = utils.StringPtr(title.(string))
+	}
+	if entityType, ok := d.GetOk("entity_type"); ok {
+		body.EntityType = utils.StringPtr(entityType.(string))
+	}
+	if desc, ok := d.GetOk("description"); ok {
+		body.Description = utils.StringPtr(desc.(string))
+	}
+	if tc, ok := d.GetOk("trigger_conditions"); ok {
+		body.TriggerConditions = expandTriggerConditions(tc.([]interface{}))
+	}
+	if f, ok := d.GetOk("filters"); ok {
+		body.Filters = expandFilters(f.([]interface{}))
+	}
+	if it, ok := d.GetOk("impact_types"); ok {
+		body.ImpactTypes = expandImpactTypes(it.([]interface{}))
+	}
+	if iar, ok := d.GetOk("is_auto_resolved"); ok {
+		body.IsAutoResolved = utils.BoolPtr(iar.(bool))
+	}
+	if ie, ok := d.GetOk("is_enabled"); ok {
+		body.IsEnabled = utils.BoolPtr(ie.(bool))
+	}
+	if ieoc, ok := d.GetOk("is_expected_to_error_on_conflict"); ok {
+		body.IsExpectedToErrorOnConflict = utils.BoolPtr(ieoc.(bool))
+	}
+	if twp, ok := d.GetOk("trigger_wait_period"); ok {
+		body.TriggerWaitPeriod = utils.Int64Ptr(int64(twp.(int)))
+	}
+	if pto, ok := d.GetOk("policies_to_override"); ok {
+		ptoList := pto.([]interface{})
+		ptoStrings := make([]string, len(ptoList))
+		for i, v := range ptoList {
+			ptoStrings[i] = v.(string)
+		}
+		body.PoliciesToOverride = ptoStrings
+	}
+
+	resp, err := conn.UserDefinedPolicies.CreateUdaPolicy(body)
+	if err != nil {
+		return diag.Errorf("error while creating User-Defined Alert policy: %v", err)
+	}
+
+	getResp := resp.Data.GetValue().(serviceability.UserDefinedPolicy)
+	d.SetId(utils.StringValue(getResp.ExtId))
+
+	return ResourceNutanixUdaPolicyV2Read(ctx, d, meta)
+}
+
+func ResourceNutanixUdaPolicyV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	extID := d.Id()
+
+	resp, err := conn.UserDefinedPolicies.GetUdaPolicyById(utils.StringPtr(extID))
+	if err != nil {
+		return diag.Errorf("error while fetching User-Defined Alert policy: %s", err)
+	}
+
+	getResp := resp.Data.GetValue().(serviceability.UserDefinedPolicy)
+
+	if err := d.Set("ext_id", getResp.ExtId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("tenant_id", getResp.TenantId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("links", flattenLinks(getResp.Links)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("title", getResp.Title); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("description", getResp.Description); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("entity_type", getResp.EntityType); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("trigger_conditions", flattenTriggerConditions(getResp.TriggerConditions)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("filters", flattenFilters(getResp.Filters)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("impact_types", flattenImpactTypes(getResp.ImpactTypes)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_auto_resolved", getResp.IsAutoResolved); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_enabled", getResp.IsEnabled); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_expected_to_error_on_conflict", getResp.IsExpectedToErrorOnConflict); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("trigger_wait_period", getResp.TriggerWaitPeriod); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("created_by", getResp.CreatedBy); err != nil {
+		return diag.FromErr(err)
+	}
+	if getResp.LastUpdatedTime != nil {
+		if err := d.Set("last_updated_time", getResp.LastUpdatedTime.String()); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err := d.Set("policies_to_override", getResp.PoliciesToOverride); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("related_policies", flattenRelatedPolicies(getResp.RelatedPolicies)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func ResourceNutanixUdaPolicyV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	extID := d.Id()
+
+	readResp, err := conn.UserDefinedPolicies.GetUdaPolicyById(utils.StringPtr(extID))
+	if err != nil {
+		return diag.Errorf("error while fetching User-Defined Alert policy for update: %s", err)
+	}
+
+	getResp := readResp.Data.GetValue().(serviceability.UserDefinedPolicy)
+	body := &getResp
+
+	if d.HasChange("title") {
+		body.Title = utils.StringPtr(d.Get("title").(string))
+	}
+	if d.HasChange("entity_type") {
+		body.EntityType = utils.StringPtr(d.Get("entity_type").(string))
+	}
+	if d.HasChange("description") {
+		body.Description = utils.StringPtr(d.Get("description").(string))
+	}
+	if d.HasChange("trigger_conditions") {
+		body.TriggerConditions = expandTriggerConditions(d.Get("trigger_conditions").([]interface{}))
+	}
+	if d.HasChange("filters") {
+		body.Filters = expandFilters(d.Get("filters").([]interface{}))
+	}
+	if d.HasChange("impact_types") {
+		body.ImpactTypes = expandImpactTypes(d.Get("impact_types").([]interface{}))
+	}
+	if d.HasChange("is_auto_resolved") {
+		body.IsAutoResolved = utils.BoolPtr(d.Get("is_auto_resolved").(bool))
+	}
+	if d.HasChange("is_enabled") {
+		body.IsEnabled = utils.BoolPtr(d.Get("is_enabled").(bool))
+	}
+	if d.HasChange("is_expected_to_error_on_conflict") {
+		body.IsExpectedToErrorOnConflict = utils.BoolPtr(d.Get("is_expected_to_error_on_conflict").(bool))
+	}
+	if d.HasChange("trigger_wait_period") {
+		body.TriggerWaitPeriod = utils.Int64Ptr(int64(d.Get("trigger_wait_period").(int)))
+	}
+	if d.HasChange("policies_to_override") {
+		ptoList := d.Get("policies_to_override").([]interface{})
+		ptoStrings := make([]string, len(ptoList))
+		for i, v := range ptoList {
+			ptoStrings[i] = v.(string)
+		}
+		body.PoliciesToOverride = ptoStrings
+	}
+
+	_, err = conn.UserDefinedPolicies.UpdateUdaPolicyById(utils.StringPtr(extID), body)
+	if err != nil {
+		return diag.Errorf("error while updating User-Defined Alert policy: %v", err)
+	}
+
+	return ResourceNutanixUdaPolicyV2Read(ctx, d, meta)
+}
+
+func ResourceNutanixUdaPolicyV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	extID := d.Id()
+
+	_, err := conn.UserDefinedPolicies.DeleteUdaPolicyById(utils.StringPtr(extID))
+	if err != nil {
+		return diag.Errorf("error while deleting User-Defined Alert policy: %v", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/nutanix/services/monitoringv2/resource_nutanix_uda_policy_v2_test.go
+++ b/nutanix/services/monitoringv2/resource_nutanix_uda_policy_v2_test.go
@@ -1,0 +1,114 @@
+package monitoringv2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const resourceNameUdaPolicy = "nutanix_uda_policy_v2.test"
+
+func TestAccV2NutanixUdaPolicyResource_Basic(t *testing.T) {
+	r := acctest.RandInt()
+	title := fmt.Sprintf("tf-test-uda-policy-%d", r)
+	updatedTitle := fmt.Sprintf("tf-test-uda-policy-%d-updated", r)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testUdaPolicyV2CheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testUdaPolicyResourceConfig(title),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameUdaPolicy, "ext_id"),
+					resource.TestCheckResourceAttr(resourceNameUdaPolicy, "title", title),
+					resource.TestCheckResourceAttr(resourceNameUdaPolicy, "entity_type", "vm"),
+					resource.TestCheckResourceAttr(resourceNameUdaPolicy, "trigger_conditions.0.condition.0.metric_name", "hypervisor_cpu_usage_ppm"),
+					resource.TestCheckResourceAttr(resourceNameUdaPolicy, "trigger_conditions.0.condition.0.operator", "GREATER_THAN"),
+					resource.TestCheckResourceAttr(resourceNameUdaPolicy, "trigger_conditions.0.condition_type", "STATIC_THRESHOLD"),
+					resource.TestCheckResourceAttr(resourceNameUdaPolicy, "trigger_conditions.0.severity_level", "CRITICAL"),
+					resource.TestCheckResourceAttrSet(resourceNameUdaPolicy, "is_enabled"),
+					resource.TestCheckResourceAttrSet(resourceNameUdaPolicy, "trigger_wait_period"),
+				),
+			},
+			{
+				Config: testUdaPolicyResourceConfigUpdated(updatedTitle),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameUdaPolicy, "ext_id"),
+					resource.TestCheckResourceAttr(resourceNameUdaPolicy, "title", updatedTitle),
+					resource.TestCheckResourceAttr(resourceNameUdaPolicy, "entity_type", "vm"),
+					resource.TestCheckResourceAttr(resourceNameUdaPolicy, "description", "updated description"),
+					resource.TestCheckResourceAttr(resourceNameUdaPolicy, "trigger_conditions.0.condition.0.metric_name", "hypervisor_cpu_usage_ppm"),
+					resource.TestCheckResourceAttr(resourceNameUdaPolicy, "trigger_conditions.0.condition.0.operator", "GREATER_THAN"),
+					resource.TestCheckResourceAttr(resourceNameUdaPolicy, "trigger_conditions.0.condition_type", "STATIC_THRESHOLD"),
+					resource.TestCheckResourceAttr(resourceNameUdaPolicy, "trigger_conditions.0.severity_level", "WARNING"),
+				),
+			},
+		},
+	})
+}
+
+func testUdaPolicyV2CheckDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "nutanix_uda_policy_v2" {
+			continue
+		}
+		if rs.Primary.ID == "" {
+			continue
+		}
+	}
+	return nil
+}
+
+func testUdaPolicyResourceConfig(title string) string {
+	return fmt.Sprintf(`
+resource "nutanix_uda_policy_v2" "test" {
+  title       = "%s"
+  entity_type = "vm"
+  description = "test uda policy"
+  is_enabled  = true
+  trigger_wait_period = 600
+
+  trigger_conditions {
+    condition {
+      metric_name = "hypervisor_cpu_usage_ppm"
+      operator    = "GREATER_THAN"
+      threshold_value {
+        int_value = 900000
+      }
+    }
+    condition_type = "STATIC_THRESHOLD"
+    severity_level = "CRITICAL"
+  }
+}
+`, title)
+}
+
+func testUdaPolicyResourceConfigUpdated(title string) string {
+	return fmt.Sprintf(`
+resource "nutanix_uda_policy_v2" "test" {
+  title       = "%s"
+  entity_type = "vm"
+  description = "updated description"
+  is_enabled  = true
+  trigger_wait_period = 600
+
+  trigger_conditions {
+    condition {
+      metric_name = "hypervisor_cpu_usage_ppm"
+      operator    = "GREATER_THAN"
+      threshold_value {
+        int_value = 800000
+      }
+    }
+    condition_type = "STATIC_THRESHOLD"
+    severity_level = "WARNING"
+  }
+}
+`, title)
+}

--- a/website/docs/d/uda_policies_v2.html.markdown
+++ b/website/docs/d/uda_policies_v2.html.markdown
@@ -1,0 +1,89 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_uda_policies_v2"
+sidebar_current: "docs-nutanix-datasource-uda-policies-v2"
+description: |-
+  Fetches a list of User-Defined Alert policies.
+
+---
+
+# nutanix_uda_policies_v2
+
+Fetches a list of User-Defined Alert policies.
+
+## Example Usage
+
+```hcl
+data "nutanix_uda_policies_v2" "example" {}
+```
+
+## Argument Reference
+
+No arguments are required.
+
+## Attribute Reference
+
+* `uda_policies` - List of User-Defined Alert policies.
+
+### uda_policies
+
+* `ext_id` - A globally unique identifier of an instance that is suitable for external consumption.
+* `tenant_id` - A globally unique identifier that represents the tenant that owns this entity.
+* `links` - A HATEOAS style link for the response.
+* `title` - Title of the policy.
+* `description` - Description of the policy.
+* `entity_type` - Entity type associated with the User-Defined Alert policy. Allowed values are VM, node and cluster.
+* `trigger_conditions` - Trigger conditions for the policy.
+* `filters` - Filter criteria for narrowing down the entities on which User-Defined Alert policies can be set up.
+* `impact_types` - Impact types for the associated resulting alert.
+* `is_auto_resolved` - Indicates whether the auto-resolve feature is enabled for this policy.
+* `is_enabled` - Enable/Disable flag for the policy.
+* `trigger_wait_period` - Waiting duration in seconds before triggering the alert, when the specified condition is met.
+* `created_by` - Username of the user who created the policy.
+* `last_updated_time` - Last updated time of the policy in ISO 8601 format.
+* `policies_to_override` - List of IDs of the alert policies that should be overridden.
+* `related_policies` - List of alert policies that are related to the entities of the current policy.
+* `is_expected_to_error_on_conflict` - Error when conflicting alert policies are found.
+
+### links
+
+* `href` - The URL at which the entity described by the link can be accessed.
+* `rel` - A name that identifies the relationship of the link to the object that is returned by the URL.
+
+### trigger_conditions
+
+* `condition` - The condition for the trigger.
+* `condition_type` - The condition type.
+* `severity_level` - The severity level.
+
+#### condition
+
+* `metric_name` - The metric key.
+* `operator` - Comparison operator.
+* `threshold_value` - The threshold value that was used for the condition evaluation.
+
+##### threshold_value
+
+* `int_value` - Denotes a value of type integer.
+* `double_value` - Denotes a value of type double.
+
+### filters
+
+* `entity_filter` - List of entity filters.
+* `group_filter` - List of group filters.
+
+#### entity_filter
+
+* `ext_id` - Entity UUID on which the User-Defined Alert policy should be set up.
+
+#### group_filter
+
+* `ext_id` - Entity UUID of the group entity type on which the User-Defined Alert policy should be set up.
+* `type` - The group entity type.
+
+### related_policies
+
+* `entity_uuid` - UUID of the entity the User-Defined Alert policy is associated with.
+* `policy_ids` - Policy IDs associated with the specified entity.
+
+See detailed information in [Nutanix User-Defined Alert Policies](https://developers.nutanix.com/).

--- a/website/docs/d/uda_policy_v2.html.markdown
+++ b/website/docs/d/uda_policy_v2.html.markdown
@@ -1,0 +1,86 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_uda_policy_v2"
+sidebar_current: "docs-nutanix-datasource-uda-policy-v2"
+description: |-
+  Fetches the details of a User-Defined Alert policy identified by external identifier.
+
+---
+
+# nutanix_uda_policy_v2
+
+Fetches the details of a User-Defined Alert policy identified by external identifier.
+
+## Example Usage
+
+```hcl
+data "nutanix_uda_policy_v2" "example" {
+  ext_id = "00000000-0000-0000-0000-000000000000"
+}
+```
+
+## Argument Reference
+
+* `ext_id` - (Required) A globally unique identifier of an instance that is suitable for external consumption.
+
+## Attribute Reference
+
+* `tenant_id` - A globally unique identifier that represents the tenant that owns this entity.
+* `links` - A HATEOAS style link for the response.
+* `title` - Title of the policy.
+* `description` - Description of the policy.
+* `entity_type` - Entity type associated with the User-Defined Alert policy. Allowed values are VM, node and cluster.
+* `trigger_conditions` - Trigger conditions for the policy. If there are multiple trigger conditions, all of them will be considered during the operation.
+* `filters` - Filter criteria for narrowing down the entities on which User-Defined Alert policies can be set up.
+* `impact_types` - Impact types for the associated resulting alert.
+* `is_auto_resolved` - Indicates whether the auto-resolve feature is enabled for this policy.
+* `is_enabled` - Enable/Disable flag for the policy.
+* `trigger_wait_period` - Waiting duration in seconds before triggering the alert, when the specified condition is met.
+* `created_by` - Username of the user who created the policy.
+* `last_updated_time` - Last updated time of the policy in ISO 8601 format.
+* `policies_to_override` - List of IDs of the alert policies that should be overridden.
+* `related_policies` - List of alert policies that are related to the entities of the current policy.
+* `is_expected_to_error_on_conflict` - Error when conflicting alert policies are found.
+
+### links
+
+* `href` - The URL at which the entity described by the link can be accessed.
+* `rel` - A name that identifies the relationship of the link to the object that is returned by the URL.
+
+### trigger_conditions
+
+* `condition` - The condition for the trigger.
+* `condition_type` - The condition type.
+* `severity_level` - The severity level.
+
+#### condition
+
+* `metric_name` - The metric key.
+* `operator` - Comparison operator.
+* `threshold_value` - The threshold value that was used for the condition evaluation.
+
+##### threshold_value
+
+* `int_value` - Denotes a value of type integer.
+* `double_value` - Denotes a value of type double.
+
+### filters
+
+* `entity_filter` - List of entity filters.
+* `group_filter` - List of group filters.
+
+#### entity_filter
+
+* `ext_id` - Entity UUID on which the User-Defined Alert policy should be set up.
+
+#### group_filter
+
+* `ext_id` - Entity UUID of the group entity type on which the User-Defined Alert policy should be set up.
+* `type` - The group entity type.
+
+### related_policies
+
+* `entity_uuid` - UUID of the entity the User-Defined Alert policy is associated with.
+* `policy_ids` - Policy IDs associated with the specified entity.
+
+See detailed information in [Nutanix User-Defined Alert Policies](https://developers.nutanix.com/).

--- a/website/docs/r/find_conflicting_uda_policies_v2.html.markdown
+++ b/website/docs/r/find_conflicting_uda_policies_v2.html.markdown
@@ -1,0 +1,86 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_find_conflicting_uda_policies_v2"
+sidebar_current: "docs-nutanix-resource-find-conflicting-uda-policies-v2"
+description: |-
+  Fetches all the existing policies with conflicting criteria to a User-Defined Alert policy identified by external identifier.
+
+---
+
+# nutanix_find_conflicting_uda_policies_v2
+
+Fetches all the existing policies with conflicting criteria to a User-Defined Alert policy identified by external identifier.
+
+## Example Usage
+
+```hcl
+resource "nutanix_find_conflicting_uda_policies_v2" "example" {
+  title       = "conflict-check-policy"
+  entity_type = "VM"
+
+  trigger_conditions {
+    condition {
+      metric_name = "hypervisor_cpu_usage_ppm"
+      operator    = "GREATER_THAN"
+      threshold_value {
+        int_value = 900000
+      }
+    }
+    condition_type = "STATIC_THRESHOLD"
+    severity_level = "CRITICAL"
+  }
+}
+```
+
+## Argument Reference
+
+* `title` - (Required) Title of the policy.
+* `entity_type` - (Required) Entity type associated with the User-Defined Alert policy. Allowed values are VM, node and cluster.
+* `trigger_conditions` - (Required) Trigger conditions for the policy.
+* `description` - (Optional) Description of the policy.
+* `filters` - (Optional) Filter criteria for narrowing down the entities on which User-Defined Alert policies can be set up.
+* `impact_types` - (Optional) Impact types for the associated resulting alert.
+* `is_auto_resolved` - (Optional) Indicates whether the auto-resolve feature is enabled for this policy.
+* `is_enabled` - (Optional) Enable/Disable flag for the policy.
+* `trigger_wait_period` - (Optional) Waiting duration in seconds before triggering the alert, when the specified condition is met.
+
+### trigger_conditions
+
+* `condition` - (Required) The condition for the trigger.
+* `condition_type` - (Required) The condition type.
+* `severity_level` - (Required) The severity level.
+
+#### condition
+
+* `metric_name` - (Required) The metric key.
+* `operator` - (Required) Comparison operator.
+* `threshold_value` - (Required) The threshold value that was used for the condition evaluation.
+
+##### threshold_value
+
+* `int_value` - (Optional) Denotes a value of type integer.
+* `double_value` - (Optional) Denotes a value of type double.
+
+### filters
+
+* `entity_filter` - (Optional) List of entity filters.
+* `group_filter` - (Optional) List of group filters.
+
+#### entity_filter
+
+* `ext_id` - (Required) Entity UUID on which the User-Defined Alert policy should be set up.
+
+#### group_filter
+
+* `ext_id` - (Required) Entity UUID of the group entity type on which the User-Defined Alert policy should be set up.
+* `type` - (Required) The group entity type.
+
+## Attribute Reference
+
+* `conflicting_policies` - List of conflicting policies.
+
+### conflicting_policies
+
+* `ext_id` - Unique UUID associated with the User-Defined Alert policy, that conflicts with the given policy.
+
+See detailed information in [Nutanix User-Defined Alert Policies](https://developers.nutanix.com/).

--- a/website/docs/r/uda_policy_v2.html.markdown
+++ b/website/docs/r/uda_policy_v2.html.markdown
@@ -1,0 +1,110 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_uda_policy_v2"
+sidebar_current: "docs-nutanix-resource-uda-policy-v2"
+description: |-
+  Creates a new User-Defined Alert policy.
+
+---
+
+# nutanix_uda_policy_v2
+
+Creates a new User-Defined Alert policy.
+
+## Example Usage
+
+```hcl
+resource "nutanix_uda_policy_v2" "example" {
+  title       = "example-uda-policy"
+  entity_type = "VM"
+  description = "Example User-Defined Alert policy"
+  is_enabled  = true
+  trigger_wait_period = 600
+
+  trigger_conditions {
+    condition {
+      metric_name = "hypervisor_cpu_usage_ppm"
+      operator    = "GREATER_THAN"
+      threshold_value {
+        int_value = 900000
+      }
+    }
+    condition_type = "STATIC_THRESHOLD"
+    severity_level = "CRITICAL"
+  }
+}
+```
+
+## Argument Reference
+
+* `title` - (Required) Title of the policy.
+* `entity_type` - (Required) Entity type associated with the User-Defined Alert policy. Allowed values are VM, node and cluster.
+* `trigger_conditions` - (Required) Trigger conditions for the policy. If there are multiple trigger conditions, all of them will be considered during the operation.
+* `description` - (Optional) Description of the policy.
+* `filters` - (Optional) Filter criteria for narrowing down the entities on which User-Defined Alert policies can be set up.
+* `impact_types` - (Optional) Impact types for the associated resulting alert.
+* `is_auto_resolved` - (Optional) Indicates whether the auto-resolve feature is enabled for this policy.
+* `is_enabled` - (Optional) Enable/Disable flag for the policy.
+* `is_expected_to_error_on_conflict` - (Optional) Error when conflicting alert policies are found.
+* `trigger_wait_period` - (Optional) Waiting duration in seconds before triggering the alert, when the specified condition is met. It is set to 600s by default.
+* `policies_to_override` - (Optional) List of IDs of the alert policies that should be overridden.
+
+### trigger_conditions
+
+* `condition` - (Required) The condition for the trigger.
+* `condition_type` - (Required) The condition type.
+* `severity_level` - (Required) The severity level.
+
+#### condition
+
+* `metric_name` - (Required) The metric key.
+* `operator` - (Required) Comparison operator.
+* `threshold_value` - (Required) The threshold value that was used for the condition evaluation.
+
+##### threshold_value
+
+* `int_value` - (Optional) Denotes a value of type integer.
+* `double_value` - (Optional) Denotes a value of type double.
+
+### filters
+
+* `entity_filter` - (Optional) List of entity filters.
+* `group_filter` - (Optional) List of group filters.
+
+#### entity_filter
+
+* `ext_id` - (Required) Entity UUID on which the User-Defined Alert policy should be set up.
+
+#### group_filter
+
+* `ext_id` - (Required) Entity UUID of the group entity type on which the User-Defined Alert policy should be set up.
+* `type` - (Required) The group entity type.
+
+## Attribute Reference
+
+* `ext_id` - A globally unique identifier of an instance that is suitable for external consumption.
+* `tenant_id` - A globally unique identifier that represents the tenant that owns this entity.
+* `links` - A HATEOAS style link for the response.
+* `created_by` - Username of the user who created the policy.
+* `last_updated_time` - Last updated time of the policy in ISO 8601 format.
+* `related_policies` - List of alert policies that are related to the entities of the current policy.
+
+### links
+
+* `href` - The URL at which the entity described by the link can be accessed.
+* `rel` - A name that identifies the relationship of the link to the object that is returned by the URL.
+
+### related_policies
+
+* `entity_uuid` - UUID of the entity the User-Defined Alert policy is associated with.
+* `policy_ids` - Policy IDs associated with the specified entity.
+
+## Import
+
+`nutanix_uda_policy_v2` can be imported using the `ext_id`:
+
+```shell
+terraform import nutanix_uda_policy_v2.example 00000000-0000-0000-0000-000000000000
+```
+
+See detailed information in [Nutanix User-Defined Alert Policies](https://developers.nutanix.com/).


### PR DESCRIPTION
## Summary

Auto-generated Terraform provider code for the **monitoring** namespace, entity
**userdefined**, based on the inline `sdk_info.json` (see prompt). One PR per code-gen run.

- SDK module: `github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4@v4.2.2`  (read from `go.mod`)
- API methods covered: `6` (CreateUdaPolicy, DeleteUdaPolicyById, FindConflictingUdaPolicies, GetUdaPolicyById, ListUdaPolicies, UpdateUdaPolicyById)
- Datasources generated: `2` — `nutanix_uda_policy_v2` (singular), `nutanix_uda_policies_v2` (plural)
- Resources generated:   `2` — `nutanix_uda_policy_v2` (CRUD), `nutanix_find_conflicting_uda_policies_v2` (action)

## Files changed

**nutanix/sdks/v4/monitoring/**
- `monitoring.go` — SDK client for monitoring namespace (UserDefinedPoliciesApi)

**nutanix/ (provider core)**
- `config.go` — Added MonitoringAPI client field and initialization
- `provider/provider.go` — Registered 2 datasources and 2 resources in DataSourcesMap / ResourcesMap

**nutanix/services/monitoringv2/**
- `data_source_nutanix_uda_policy_v2.go` — Singular datasource (GetUdaPolicyById)
- `data_source_nutanix_uda_policies_v2.go` — Plural datasource (ListUdaPolicies)
- `resource_nutanix_uda_policy_v2.go` — CRUD resource (Create/Read/Update/Delete UdaPolicy)
- `resource_nutanix_find_conflicting_uda_policies_v2.go` — Action resource (FindConflictingUdaPolicies)
- `helpers.go` — Schema definitions, flatten/expand helpers, enum converters
- `main_test.go` — Test setup and TestMain
- `resource_nutanix_uda_policy_v2_test.go` — Resource acceptance tests (create + update)
- `data_source_nutanix_uda_policy_v2_test.go` — Singular datasource acceptance test
- `data_source_nutanix_uda_policies_v2_test.go` — Plural datasource acceptance test
- `resource_nutanix_find_conflicting_uda_policies_v2_test.go` — Action resource acceptance test

**examples/monitoring_v2/userdefined/**
- `main.tf` — Terraform + provider blocks, resource and datasource examples
- `variables.tf` — Variable declarations
- `terraform.tfvars` — Placeholder variable values

**website/docs/d/**
- `uda_policy_v2.html.markdown` — Singular datasource documentation
- `uda_policies_v2.html.markdown` — Plural datasource documentation

**website/docs/r/**
- `uda_policy_v2.html.markdown` — CRUD resource documentation
- `find_conflicting_uda_policies_v2.html.markdown` — Action resource documentation

**go.mod / go.sum** — Added monitoring-go-client v4.2.2 dependency

## Test execution

| Metric              | Value                                          |
|---------------------|-------------------------------------------------|
| Command             | `TF_ACC=1 go test ./nutanix/services/monitoringv2 -v "-run=TestAccV2Nutanix" -timeout 500m -coverprofile "$ARTIFACTS/c.out" -covermode=count` |
| Total testcases     | `4`                                             |
| Passed              | `4`                                             |
| Failed              | `0`                                             |
| Skipped             | `0`                                             |
| Wall-clock duration | `0:00:53`                                       |
| Cluster (PC)        | `10.44.76.91`                                   |

### Analysis

All 4 tests passed successfully:

1. **TestAccV2NutanixUdaPoliciesDatasource_Basic** (17.08s) — Creates a UDA policy resource, then reads via the plural datasource (ListUdaPolicies). Verified that `uda_policies` list is populated.
2. **TestAccV2NutanixUdaPolicyDatasource_Basic** (12.99s) — Creates a UDA policy resource, then reads via the singular datasource (GetUdaPolicyById). Verified title, entity_type, trigger_conditions attributes.
3. **TestAccV2NutanixFindConflictingUdaPoliciesResource_Basic** (4.05s) — Calls FindConflictingUdaPolicies action endpoint. Verified conflicting_policies is populated.
4. **TestAccV2NutanixUdaPolicyResource_Basic** (18.28s) — Full CRUD lifecycle: Create → Read → Update (title change) → Read → Delete. All API calls returned expected status codes (201, 200, 204).

No failures. Coverage: 57.4% of statements.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
--- PASS: TestAccV2NutanixUdaPoliciesDatasource_Basic (17.08s)
--- PASS: TestAccV2NutanixUdaPolicyDatasource_Basic (12.99s)
--- PASS: TestAccV2NutanixFindConflictingUdaPoliciesResource_Basic (4.05s)
--- PASS: TestAccV2NutanixUdaPolicyResource_Basic (18.28s)
PASS
coverage: 57.4% of statements
ok  	github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/monitoringv2	53.538s	coverage: 57.4% of statements
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` are stored only in the agent transcript;
  no `sdk_info.json` is committed to this branch.
