### PR TITLE
code-gen(monitoring/event): terraform v2 provider code

### DIFF
--- a/examples/monitoring_v2/event/main.tf
+++ b/examples/monitoring_v2/event/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = "2.0.0"
+    }
+  }
+}
+
+#defining nutanix configuration
+provider "nutanix" {
+  username = var.nutanix_username
+  password = var.nutanix_password
+  endpoint = var.nutanix_endpoint
+  port     = 9440
+  insecure = true
+}
+
+data "nutanix_events_v2" "events-list" {}
+
+data "nutanix_events_v2" "filtered-events" {
+  limit = 2
+}
+
+data "nutanix_event_v2" "get-event" {
+  ext_id = "00000000-0000-0000-0000-000000000000"
+}

--- a/examples/monitoring_v2/event/terraform.tfvars
+++ b/examples/monitoring_v2/event/terraform.tfvars
@@ -1,0 +1,4 @@
+#define values to the variables to be used in terraform file
+nutanix_username = "admin"
+nutanix_password = "password"
+nutanix_endpoint = "10.xx.xx.xx"

--- a/examples/monitoring_v2/event/variables.tf
+++ b/examples/monitoring_v2/event/variables.tf
@@ -1,0 +1,10 @@
+#define the type of variables to be used in terraform file
+variable "nutanix_username" {
+  type = string
+}
+variable "nutanix_password" {
+  type = string
+}
+variable "nutanix_endpoint" {
+  type = string
+}

--- a/go.mod
+++ b/go.mod
@@ -107,6 +107,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/nakabonne/nestif v0.3.0 // indirect
 	github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d // indirect
+	github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -467,6 +467,8 @@ github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2 h1:ms+a
 github.com/nutanix/ntnx-api-golang-clients/lifecycle-go-client/v4 v4.2.2/go.mod h1:X3TsJoGBbkQzz6OP8Be7XvGhH4CwKkF9t35OmJpPY0w=
 github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2 h1:dE0zUP3ExJBnMUaGDAIZGN7/UZ0a85IWzHygMGcUDMc=
 github.com/nutanix/ntnx-api-golang-clients/microseg-go-client/v4 v4.2.2/go.mod h1:vo3VMB097Zd9cw4hLDbnpyBVcBZkpFmcQ2nNgpOpo7U=
+github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2 h1:dXFgnBHMd6MipSXkQE5cRysjKX96MeYeIFIkZDvye60=
+github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4 v4.2.2/go.mod h1:msvlZou4z7vn5pHFhJ65OtAbh99z1ISsqCzfehdcWfw=
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1 h1:VWxK8mY6kOag/ocDBttDViktEi8bcjbAvm3i9laDyCA=
 github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1/go.mod h1:4fUdP3zeL4UFS/UVaii5EdS2v+KlM4gI07KcnS+wDuY=
 github.com/nutanix/ntnx-api-golang-clients/objects-go-client/v4 v4.0.3 h1:TE/G5GHrnvBGPI8MC0fSMSAaeD6HcdtezIgEmn8V/Yo=

--- a/nutanix/config.go
+++ b/nutanix/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/iam"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/lcm"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/microseg"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/monitoring"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/networking"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/objectstores"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/prism"
@@ -140,6 +141,10 @@ func (c *Config) Client() (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	monitoringClient, err := monitoring.NewMonitoringClient(configCreds)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Client{
 		WaitTimeout:         c.WaitTimeout,
@@ -161,6 +166,7 @@ func (c *Config) Client() (*Client, error) {
 		CalmAPI:             calmClient,
 		ObjectStoreAPI:      ObjectStoreClient,
 		SecurityAPI:         SecurityClient,
+		MonitoringAPI:       monitoringClient,
 	}, nil
 }
 
@@ -185,4 +191,5 @@ type Client struct {
 	CalmAPI             *selfservice.Client
 	ObjectStoreAPI      *objectstores.Client
 	SecurityAPI         *security.Client
+	MonitoringAPI       *monitoring.Client
 }

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/iamv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/lcmv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/microsegv2"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/monitoringv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/ndb"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/networking"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/networkingv2"
@@ -370,6 +371,8 @@ func Provider() *schema.Provider {
 			"nutanix_stigs_v2":                                securityv2.DatasourceNutanixStigsControlsV2(),
 			"nutanix_entity_group_v2":                         microsegv2.DatasourceNutanixEntityGroupV2(),
 			"nutanix_entity_groups_v2":                        microsegv2.DatasourceNutanixEntityGroupsV2(),
+			"nutanix_event_v2":                                monitoringv2.DatasourceNutanixEventV2(),
+			"nutanix_events_v2":                               monitoringv2.DatasourceNutanixEventsV2(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"nutanix_virtual_machine":                         vmm.ResourceNutanixVirtualMachine(),

--- a/nutanix/sdks/v4/monitoring/monitoring.go
+++ b/nutanix/sdks/v4/monitoring/monitoring.go
@@ -1,0 +1,31 @@
+package monitoring
+
+import (
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/api"
+	monitoringClient "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
+)
+
+type Client struct {
+	EventsAPI *api.EventsServiceApi
+}
+
+func NewMonitoringClient(credentials client.Credentials) (*Client, error) {
+	var baseClient *monitoringClient.ApiClient
+
+	pcClient := monitoringClient.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
+		baseClient = pcClient
+	}
+
+	return &Client{
+		EventsAPI: api.NewEventsServiceApi(baseClient),
+	}, nil
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_event_v2.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_event_v2.go
@@ -1,0 +1,167 @@
+package monitoringv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/request/events"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixEventV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceNutanixEventV2Read,
+		Schema: map[string]*schema.Schema{
+			"ext_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "UUID of the generated event.",
+			},
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A globally unique identifier that represents the tenant that owns this entity.",
+			},
+			"links": schemaForLinks(),
+			"affected_entities": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of all the entities that are affected by the event or audit.",
+				Elem: &schema.Resource{
+					Schema: schemaForEntityReference(),
+				},
+			},
+			"classifications": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Various categories into which this event type can be classified. For example, hardware, storage, or license.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"cluster_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Name of the cluster associated with the entity.",
+			},
+			"cluster_uuid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Cluster UUID associated with the cluster where the event was first raised.",
+			},
+			"creation_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The time in ISO 8601 format when the event was created.",
+			},
+			"event_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A preconfigured or dynamically generated unique value for each event type.",
+			},
+			"message": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Additional message associated with the event.",
+			},
+			"metric_details": schemaForMetricDetails(),
+			"operation_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The operation type associated with the audit.",
+			},
+			"parameters": schemaForParameters(),
+			"service_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The service which raised the event or audit. For internal Nutanix services, this value is set to \"Nutanix\".",
+			},
+			"source_cluster_uuid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Cluster UUID associated with the source entity of the event.",
+			},
+			"source_entity": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The source entity associated with the event.",
+				Elem: &schema.Resource{
+					Schema: schemaForEntityReference(),
+				},
+			},
+		},
+	}
+}
+
+func datasourceNutanixEventV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	extID := d.Get("ext_id").(string)
+
+	req := &events.GetEventByIdRequest{
+		ExtId: utils.StringPtr(extID),
+	}
+
+	resp, err := conn.EventsAPI.GetEventById(ctx, req)
+	if err != nil {
+		return diag.Errorf("error while fetching event: %v", err)
+	}
+
+	getResp := resp.Data.GetValue().(serviceability.Event)
+
+	if err := d.Set("tenant_id", utils.StringValue(getResp.TenantId)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("links", flattenLinks(getResp.Links)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("affected_entities", flattenEntityReferences(getResp.AffectedEntities)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("classifications", getResp.Classifications); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("cluster_name", utils.StringValue(getResp.ClusterName)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("cluster_uuid", utils.StringValue(getResp.ClusterUUID)); err != nil {
+		return diag.FromErr(err)
+	}
+	if getResp.CreationTime != nil {
+		if err := d.Set("creation_time", getResp.CreationTime.String()); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err := d.Set("event_type", utils.StringValue(getResp.EventType)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("message", utils.StringValue(getResp.Message)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("metric_details", flattenMetricDetails(getResp.MetricDetails)); err != nil {
+		return diag.FromErr(err)
+	}
+	if getResp.OperationType != nil {
+		if err := d.Set("operation_type", getResp.OperationType.GetName()); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err := d.Set("parameters", flattenParameters(getResp.Parameters)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("service_name", utils.StringValue(getResp.ServiceName)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("source_cluster_uuid", utils.StringValue(getResp.SourceClusterUUID)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("source_entity", flattenEventEntityReference(getResp.SourceEntity)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(utils.StringValue(getResp.ExtId))
+	return nil
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_event_v2_test.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_event_v2_test.go
@@ -1,0 +1,46 @@
+package monitoringv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const datasourceNameEvent = "data.nutanix_event_v2.test"
+
+func TestAccV2NutanixEventDatasource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEventDatasourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameEvent, "ext_id"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvent, "event_type"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvent, "creation_time"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvent, "cluster_uuid"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvent, "links.#"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvent, "affected_entities.#"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvent, "classifications.#"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvent, "parameters.#"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvent, "source_entity.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccEventDatasourceConfig() string {
+	return `
+data "nutanix_events_v2" "events" {
+  limit = 1
+}
+
+data "nutanix_event_v2" "test" {
+  ext_id = data.nutanix_events_v2.events.events[0].ext_id
+  depends_on = [data.nutanix_events_v2.events]
+}
+`
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_events_v2.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_events_v2.go
@@ -1,0 +1,140 @@
+package monitoringv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/request/events"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixEventsV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceNutanixEventsV2Read,
+		Schema: map[string]*schema.Schema{
+			"page": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "A URL query parameter that specifies the page number of the result set.",
+			},
+			"limit": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "A URL query parameter that specifies the total number of records returned in the result set. Must be a positive integer between 1 and 100.",
+			},
+			"filter": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A URL query parameter that allows clients to filter a collection of resources.",
+			},
+			"order_by": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A URL query parameter that allows clients to specify the sort criteria for the returned list of objects.",
+			},
+			"select": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A URL query parameter that allows clients to request a specific set of properties for each entity or complex type.",
+			},
+			"events": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     DatasourceNutanixEventV2(),
+			},
+		},
+	}
+}
+
+func datasourceNutanixEventsV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MonitoringAPI
+
+	req := &events.ListEventsRequest{}
+
+	if pagef, ok := d.GetOk("page"); ok {
+		req.Page_ = utils.IntPtr(pagef.(int))
+	}
+	if limitf, ok := d.GetOk("limit"); ok {
+		req.Limit_ = utils.IntPtr(limitf.(int))
+	}
+	if filterf, ok := d.GetOk("filter"); ok {
+		req.Filter_ = utils.StringPtr(filterf.(string))
+	}
+	if order, ok := d.GetOk("order_by"); ok {
+		req.Orderby_ = utils.StringPtr(order.(string))
+	}
+	if selectf, ok := d.GetOk("select"); ok {
+		req.Select_ = utils.StringPtr(selectf.(string))
+	}
+
+	resp, err := conn.EventsAPI.ListEvents(ctx, req)
+	if err != nil {
+		return diag.Errorf("error while fetching events: %v", err)
+	}
+
+	if resp.Data == nil {
+		if err := d.Set("events", []map[string]interface{}{}); err != nil {
+			return diag.FromErr(err)
+		}
+		d.SetId(utils.GenUUID())
+
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "No data found.",
+			Detail:   "The API returned an empty list of events.",
+		}}
+	}
+
+	getResp := resp.Data.GetValue().([]serviceability.Event)
+
+	if err := d.Set("events", flattenEvents(getResp)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(utils.GenUUID())
+	return nil
+}
+
+func flattenEvents(eventsList []serviceability.Event) []map[string]interface{} {
+	if len(eventsList) == 0 {
+		return []map[string]interface{}{}
+	}
+
+	result := make([]map[string]interface{}, len(eventsList))
+
+	for i, event := range eventsList {
+		eventMap := make(map[string]interface{})
+
+		eventMap["ext_id"] = utils.StringValue(event.ExtId)
+		eventMap["tenant_id"] = utils.StringValue(event.TenantId)
+		eventMap["links"] = flattenLinks(event.Links)
+		eventMap["affected_entities"] = flattenEntityReferences(event.AffectedEntities)
+		eventMap["classifications"] = event.Classifications
+		eventMap["cluster_name"] = utils.StringValue(event.ClusterName)
+		eventMap["cluster_uuid"] = utils.StringValue(event.ClusterUUID)
+
+		if event.CreationTime != nil {
+			eventMap["creation_time"] = event.CreationTime.String()
+		}
+
+		eventMap["event_type"] = utils.StringValue(event.EventType)
+		eventMap["message"] = utils.StringValue(event.Message)
+		eventMap["metric_details"] = flattenMetricDetails(event.MetricDetails)
+
+		if event.OperationType != nil {
+			eventMap["operation_type"] = event.OperationType.GetName()
+		}
+
+		eventMap["parameters"] = flattenParameters(event.Parameters)
+		eventMap["service_name"] = utils.StringValue(event.ServiceName)
+		eventMap["source_cluster_uuid"] = utils.StringValue(event.SourceClusterUUID)
+		eventMap["source_entity"] = flattenEventEntityReference(event.SourceEntity)
+
+		result[i] = eventMap
+	}
+
+	return result
+}

--- a/nutanix/services/monitoringv2/data_source_nutanix_events_v2_test.go
+++ b/nutanix/services/monitoringv2/data_source_nutanix_events_v2_test.go
@@ -1,0 +1,88 @@
+package monitoringv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const datasourceNameEvents = "data.nutanix_events_v2.test"
+
+func TestAccV2NutanixEventsDatasource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEventsDatasourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameEvents, "events.#"),
+					checkAttributeLength(datasourceNameEvents, "events", 1),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixEventsDatasource_WithLimit(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEventsDatasourceWithLimitConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameEvents, "events.#"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvents, "events.0.ext_id"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvents, "events.0.event_type"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvents, "events.0.creation_time"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvents, "events.0.cluster_uuid"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvents, "events.0.links.#"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvents, "events.0.affected_entities.#"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvents, "events.0.classifications.#"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvents, "events.0.parameters.#"),
+					resource.TestCheckResourceAttrSet(datasourceNameEvents, "events.0.source_entity.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixEventsDatasource_WithInvalidFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEventsDatasourceWithInvalidFilterConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameEvents, "events.#"),
+					resource.TestCheckResourceAttr(datasourceNameEvents, "events.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccEventsDatasourceConfig() string {
+	return `
+data "nutanix_events_v2" "test" {}
+`
+}
+
+func testAccEventsDatasourceWithLimitConfig() string {
+	return `
+data "nutanix_events_v2" "test" {
+  limit = 1
+}
+`
+}
+
+func testAccEventsDatasourceWithInvalidFilterConfig() string {
+	return `
+data "nutanix_events_v2" "test" {
+  filter = "eventType eq 'NONEXISTENT_EVENT_TYPE_ZZZZZ'"
+}
+`
+}

--- a/nutanix/services/monitoringv2/helper_test.go
+++ b/nutanix/services/monitoringv2/helper_test.go
@@ -1,0 +1,61 @@
+package monitoringv2_test
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func checkAttributeLength(resourceName, attribute string, minLength int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		attrKey := fmt.Sprintf("%s.#", attribute)
+		attr, ok := rs.Primary.Attributes[attrKey]
+		if !ok {
+			return fmt.Errorf("attribute %s not found", attrKey)
+		}
+
+		count, err := strconv.Atoi(attr)
+		if err != nil {
+			return fmt.Errorf("error converting %s to int: %s", attrKey, err)
+		}
+
+		if count < minLength {
+			return fmt.Errorf("expected %s to be >= %d, got %d", attrKey, minLength, count)
+		}
+
+		return nil
+	}
+}
+
+func checkAttributeLengthEqual(resourceName, attribute string, expectedLength int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		attrKey := fmt.Sprintf("%s.#", attribute)
+		attr, ok := rs.Primary.Attributes[attrKey]
+		if !ok {
+			return fmt.Errorf("attribute %s not found", attrKey)
+		}
+
+		count, err := strconv.Atoi(attr)
+		if err != nil {
+			return fmt.Errorf("error converting %s to int: %s", attrKey, err)
+		}
+
+		if count != expectedLength {
+			return fmt.Errorf("expected %s to be %d, got %d", attrKey, expectedLength, count)
+		}
+
+		return nil
+	}
+}

--- a/nutanix/services/monitoringv2/helpers.go
+++ b/nutanix/services/monitoringv2/helpers.go
@@ -1,0 +1,384 @@
+package monitoringv2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/common/v1/response"
+	monitoringCommon "github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/common"
+	"github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4/models/monitoring/v4/serviceability"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func schemaForLinks() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Computed:    true,
+		Description: "A HATEOAS style link for the response. Each link contains a user-friendly name identifying the link and an address for retrieving the particular resource.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"href": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The URL at which the entity described by the link can be accessed.",
+				},
+				"rel": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "A name that identifies the relationship of the link to the object that is returned by the URL. The unique value of \"self\" identifies the URL for the object.",
+				},
+			},
+		},
+	}
+}
+
+func schemaForEntityReference() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"ext_id": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "UUID of the entity.",
+		},
+		"name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The name of the entity.",
+		},
+		"type": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The type of entity. For example, VM, node, or cluster.",
+		},
+	}
+}
+
+func schemaForOneOfValue() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"string_value": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Denotes a value of type string.",
+		},
+		"bool_value": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Denotes a value of type boolean.",
+		},
+		"int_value": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Denotes a value of type integer.",
+		},
+		"double_value": {
+			Type:        schema.TypeFloat,
+			Computed:    true,
+			Description: "Denotes a value of type double.",
+		},
+	}
+}
+
+func schemaForMetricDetails() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Computed:    true,
+		Description: "Details of the metric for a metric-based event.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"comparison_operator": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The comparison operator used for the condition evaluation.",
+				},
+				"condition_type": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Indicating if this symptom is caused by a static threshold or anomaly (dynamic threshold) evaluation.",
+				},
+				"data_type": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Data type of the metric value as stored in the database.",
+				},
+				"metric_category": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Broad category under which this metric falls. For example, disk, CPU, or memory.",
+				},
+				"metric_display_name": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Readable name of the metric in English.",
+				},
+				"metric_name": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The metric key.",
+				},
+				"metric_value": {
+					Type:        schema.TypeList,
+					Computed:    true,
+					Description: "The raw value of the metric when the condition threshold was exceeded.",
+					Elem: &schema.Resource{
+						Schema: schemaForOneOfValue(),
+					},
+				},
+				"threshold_value": {
+					Type:        schema.TypeList,
+					Computed:    true,
+					Description: "The threshold value that was used for the condition evaluation.",
+					Elem: &schema.Resource{
+						Schema: schemaForOneOfValue(),
+					},
+				},
+				"trigger_time": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The time in ISO 8601 format when the event was triggered.",
+				},
+				"trigger_wait_time_seconds": {
+					Type:        schema.TypeInt,
+					Computed:    true,
+					Description: "How long the metric breached the given condition before raising an event.",
+				},
+				"unit": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Unit of the metric. For example, percentage, ms or usecs.",
+				},
+			},
+		},
+	}
+}
+
+func schemaForParameters() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Computed:    true,
+		Description: "Additional parameters associated with the event.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"param_name": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Name or key of additional parameter for an instance.",
+				},
+				"param_value": {
+					Type:        schema.TypeList,
+					Computed:    true,
+					Description: "Value of additional parameter for an instance.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"string_value": {
+								Type:        schema.TypeString,
+								Computed:    true,
+								Description: "Denotes a value of type string.",
+							},
+							"bool_value": {
+								Type:        schema.TypeBool,
+								Computed:    true,
+								Description: "Denotes a value of type boolean.",
+							},
+							"int_value": {
+								Type:        schema.TypeInt,
+								Computed:    true,
+								Description: "Denotes a value of type integer.",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func flattenLinks(links []response.ApiLink) []map[string]interface{} {
+	if len(links) == 0 {
+		return []map[string]interface{}{}
+	}
+
+	linkList := make([]map[string]interface{}, 0)
+	for _, link := range links {
+		linkMap := make(map[string]interface{})
+		if link.Rel != nil {
+			linkMap["rel"] = utils.StringValue(link.Rel)
+		}
+		if link.Href != nil {
+			linkMap["href"] = utils.StringValue(link.Href)
+		}
+		linkList = append(linkList, linkMap)
+	}
+	return linkList
+}
+
+func flattenEntityReferences(entities []monitoringCommon.EntityReference) []map[string]interface{} {
+	if len(entities) == 0 {
+		return []map[string]interface{}{}
+	}
+
+	result := make([]map[string]interface{}, len(entities))
+	for i, entity := range entities {
+		entityMap := make(map[string]interface{})
+		entityMap["ext_id"] = utils.StringValue(entity.ExtId)
+		entityMap["name"] = utils.StringValue(entity.Name)
+		entityMap["type"] = utils.StringValue(entity.Type)
+		result[i] = entityMap
+	}
+	return result
+}
+
+func flattenEventEntityReference(entity *serviceability.EventEntityReference) []map[string]interface{} {
+	if entity == nil {
+		return []map[string]interface{}{}
+	}
+
+	entityMap := make(map[string]interface{})
+	entityMap["ext_id"] = utils.StringValue(entity.ExtId)
+	entityMap["name"] = utils.StringValue(entity.Name)
+	entityMap["type"] = utils.StringValue(entity.Type)
+	return []map[string]interface{}{entityMap}
+}
+
+func flattenMetricDetails(metricDetails []monitoringCommon.MetricDetail) []map[string]interface{} {
+	if len(metricDetails) == 0 {
+		return []map[string]interface{}{}
+	}
+
+	result := make([]map[string]interface{}, len(metricDetails))
+	for i, md := range metricDetails {
+		mdMap := make(map[string]interface{})
+
+		if md.ComparisonOperator != nil {
+			mdMap["comparison_operator"] = md.ComparisonOperator.GetName()
+		}
+		if md.ConditionType != nil {
+			mdMap["condition_type"] = md.ConditionType.GetName()
+		}
+		if md.DataType != nil {
+			mdMap["data_type"] = md.DataType.GetName()
+		}
+		mdMap["metric_category"] = utils.StringValue(md.MetricCategory)
+		mdMap["metric_display_name"] = utils.StringValue(md.MetricDisplayName)
+		mdMap["metric_name"] = utils.StringValue(md.MetricName)
+		mdMap["metric_value"] = flattenOneOfMetricValue(md.MetricValue)
+		mdMap["threshold_value"] = flattenOneOfThresholdValue(md.ThresholdValue)
+
+		if md.TriggerTime != nil {
+			mdMap["trigger_time"] = md.TriggerTime.String()
+		}
+		if md.TriggerWaitTimeSeconds != nil {
+			mdMap["trigger_wait_time_seconds"] = utils.Int64Value(md.TriggerWaitTimeSeconds)
+		}
+		mdMap["unit"] = utils.StringValue(md.Unit)
+
+		result[i] = mdMap
+	}
+	return result
+}
+
+func flattenOneOfMetricValue(oneOfValue *monitoringCommon.OneOfMetricDetailMetricValue) []map[string]interface{} {
+	if oneOfValue == nil || oneOfValue.ObjectType_ == nil {
+		return []map[string]interface{}{}
+	}
+
+	valueMap := make(map[string]interface{})
+	value := oneOfValue.GetValue()
+	if value == nil {
+		return []map[string]interface{}{}
+	}
+
+	switch *oneOfValue.ObjectType_ {
+	case "monitoring.v4.common.StringValue":
+		if strVal, ok := value.(monitoringCommon.StringValue); ok && strVal.StringValue != nil {
+			valueMap["string_value"] = utils.StringValue(strVal.StringValue)
+		}
+	case "monitoring.v4.common.BoolValue":
+		if boolVal, ok := value.(monitoringCommon.BoolValue); ok && boolVal.BoolValue != nil {
+			valueMap["bool_value"] = utils.BoolValue(boolVal.BoolValue)
+		}
+	case "monitoring.v4.common.IntValue":
+		if intVal, ok := value.(monitoringCommon.IntValue); ok && intVal.IntValue != nil {
+			valueMap["int_value"] = utils.Int64Value(intVal.IntValue)
+		}
+	case "monitoring.v4.common.DoubleValue":
+		if doubleVal, ok := value.(monitoringCommon.DoubleValue); ok && doubleVal.DoubleValue != nil {
+			valueMap["double_value"] = utils.Float64Value(doubleVal.DoubleValue)
+		}
+	}
+
+	return []map[string]interface{}{valueMap}
+}
+
+func flattenOneOfThresholdValue(oneOfValue *monitoringCommon.OneOfMetricDetailThresholdValue) []map[string]interface{} {
+	if oneOfValue == nil || oneOfValue.ObjectType_ == nil {
+		return []map[string]interface{}{}
+	}
+
+	valueMap := make(map[string]interface{})
+	value := oneOfValue.GetValue()
+	if value == nil {
+		return []map[string]interface{}{}
+	}
+
+	switch *oneOfValue.ObjectType_ {
+	case "monitoring.v4.common.StringValue":
+		if strVal, ok := value.(monitoringCommon.StringValue); ok && strVal.StringValue != nil {
+			valueMap["string_value"] = utils.StringValue(strVal.StringValue)
+		}
+	case "monitoring.v4.common.BoolValue":
+		if boolVal, ok := value.(monitoringCommon.BoolValue); ok && boolVal.BoolValue != nil {
+			valueMap["bool_value"] = utils.BoolValue(boolVal.BoolValue)
+		}
+	case "monitoring.v4.common.IntValue":
+		if intVal, ok := value.(monitoringCommon.IntValue); ok && intVal.IntValue != nil {
+			valueMap["int_value"] = utils.Int64Value(intVal.IntValue)
+		}
+	case "monitoring.v4.common.DoubleValue":
+		if doubleVal, ok := value.(monitoringCommon.DoubleValue); ok && doubleVal.DoubleValue != nil {
+			valueMap["double_value"] = utils.Float64Value(doubleVal.DoubleValue)
+		}
+	}
+
+	return []map[string]interface{}{valueMap}
+}
+
+func flattenParameters(params []monitoringCommon.Parameter) []map[string]interface{} {
+	if len(params) == 0 {
+		return []map[string]interface{}{}
+	}
+
+	result := make([]map[string]interface{}, len(params))
+	for i, param := range params {
+		paramMap := make(map[string]interface{})
+		paramMap["param_name"] = utils.StringValue(param.ParamName)
+		paramMap["param_value"] = flattenOneOfParamValue(param.ParamValue)
+		result[i] = paramMap
+	}
+	return result
+}
+
+func flattenOneOfParamValue(oneOfValue *monitoringCommon.OneOfParameterParamValue) []map[string]interface{} {
+	if oneOfValue == nil || oneOfValue.ObjectType_ == nil {
+		return []map[string]interface{}{}
+	}
+
+	valueMap := make(map[string]interface{})
+	value := oneOfValue.GetValue()
+	if value == nil {
+		return []map[string]interface{}{}
+	}
+
+	switch *oneOfValue.ObjectType_ {
+	case "monitoring.v4.common.StringValue":
+		if strVal, ok := value.(monitoringCommon.StringValue); ok && strVal.StringValue != nil {
+			valueMap["string_value"] = utils.StringValue(strVal.StringValue)
+		}
+	case "monitoring.v4.common.BoolValue":
+		if boolVal, ok := value.(monitoringCommon.BoolValue); ok && boolVal.BoolValue != nil {
+			valueMap["bool_value"] = utils.BoolValue(boolVal.BoolValue)
+		}
+	case "monitoring.v4.common.IntValue":
+		if intVal, ok := value.(monitoringCommon.IntValue); ok && intVal.IntValue != nil {
+			valueMap["int_value"] = utils.Int64Value(intVal.IntValue)
+		}
+	}
+
+	return []map[string]interface{}{valueMap}
+}

--- a/nutanix/services/monitoringv2/main_test.go
+++ b/nutanix/services/monitoringv2/main_test.go
@@ -1,0 +1,41 @@
+package monitoringv2_test
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"testing"
+)
+
+type TestConfig struct {
+	Monitoring struct {
+		EventExtID string `json:"event_ext_id"`
+	} `json:"monitoring"`
+}
+
+var testVars TestConfig
+
+var (
+	path, _  = os.Getwd()
+	filepath = path + "/../../../test_config_v2.json"
+)
+
+func loadVars(filepath string, varStuct interface{}) {
+	configData, err := os.ReadFile(filepath)
+	if err != nil {
+		log.Printf("Got this error while reading config.json: %s", err.Error())
+		os.Exit(1)
+	}
+
+	err = json.Unmarshal(configData, varStuct)
+	if err != nil {
+		log.Printf("Got this error while unmarshalling config.json: %s", err.Error())
+		os.Exit(1)
+	}
+}
+
+func TestMain(m *testing.M) {
+	log.Println("Do some crazy stuff before tests!")
+	loadVars("../../../test_config_v2.json", &testVars)
+	os.Exit(m.Run())
+}

--- a/website/docs/d/event_v2.html.markdown
+++ b/website/docs/d/event_v2.html.markdown
@@ -1,0 +1,104 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_event_v2"
+sidebar_current: "docs-nutanix-datasource-event-v2"
+description: |-
+  Fetches the details of an event identified by external identifier.
+
+---
+
+# nutanix_event_v2
+
+Fetches the details of an event identified by external identifier.
+
+## Example Usage
+
+```hcl
+data "nutanix_event_v2" "example"{
+   ext_id = "00000000-0000-0000-0000-000000000000"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `ext_id`: -(Required) UUID of the generated event.
+
+## Attributes Reference
+The following attributes are exported:
+
+* `tenant_id`: - A globally unique identifier that represents the tenant that owns this entity. The system automatically assigns it, and it and is immutable from an API consumer perspective (some use cases may cause this ID to change - For instance, a use case may require the transfer of ownership of the entity, but these cases are handled automatically on the server).
+* `links`: - A HATEOAS style link for the response. Each link contains a user-friendly name identifying the link and an address for retrieving the particular resource.
+* `affected_entities`: - List of all the entities that are affected by the event or audit.
+* `classifications`: - Various categories into which this event type can be classified. For example, hardware, storage, or license.
+* `cluster_name`: - Name of the cluster associated with the entity.
+* `cluster_uuid`: - Cluster UUID associated with the cluster where the event was first raised.
+* `creation_time`: - The time in ISO 8601 format when the event was created.
+* `event_type`: - A preconfigured or dynamically generated unique value for each event type.
+* `message`: - Additional message associated with the event.
+* `metric_details`: - Details of the metric for a metric-based event.
+* `operation_type`: - The operation type associated with the audit. For example, create, update, or delete.
+* `parameters`: - Additional parameters associated with the event. These parameters can be used to indicate custom key-value pairs for a given event instance. For example, a service down event in Prism Central can have the service name as a parameter.
+* `service_name`: - The service which raised the event or audit. For internal Nutanix services, this value is set to "Nutanix".
+* `source_cluster_uuid`: - Cluster UUID associated with the source entity of the event.
+* `source_entity`: - The source entity associated with the event.
+
+
+### Links
+The links attribute supports the following:
+
+* `href`: - The URL at which the entity described by the link can be accessed.
+* `rel`: - A name that identifies the relationship of the link to the object that is returned by the URL. The unique value of "self" identifies the URL for the object.
+
+### Affected Entities
+The affected_entities attribute supports the following:
+
+* `ext_id`: - UUID of the entity.
+* `name`: - The name of the entity.
+* `type`: - The type of entity. For example, VM, node, or cluster.
+
+### Metric Details
+The metric_details attribute supports the following:
+
+* `comparison_operator`: - The comparison operator used for the condition evaluation.
+* `condition_type`: - Indicating if this symptom is caused by a static threshold or anomaly (dynamic threshold) evaluation.
+* `data_type`: - Data type of the metric value as stored in the database.
+* `metric_category`: - Broad category under which this metric falls. For example, disk, CPU, or memory.
+* `metric_display_name`: - Readable name of the metric in English.
+* `metric_name`: - The metric key.
+* `metric_value`: - The raw value of the metric when the condition threshold was exceeded.
+* `threshold_value`: - The threshold value that was used for the condition evaluation.
+* `trigger_time`: - The time in ISO 8601 format when the event was triggered.
+* `trigger_wait_time_seconds`: - How long the metric breached the given condition before raising an event.
+* `unit`: - Unit of the metric. For example, percentage, ms or usecs.
+
+#### Metric Value / Threshold Value
+The metric_value and threshold_value attributes support the following:
+
+* `string_value`: - Denotes a value of type string.
+* `bool_value`: - Denotes a value of type boolean.
+* `int_value`: - Denotes a value of type integer.
+* `double_value`: - Denotes a value of type double.
+
+### Parameters
+The parameters attribute supports the following:
+
+* `param_name`: - Name or key of additional parameter for an instance.
+* `param_value`: - Value of additional parameter for an instance.
+
+#### Param Value
+The param_value attribute supports the following:
+
+* `string_value`: - Denotes a value of type string.
+* `bool_value`: - Denotes a value of type boolean.
+* `int_value`: - Denotes a value of type integer.
+
+### Source Entity
+The source_entity attribute supports the following:
+
+* `ext_id`: - UUID of the entity.
+* `name`: - The name of the entity.
+* `type`: - The type of entity. For example, VM, node, or cluster.
+
+
+See detailed information in [Nutanix Get Event By Id V4](https://developers.nutanix.com/api-reference?namespace=monitoring&version=v4.2#tag/EventsService/operation/GetEventById).

--- a/website/docs/d/events_v2.html.markdown
+++ b/website/docs/d/events_v2.html.markdown
@@ -1,0 +1,124 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_events_v2"
+sidebar_current: "docs-nutanix-datasource-events-v2"
+description: |-
+  Fetches a list of events.
+
+---
+
+# nutanix_events_v2
+
+Fetches a list of events.
+
+## Example Usage
+
+```hcl
+// list all events
+data "nutanix_events_v2" "events-list" {}
+
+// with limit
+data "nutanix_events_v2" "events-limit" {
+  limit = 4
+}
+
+// with filter and limit
+data "nutanix_events_v2" "example"{
+  filter = "startswith(eventType, 'A')"
+  limit = 10
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `page`: -(Optional) A URL query parameter that specifies the page number of the result set. It must be a positive integer between 0 and the maximum number of pages that are available for that resource. Any number out of this range might lead to no results.
+* `limit`: -(Optional) A URL query parameter that specifies the total number of records returned in the result set. Must be a positive integer between 1 and 100. Any number out of this range will lead to a validation error. If the limit is not provided, a default value of 50 records will be returned in the result set.
+* `filter`: -(Optional) A URL query parameter that allows clients to filter a collection of resources. The expression specified with $filter is evaluated for each resource in the collection, and only items where the expression evaluates to true are included in the response. Expression specified with the $filter must conform to the OData V4.01 URL conventions.
+* `order_by`: -(Optional) A URL query parameter that allows clients to specify the sort criteria for the returned list of objects. Resources can be sorted in ascending order using asc or descending order using desc. If asc or desc are not specified, the resources will be sorted in ascending order by default.
+* `select`: -(Optional) A URL query parameter that allows clients to request a specific set of properties for each entity or complex type. Expression specified with the $select must conform to the OData V4.01 URL conventions. If a $select expression consists of a single select item that is an asterisk (i.e., *), then all properties on the matching resource will be returned.
+
+## Attributes Reference
+The following attributes are exported:
+
+* `events`: - List of events.
+
+## Events
+The `events` is a list of events. Each event supports the following attributes:
+
+* `ext_id`: - A globally unique identifier of an instance that is suitable for external consumption.
+* `tenant_id`: - A globally unique identifier that represents the tenant that owns this entity. The system automatically assigns it, and it and is immutable from an API consumer perspective (some use cases may cause this ID to change - For instance, a use case may require the transfer of ownership of the entity, but these cases are handled automatically on the server).
+* `links`: - A HATEOAS style link for the response. Each link contains a user-friendly name identifying the link and an address for retrieving the particular resource.
+* `affected_entities`: - List of all the entities that are affected by the event or audit.
+* `classifications`: - Various categories into which this event type can be classified. For example, hardware, storage, or license.
+* `cluster_name`: - Name of the cluster associated with the entity.
+* `cluster_uuid`: - Cluster UUID associated with the cluster where the event was first raised.
+* `creation_time`: - The time in ISO 8601 format when the event was created.
+* `event_type`: - A preconfigured or dynamically generated unique value for each event type.
+* `message`: - Additional message associated with the event.
+* `metric_details`: - Details of the metric for a metric-based event.
+* `operation_type`: - The operation type associated with the audit. For example, create, update, or delete.
+* `parameters`: - Additional parameters associated with the event. These parameters can be used to indicate custom key-value pairs for a given event instance. For example, a service down event in Prism Central can have the service name as a parameter.
+* `service_name`: - The service which raised the event or audit. For internal Nutanix services, this value is set to "Nutanix".
+* `source_cluster_uuid`: - Cluster UUID associated with the source entity of the event.
+* `source_entity`: - The source entity associated with the event.
+
+
+### Links
+The links attribute supports the following:
+
+* `href`: - The URL at which the entity described by the link can be accessed.
+* `rel`: - A name that identifies the relationship of the link to the object that is returned by the URL. The unique value of "self" identifies the URL for the object.
+
+### Affected Entities
+The affected_entities attribute supports the following:
+
+* `ext_id`: - UUID of the entity.
+* `name`: - The name of the entity.
+* `type`: - The type of entity. For example, VM, node, or cluster.
+
+### Metric Details
+The metric_details attribute supports the following:
+
+* `comparison_operator`: - The comparison operator used for the condition evaluation.
+* `condition_type`: - Indicating if this symptom is caused by a static threshold or anomaly (dynamic threshold) evaluation.
+* `data_type`: - Data type of the metric value as stored in the database.
+* `metric_category`: - Broad category under which this metric falls. For example, disk, CPU, or memory.
+* `metric_display_name`: - Readable name of the metric in English.
+* `metric_name`: - The metric key.
+* `metric_value`: - The raw value of the metric when the condition threshold was exceeded.
+* `threshold_value`: - The threshold value that was used for the condition evaluation.
+* `trigger_time`: - The time in ISO 8601 format when the event was triggered.
+* `trigger_wait_time_seconds`: - How long the metric breached the given condition before raising an event.
+* `unit`: - Unit of the metric. For example, percentage, ms or usecs.
+
+#### Metric Value / Threshold Value
+The metric_value and threshold_value attributes support the following:
+
+* `string_value`: - Denotes a value of type string.
+* `bool_value`: - Denotes a value of type boolean.
+* `int_value`: - Denotes a value of type integer.
+* `double_value`: - Denotes a value of type double.
+
+### Parameters
+The parameters attribute supports the following:
+
+* `param_name`: - Name or key of additional parameter for an instance.
+* `param_value`: - Value of additional parameter for an instance.
+
+#### Param Value
+The param_value attribute supports the following:
+
+* `string_value`: - Denotes a value of type string.
+* `bool_value`: - Denotes a value of type boolean.
+* `int_value`: - Denotes a value of type integer.
+
+### Source Entity
+The source_entity attribute supports the following:
+
+* `ext_id`: - UUID of the entity.
+* `name`: - The name of the entity.
+* `type`: - The type of entity. For example, VM, node, or cluster.
+
+
+See detailed information in [Nutanix List Events V4](https://developers.nutanix.com/api-reference?namespace=monitoring&version=v4.2#tag/EventsService/operation/ListEvents).


### PR DESCRIPTION
## Summary

Auto-generated Terraform provider code for the **monitoring** namespace, entity
**event**, based on the inline `sdk_info.json` (see prompt). One PR per code-gen run.

- SDK module: `github.com/nutanix/ntnx-api-golang-clients/monitoring-go-client/v4@v4.2.2`  (read from `go.mod`)
- API methods covered: `2` (GetEventById, ListEvents)
- Datasources generated: `2` (nutanix_event_v2, nutanix_events_v2)
- Resources generated:   `0` (no Create/Update/Delete methods available for events)

## Files changed

- **nutanix/sdks/v4/monitoring/**
  - `monitoring.go` — SDK client wrapper for EventsServiceApi

- **nutanix/**
  - `config.go` — Added MonitoringAPI client field and initialization

- **nutanix/provider/**
  - `provider.go` — Registered nutanix_event_v2 and nutanix_events_v2 datasources

- **nutanix/services/monitoringv2/**
  - `data_source_nutanix_event_v2.go` — Singular datasource (GetEventById)
  - `data_source_nutanix_events_v2.go` — Plural datasource (ListEvents)
  - `helpers.go` — Schema helpers and flatten functions
  - `data_source_nutanix_event_v2_test.go` — Acceptance tests for singular datasource
  - `data_source_nutanix_events_v2_test.go` — Acceptance tests for plural datasource
  - `helper_test.go` — Test helper functions
  - `main_test.go` — Test configuration loader

- **examples/monitoring_v2/event/**
  - `main.tf` — Example usage of event datasources
  - `variables.tf` — Variable declarations
  - `terraform.tfvars` — Placeholder values

- **website/docs/d/**
  - `event_v2.html.markdown` — Documentation for singular event datasource
  - `events_v2.html.markdown` — Documentation for plural events datasource

- **go.mod / go.sum** — Added monitoring-go-client/v4 v4.2.2 dependency

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `TF_ACC=1 go test ./nutanix/services/monitoringv2 -v "-run=TestAccV2Nutanix" -timeout 500m -coverprofile "$ARTIFACTS/c.out" -covermode=count` |
| Total testcases     | `4`                                            |
| Passed              | `4`                                            |
| Failed              | `0`                                            |
| Skipped             | `0`                                            |
| Wall-clock duration | `0:03:05` (185s total across 2 runs)           |
| Cluster (PC)        | `10.44.76.91`                                  |

### Analysis

All 4 test cases passed on the first attempt:

1. **TestAccV2NutanixEventDatasource_Basic** (36.19s) — Lists events with limit=1, then fetches the first event by ext_id. Validates ext_id, event_type, creation_time, cluster_uuid, links, affected_entities, classifications, parameters, and source_entity are set.
2. **TestAccV2NutanixEventsDatasource_Basic** (36.04s) — Lists all events without filters. Validates events list has at least 1 entry.
3. **TestAccV2NutanixEventsDatasource_WithLimit** (31.59s) — Lists events with limit=1. Validates all event attributes are populated for the first event.
4. **TestAccV2NutanixEventsDatasource_WithInvalidFilter** (34.77s) — Filters by nonexistent event type. Validates empty result set (events.# = 0).

No failures. Coverage: 72.1% of statements.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
2026/05/08 13:09:08 Do some crazy stuff before tests!
=== RUN   TestAccV2NutanixEventDatasource_Basic
--- PASS: TestAccV2NutanixEventDatasource_Basic (44.92s)
=== RUN   TestAccV2NutanixEventsDatasource_Basic
--- PASS: TestAccV2NutanixEventsDatasource_Basic (36.04s)
=== RUN   TestAccV2NutanixEventsDatasource_WithLimit
--- PASS: TestAccV2NutanixEventsDatasource_WithLimit (31.59s)
=== RUN   TestAccV2NutanixEventsDatasource_WithInvalidFilter
--- PASS: TestAccV2NutanixEventsDatasource_WithInvalidFilter (34.77s)
PASS
coverage: 72.1% of statements
ok  	github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/monitoringv2	148.068s
=== RUN   TestAccV2NutanixEventDatasource_Basic
--- PASS: TestAccV2NutanixEventDatasource_Basic (36.19s)
PASS
coverage: 68.6% of statements
ok  	github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/monitoringv2	36.982s
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` are stored only in the agent transcript;
  no `sdk_info.json` is committed to this branch.
