### PR TITLE
code-gen(cluster_management/RsyslogServer): terraform v2 provider code

### DIFF
--- a/examples/cluster_management_v2/RsyslogServer/main.tf
+++ b/examples/cluster_management_v2/RsyslogServer/main.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = "2.0.0"
+    }
+  }
+}
+
+#defining nutanix configuration
+provider "nutanix" {
+  username = var.nutanix_username
+  password = var.nutanix_password
+  endpoint = var.nutanix_endpoint
+  port     = 9440
+  insecure = true
+}
+
+resource "nutanix_rsyslog_server_v2" "example" {
+  cluster_ext_id   = "00000000-0000-0000-0000-000000000000"
+  server_name      = "example-rsyslog-server"
+  port             = 514
+  network_protocol = "UDP"
+
+  ip_address {
+    ipv4 {
+      value = "10.0.0.100"
+    }
+  }
+
+  modules {
+    name                     = "CASSANDRA"
+    log_severity_level       = "INFO"
+    should_log_monitor_files = true
+  }
+
+  modules {
+    name                     = "PRISM"
+    log_severity_level       = "WARNING"
+    should_log_monitor_files = false
+  }
+}
+
+data "nutanix_rsyslog_server_v2" "example" {
+  cluster_ext_id = nutanix_rsyslog_server_v2.example.cluster_ext_id
+  ext_id         = nutanix_rsyslog_server_v2.example.id
+}
+
+data "nutanix_rsyslog_servers_v2" "example" {
+  cluster_ext_id = "00000000-0000-0000-0000-000000000000"
+}

--- a/examples/cluster_management_v2/RsyslogServer/terraform.tfvars
+++ b/examples/cluster_management_v2/RsyslogServer/terraform.tfvars
@@ -1,0 +1,4 @@
+#define values to the variables to be used in terraform file
+nutanix_username = "admin"
+nutanix_password = "password"
+nutanix_endpoint = "10.xx.xx.xx"

--- a/examples/cluster_management_v2/RsyslogServer/variables.tf
+++ b/examples/cluster_management_v2/RsyslogServer/variables.tf
@@ -1,0 +1,10 @@
+#define the type of variables to be used in terraform file
+variable "nutanix_username" {
+  type = string
+}
+variable "nutanix_password" {
+  type = string
+}
+variable "nutanix_endpoint" {
+  type = string
+}

--- a/nutanix/config.go
+++ b/nutanix/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v3/karbon"
 	v3 "github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v3/prism"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v3/selfservice"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/cluster_management"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/clusters"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/datapolicies"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/dataprotection"
@@ -140,6 +141,10 @@ func (c *Config) Client() (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	clusterManagementClient, err := cluster_management.NewClusterManagementClient(configCreds)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Client{
 		WaitTimeout:         c.WaitTimeout,
@@ -161,6 +166,7 @@ func (c *Config) Client() (*Client, error) {
 		CalmAPI:             calmClient,
 		ObjectStoreAPI:      ObjectStoreClient,
 		SecurityAPI:         SecurityClient,
+		ClusterMgmtAPI:     clusterManagementClient,
 	}, nil
 }
 
@@ -185,4 +191,5 @@ type Client struct {
 	CalmAPI             *selfservice.Client
 	ObjectStoreAPI      *objectstores.Client
 	SecurityAPI         *security.Client
+	ClusterMgmtAPI     *cluster_management.Client
 }

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/internal"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/clusters"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/clustersv2"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/cluster_managementv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/datapoliciesv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/dataprotectionv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/foundation"
@@ -370,6 +371,8 @@ func Provider() *schema.Provider {
 			"nutanix_stigs_v2":                                securityv2.DatasourceNutanixStigsControlsV2(),
 			"nutanix_entity_group_v2":                         microsegv2.DatasourceNutanixEntityGroupV2(),
 			"nutanix_entity_groups_v2":                        microsegv2.DatasourceNutanixEntityGroupsV2(),
+			"nutanix_rsyslog_server_v2":                       cluster_managementv2.DatasourceNutanixRsyslogServerV2(),
+			"nutanix_rsyslog_servers_v2":                      cluster_managementv2.DatasourceNutanixRsyslogServersV2(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"nutanix_virtual_machine":                         vmm.ResourceNutanixVirtualMachine(),
@@ -501,6 +504,7 @@ func Provider() *schema.Provider {
 			"nutanix_object_store_certificate_v2":             objectstoresv2.ResourceNutanixObjectStoreCertificateV2(),
 			"nutanix_key_management_server_v2":                securityv2.ResourceNutanixKeyManagementServerV2(),
 			"nutanix_entity_group_v2":                         microsegv2.ResourceNutanixEntityGroupV2(),
+			"nutanix_rsyslog_server_v2":                       cluster_managementv2.ResourceNutanixRsyslogServerV2(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}

--- a/nutanix/sdks/v4/cluster_management/cluster_management.go
+++ b/nutanix/sdks/v4/cluster_management/cluster_management.go
@@ -1,0 +1,31 @@
+package cluster_management
+
+import (
+	"github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/api"
+	cluster "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/client"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/sdkconfig"
+)
+
+type Client struct {
+	ClustersServiceAPI *api.ClustersServiceApi
+}
+
+func NewClusterManagementClient(credentials client.Credentials) (*Client, error) {
+	var baseClient *cluster.ApiClient
+
+	pcClient := cluster.NewApiClient()
+	if cfg := sdkconfig.ConfigureV4Client(credentials, pcClient); cfg != nil {
+		pcClient.Host = cfg.Host
+		pcClient.Port = cfg.Port
+		pcClient.Username = cfg.Username
+		pcClient.Password = cfg.Password
+		pcClient.VerifySSL = cfg.VerifySSL
+		pcClient.AllowVersionNegotiation = cfg.AllowVersionNegotiation
+		baseClient = pcClient
+	}
+
+	return &Client{
+		ClustersServiceAPI: api.NewClustersServiceApi(baseClient),
+	}, nil
+}

--- a/nutanix/services/cluster_managementv2/data_source_nutanix_rsyslog_server_v2.go
+++ b/nutanix/services/cluster_managementv2/data_source_nutanix_rsyslog_server_v2.go
@@ -1,0 +1,120 @@
+package cluster_managementv2
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	clustermgmtConfig "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/config"
+	clustermgmtRequest "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/request/clusters"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixRsyslogServerV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceNutanixRsyslogServerV2Read,
+		Schema: map[string]*schema.Schema{
+			"cluster_ext_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ext_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"links": schemaForLinks(),
+			"ip_address": schemaForIPAddress(),
+			"server_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"network_protocol": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"modules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"log_severity_level": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"should_log_monitor_files": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func datasourceNutanixRsyslogServerV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).ClusterMgmtAPI
+
+	clusterExtID := d.Get("cluster_ext_id").(string)
+	extID := d.Get("ext_id").(string)
+
+	request := &clustermgmtRequest.GetRsyslogServerByIdRequest{
+		ClusterExtId: utils.StringPtr(clusterExtID),
+		ExtId:        utils.StringPtr(extID),
+	}
+
+	resp, err := conn.ClustersServiceAPI.GetRsyslogServerById(ctx, request)
+	if err != nil {
+		return diag.Errorf("error while reading Rsyslog Server: %v", err)
+	}
+	if resp == nil || resp.Data == nil {
+		return diag.Errorf("no Rsyslog Server found with ext_id: %s", extID)
+	}
+
+	server := resp.Data.GetValue().(clustermgmtConfig.RsyslogServer)
+	aJSON, _ := json.MarshalIndent(server, "", "  ")
+	log.Printf("[DEBUG] Get Rsyslog Server Response: %s", string(aJSON))
+
+	d.SetId(utils.StringValue(server.ExtId))
+
+	if err := d.Set("tenant_id", utils.StringValue(server.TenantId)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("links", flattenLinks(server.Links)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("ip_address", flattenIPAddress(server.IpAddress)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("server_name", utils.StringValue(server.ServerName)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("port", utils.IntValue(server.Port)); err != nil {
+		return diag.FromErr(err)
+	}
+	if server.NetworkProtocol != nil {
+		if err := d.Set("network_protocol", server.NetworkProtocol.GetName()); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err := d.Set("modules", flattenRsyslogModules(server.Modules)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/nutanix/services/cluster_managementv2/data_source_nutanix_rsyslog_servers_v2.go
+++ b/nutanix/services/cluster_managementv2/data_source_nutanix_rsyslog_servers_v2.go
@@ -1,0 +1,138 @@
+package cluster_managementv2
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	clustermgmtConfig "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/config"
+	clustermgmtRequest "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/request/clusters"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixRsyslogServersV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceNutanixRsyslogServersV2Read,
+		Schema: map[string]*schema.Schema{
+			"cluster_ext_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"rsyslog_servers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ext_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tenant_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"links": schemaForLinks(),
+						"ip_address": schemaForIPAddress(),
+						"server_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"network_protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"modules": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"log_severity_level": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"should_log_monitor_files": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func datasourceNutanixRsyslogServersV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).ClusterMgmtAPI
+
+	clusterExtID := d.Get("cluster_ext_id").(string)
+
+	request := &clustermgmtRequest.ListRsyslogServersByClusterIdRequest{
+		ClusterExtId: utils.StringPtr(clusterExtID),
+	}
+
+	resp, err := conn.ClustersServiceAPI.ListRsyslogServersByClusterId(ctx, request)
+	if err != nil {
+		return diag.Errorf("error while listing Rsyslog Servers: %v", err)
+	}
+	if resp == nil || resp.Data == nil {
+		if err := d.Set("rsyslog_servers", []map[string]interface{}{}); err != nil {
+			return diag.FromErr(err)
+		}
+		d.SetId(utils.GenUUID())
+		return nil
+	}
+
+	servers := resp.Data.GetValue().([]clustermgmtConfig.RsyslogServer)
+	aJSON, _ := json.MarshalIndent(servers, "", "  ")
+	log.Printf("[DEBUG] List Rsyslog Servers Response: %s", string(aJSON))
+
+	if err := d.Set("rsyslog_servers", flattenRsyslogServers(servers)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(utils.GenUUID())
+	return nil
+}
+
+func flattenRsyslogServers(servers []clustermgmtConfig.RsyslogServer) []map[string]interface{} {
+	if len(servers) == 0 {
+		return []map[string]interface{}{}
+	}
+	result := make([]map[string]interface{}, 0, len(servers))
+	for _, server := range servers {
+		result = append(result, flattenRsyslogServer(server))
+	}
+	return result
+}
+
+func flattenRsyslogServer(server clustermgmtConfig.RsyslogServer) map[string]interface{} {
+	m := map[string]interface{}{
+		"ext_id":      utils.StringValue(server.ExtId),
+		"tenant_id":   utils.StringValue(server.TenantId),
+		"links":       flattenLinks(server.Links),
+		"ip_address":  flattenIPAddress(server.IpAddress),
+		"server_name": utils.StringValue(server.ServerName),
+		"port":        utils.IntValue(server.Port),
+		"modules":     flattenRsyslogModules(server.Modules),
+	}
+	if server.NetworkProtocol != nil {
+		m["network_protocol"] = server.NetworkProtocol.GetName()
+	} else {
+		m["network_protocol"] = ""
+	}
+	return m
+}

--- a/nutanix/services/cluster_managementv2/helpers.go
+++ b/nutanix/services/cluster_managementv2/helpers.go
@@ -1,0 +1,297 @@
+package cluster_managementv2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	clustermgmtConfig "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/config"
+	commonConfig "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/common/v1/config"
+	commonResponse "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/common/v1/response"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func schemaForLinks() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"href": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"rel": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+func schemaForIPAddress() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"ipv4": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"value": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"prefix_length": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"ipv6": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"value": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"prefix_length": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemaForIPAddressInput() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"ipv4": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"value": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"prefix_length": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"ipv6": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"value": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"prefix_length": {
+								Type:     schema.TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func flattenLinks(links []commonResponse.ApiLink) []map[string]interface{} {
+	if len(links) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, 0, len(links))
+	for _, link := range links {
+		result = append(result, map[string]interface{}{
+			"href": utils.StringValue(link.Href),
+			"rel":  utils.StringValue(link.Rel),
+		})
+	}
+	return result
+}
+
+func flattenIPAddress(ip *commonConfig.IPAddress) []map[string]interface{} {
+	if ip == nil {
+		return nil
+	}
+	m := map[string]interface{}{}
+	if ip.Ipv4 != nil {
+		m["ipv4"] = []map[string]interface{}{
+			{
+				"value":         utils.StringValue(ip.Ipv4.Value),
+				"prefix_length": utils.IntValue(ip.Ipv4.PrefixLength),
+			},
+		}
+	} else {
+		m["ipv4"] = []map[string]interface{}{}
+	}
+	if ip.Ipv6 != nil {
+		m["ipv6"] = []map[string]interface{}{
+			{
+				"value":         utils.StringValue(ip.Ipv6.Value),
+				"prefix_length": utils.IntValue(ip.Ipv6.PrefixLength),
+			},
+		}
+	} else {
+		m["ipv6"] = []map[string]interface{}{}
+	}
+	return []map[string]interface{}{m}
+}
+
+func flattenRsyslogModules(modules []clustermgmtConfig.RsyslogModuleItem) []map[string]interface{} {
+	if len(modules) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, 0, len(modules))
+	for _, module := range modules {
+		m := map[string]interface{}{
+			"should_log_monitor_files": utils.BoolValue(module.ShouldLogMonitorFiles),
+		}
+		if module.Name != nil {
+			m["name"] = module.Name.GetName()
+		} else {
+			m["name"] = ""
+		}
+		if module.LogSeverityLevel != nil {
+			m["log_severity_level"] = module.LogSeverityLevel.GetName()
+		} else {
+			m["log_severity_level"] = ""
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+func expandIPAddress(ipList []interface{}) *commonConfig.IPAddress {
+	if len(ipList) == 0 {
+		return nil
+	}
+	ipMap := ipList[0].(map[string]interface{})
+	ip := &commonConfig.IPAddress{}
+
+	if ipv4List, ok := ipMap["ipv4"].([]interface{}); ok && len(ipv4List) > 0 {
+		ipv4Map := ipv4List[0].(map[string]interface{})
+		ip.Ipv4 = &commonConfig.IPv4Address{
+			Value: utils.StringPtr(ipv4Map["value"].(string)),
+		}
+		if pl, ok := ipv4Map["prefix_length"].(int); ok && pl > 0 {
+			ip.Ipv4.PrefixLength = utils.IntPtr(pl)
+		}
+	}
+
+	if ipv6List, ok := ipMap["ipv6"].([]interface{}); ok && len(ipv6List) > 0 {
+		ipv6Map := ipv6List[0].(map[string]interface{})
+		ip.Ipv6 = &commonConfig.IPv6Address{
+			Value: utils.StringPtr(ipv6Map["value"].(string)),
+		}
+		if pl, ok := ipv6Map["prefix_length"].(int); ok && pl > 0 {
+			ip.Ipv6.PrefixLength = utils.IntPtr(pl)
+		}
+	}
+
+	return ip
+}
+
+func expandRsyslogModules(modulesList []interface{}) []clustermgmtConfig.RsyslogModuleItem {
+	if len(modulesList) == 0 {
+		return nil
+	}
+	modules := make([]clustermgmtConfig.RsyslogModuleItem, 0, len(modulesList))
+	for _, m := range modulesList {
+		moduleMap := m.(map[string]interface{})
+		item := clustermgmtConfig.RsyslogModuleItem{}
+
+		if name, ok := moduleMap["name"].(string); ok && name != "" {
+			item.Name = rsyslogModuleNameFromString(name)
+		}
+		if severity, ok := moduleMap["log_severity_level"].(string); ok && severity != "" {
+			item.LogSeverityLevel = rsyslogModuleLogSeverityLevelFromString(severity)
+		}
+		if shouldLog, ok := moduleMap["should_log_monitor_files"].(bool); ok {
+			item.ShouldLogMonitorFiles = utils.BoolPtr(shouldLog)
+		}
+		modules = append(modules, item)
+	}
+	return modules
+}
+
+func rsyslogNetworkProtocolFromString(s string) *clustermgmtConfig.RsyslogNetworkProtocol {
+	protoMap := map[string]clustermgmtConfig.RsyslogNetworkProtocol{
+		"UDP":  clustermgmtConfig.RSYSLOGNETWORKPROTOCOL_UDP,
+		"TCP":  clustermgmtConfig.RSYSLOGNETWORKPROTOCOL_TCP,
+		"RELP": clustermgmtConfig.RSYSLOGNETWORKPROTOCOL_RELP,
+	}
+	if v, ok := protoMap[s]; ok {
+		return &v
+	}
+	return nil
+}
+
+func rsyslogModuleNameFromString(s string) *clustermgmtConfig.RsyslogModuleName {
+	nameMap := map[string]clustermgmtConfig.RsyslogModuleName{
+		"CASSANDRA":         clustermgmtConfig.RSYSLOGMODULENAME_CASSANDRA,
+		"CEREBRO":           clustermgmtConfig.RSYSLOGMODULENAME_CEREBRO,
+		"CURATOR":           clustermgmtConfig.RSYSLOGMODULENAME_CURATOR,
+		"GENESIS":           clustermgmtConfig.RSYSLOGMODULENAME_GENESIS,
+		"PRISM":             clustermgmtConfig.RSYSLOGMODULENAME_PRISM,
+		"STARGATE":          clustermgmtConfig.RSYSLOGMODULENAME_STARGATE,
+		"SYSLOG_MODULE":     clustermgmtConfig.RSYSLOGMODULENAME_SYSLOG_MODULE,
+		"ZOOKEEPER":         clustermgmtConfig.RSYSLOGMODULENAME_ZOOKEEPER,
+		"UHARA":             clustermgmtConfig.RSYSLOGMODULENAME_UHARA,
+		"LAZAN":             clustermgmtConfig.RSYSLOGMODULENAME_LAZAN,
+		"API_AUDIT":         clustermgmtConfig.RSYSLOGMODULENAME_API_AUDIT,
+		"AUDIT":             clustermgmtConfig.RSYSLOGMODULENAME_AUDIT,
+		"CALM":              clustermgmtConfig.RSYSLOGMODULENAME_CALM,
+		"EPSILON":           clustermgmtConfig.RSYSLOGMODULENAME_EPSILON,
+		"ACROPOLIS":         clustermgmtConfig.RSYSLOGMODULENAME_ACROPOLIS,
+		"MINERVA_CVM":       clustermgmtConfig.RSYSLOGMODULENAME_MINERVA_CVM,
+		"FLOW":              clustermgmtConfig.RSYSLOGMODULENAME_FLOW,
+		"FLOW_SERVICE_LOGS": clustermgmtConfig.RSYSLOGMODULENAME_FLOW_SERVICE_LOGS,
+		"LCM":               clustermgmtConfig.RSYSLOGMODULENAME_LCM,
+		"APLOS":             clustermgmtConfig.RSYSLOGMODULENAME_APLOS,
+		"NCM_AIOPS":         clustermgmtConfig.RSYSLOGMODULENAME_NCM_AIOPS,
+	}
+	if v, ok := nameMap[s]; ok {
+		return &v
+	}
+	return nil
+}
+
+func rsyslogModuleLogSeverityLevelFromString(s string) *clustermgmtConfig.RsyslogModuleLogSeverityLevel {
+	levelMap := map[string]clustermgmtConfig.RsyslogModuleLogSeverityLevel{
+		"EMERGENCY": clustermgmtConfig.RSYSLOGMODULELOGSEVERITYLEVEL_EMERGENCY,
+		"ALERT":     clustermgmtConfig.RSYSLOGMODULELOGSEVERITYLEVEL_ALERT,
+		"CRITICAL":  clustermgmtConfig.RSYSLOGMODULELOGSEVERITYLEVEL_CRITICAL,
+		"ERROR":     clustermgmtConfig.RSYSLOGMODULELOGSEVERITYLEVEL_ERROR,
+		"WARNING":   clustermgmtConfig.RSYSLOGMODULELOGSEVERITYLEVEL_WARNING,
+		"NOTICE":    clustermgmtConfig.RSYSLOGMODULELOGSEVERITYLEVEL_NOTICE,
+		"INFO":      clustermgmtConfig.RSYSLOGMODULELOGSEVERITYLEVEL_INFO,
+		"DEBUG":     clustermgmtConfig.RSYSLOGMODULELOGSEVERITYLEVEL_DEBUG,
+	}
+	if v, ok := levelMap[s]; ok {
+		return &v
+	}
+	return nil
+}

--- a/nutanix/services/cluster_managementv2/main_test.go
+++ b/nutanix/services/cluster_managementv2/main_test.go
@@ -1,0 +1,39 @@
+package cluster_managementv2_test
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"testing"
+)
+
+type TestConfig struct {
+	ClusterExtID string `json:"cluster_ext_id"`
+}
+
+var testVars TestConfig
+
+var (
+	path, _  = os.Getwd()
+	filepath = path + "/../../../test_config_v2.json"
+)
+
+func loadVars(filepath string, varStruct interface{}) {
+	configData, err := os.ReadFile(filepath)
+	if err != nil {
+		log.Printf("Got this error while reading config.json: %s", err.Error())
+		os.Exit(1)
+	}
+
+	err = json.Unmarshal(configData, varStruct)
+	if err != nil {
+		log.Printf("Got this error while unmarshalling config.json: %s", err.Error())
+		os.Exit(1)
+	}
+}
+
+func TestMain(m *testing.M) {
+	log.Println("Setting up cluster_managementv2 tests")
+	loadVars("../../../test_config_v2.json", &testVars)
+	os.Exit(m.Run())
+}

--- a/nutanix/services/cluster_managementv2/resource_nutanix_rsyslog_server_v2.go
+++ b/nutanix/services/cluster_managementv2/resource_nutanix_rsyslog_server_v2.go
@@ -1,0 +1,326 @@
+package cluster_managementv2
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	clustermgmtConfig "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/config"
+	clustermgmtRequest "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/request/clusters"
+	prismConfig "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/prism/v4/config"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/common"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func ResourceNutanixRsyslogServerV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNutanixRsyslogServerV2Create,
+		ReadContext:   resourceNutanixRsyslogServerV2Read,
+		UpdateContext: resourceNutanixRsyslogServerV2Update,
+		DeleteContext: resourceNutanixRsyslogServerV2Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"cluster_ext_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ext_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"links": schemaForLinks(),
+			"ip_address": schemaForIPAddressInput(),
+			"server_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"port": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"network_protocol": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"UDP", "TCP", "RELP"}, false),
+			},
+			"modules": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"CASSANDRA", "CEREBRO", "CURATOR", "GENESIS", "PRISM",
+								"STARGATE", "SYSLOG_MODULE", "ZOOKEEPER", "UHARA", "LAZAN",
+								"API_AUDIT", "AUDIT", "CALM", "EPSILON", "ACROPOLIS",
+								"MINERVA_CVM", "FLOW", "FLOW_SERVICE_LOGS", "LCM", "APLOS", "NCM_AIOPS",
+							}, false),
+						},
+						"log_severity_level": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"EMERGENCY", "ALERT", "CRITICAL", "ERROR",
+								"WARNING", "NOTICE", "INFO", "DEBUG",
+							}, false),
+						},
+						"should_log_monitor_files": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceNutanixRsyslogServerV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).ClusterMgmtAPI
+
+	clusterExtID := d.Get("cluster_ext_id").(string)
+
+	body := &clustermgmtConfig.RsyslogServer{}
+
+	if v, ok := d.GetOk("server_name"); ok {
+		body.ServerName = utils.StringPtr(v.(string))
+	}
+	if v, ok := d.GetOk("port"); ok {
+		body.Port = utils.IntPtr(v.(int))
+	}
+	if v, ok := d.GetOk("network_protocol"); ok {
+		body.NetworkProtocol = rsyslogNetworkProtocolFromString(v.(string))
+	}
+	if v, ok := d.GetOk("ip_address"); ok {
+		body.IpAddress = expandIPAddress(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("modules"); ok {
+		body.Modules = expandRsyslogModules(v.([]interface{}))
+	}
+
+	request := &clustermgmtRequest.CreateRsyslogServerRequest{
+		ClusterExtId: utils.StringPtr(clusterExtID),
+		Body:         body,
+	}
+
+	aJSON, _ := json.MarshalIndent(body, "", "  ")
+	log.Printf("[DEBUG] Create Rsyslog Server Request Body: %s", string(aJSON))
+
+	resp, err := conn.ClustersServiceAPI.CreateRsyslogServer(ctx, request)
+	if err != nil {
+		return diag.Errorf("error while creating Rsyslog Server: %v", err)
+	}
+
+	taskRef := resp.Data.GetValue().(prismConfig.TaskReference)
+	taskUUID := taskRef.ExtId
+	log.Printf("[DEBUG] Create Rsyslog Server Task UUID: %s", utils.StringValue(taskUUID))
+
+	taskconn := meta.(*conns.Client).PrismAPI
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"QUEUED", "RUNNING", "PENDING"},
+		Target:  []string{"SUCCEEDED"},
+		Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, taskconn, utils.StringValue(taskUUID)),
+		Timeout: 5 * time.Minute,
+	}
+	if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
+		return diag.Errorf("error waiting for rsyslog server to create: %s", errWaitTask)
+	}
+
+	// After task completes, list and find the created server by name
+	listRequest := &clustermgmtRequest.ListRsyslogServersByClusterIdRequest{
+		ClusterExtId: utils.StringPtr(clusterExtID),
+	}
+	listResp, err := conn.ClustersServiceAPI.ListRsyslogServersByClusterId(ctx, listRequest)
+	if err != nil {
+		return diag.Errorf("error while listing Rsyslog Servers after creation: %v", err)
+	}
+
+	if listResp != nil && listResp.Data != nil {
+		servers := listResp.Data.GetValue().([]clustermgmtConfig.RsyslogServer)
+		for _, server := range servers {
+			if utils.StringValue(server.ServerName) == d.Get("server_name").(string) {
+				d.SetId(utils.StringValue(server.ExtId))
+				return resourceNutanixRsyslogServerV2Read(ctx, d, meta)
+			}
+		}
+	}
+
+	return diag.Errorf("rsyslog server was created but could not be found in list response")
+}
+
+func resourceNutanixRsyslogServerV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).ClusterMgmtAPI
+
+	clusterExtID := d.Get("cluster_ext_id").(string)
+	extID := d.Id()
+
+	request := &clustermgmtRequest.GetRsyslogServerByIdRequest{
+		ClusterExtId: utils.StringPtr(clusterExtID),
+		ExtId:        utils.StringPtr(extID),
+	}
+
+	resp, err := conn.ClustersServiceAPI.GetRsyslogServerById(ctx, request)
+	if err != nil {
+		return diag.Errorf("error while reading Rsyslog Server: %v", err)
+	}
+	if resp == nil || resp.Data == nil {
+		d.SetId("")
+		return nil
+	}
+
+	server := resp.Data.GetValue().(clustermgmtConfig.RsyslogServer)
+	aJSON, _ := json.MarshalIndent(server, "", "  ")
+	log.Printf("[DEBUG] Read Rsyslog Server Response: %s", string(aJSON))
+
+	if err := d.Set("ext_id", utils.StringValue(server.ExtId)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("tenant_id", utils.StringValue(server.TenantId)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("links", flattenLinks(server.Links)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("ip_address", flattenIPAddress(server.IpAddress)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("server_name", utils.StringValue(server.ServerName)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("port", utils.IntValue(server.Port)); err != nil {
+		return diag.FromErr(err)
+	}
+	if server.NetworkProtocol != nil {
+		if err := d.Set("network_protocol", server.NetworkProtocol.GetName()); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err := d.Set("modules", flattenRsyslogModules(server.Modules)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceNutanixRsyslogServerV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).ClusterMgmtAPI
+
+	clusterExtID := d.Get("cluster_ext_id").(string)
+	extID := d.Id()
+
+	// Read first to get the ETag
+	getRequest := &clustermgmtRequest.GetRsyslogServerByIdRequest{
+		ClusterExtId: utils.StringPtr(clusterExtID),
+		ExtId:        utils.StringPtr(extID),
+	}
+	getResp, err := conn.ClustersServiceAPI.GetRsyslogServerById(ctx, getRequest)
+	if err != nil {
+		return diag.Errorf("error reading Rsyslog Server for update: %v", err)
+	}
+	serverData := getResp.Data.GetValue().(clustermgmtConfig.RsyslogServer)
+	etagValue := conn.ClustersServiceAPI.ApiClient.GetEtag(&serverData)
+	args := make(map[string]interface{})
+	args["If-Match"] = utils.StringPtr(etagValue)
+
+	body := &clustermgmtConfig.RsyslogServer{}
+
+	if v, ok := d.GetOk("server_name"); ok {
+		body.ServerName = utils.StringPtr(v.(string))
+	}
+	if v, ok := d.GetOk("port"); ok {
+		body.Port = utils.IntPtr(v.(int))
+	}
+	if v, ok := d.GetOk("network_protocol"); ok {
+		body.NetworkProtocol = rsyslogNetworkProtocolFromString(v.(string))
+	}
+	if v, ok := d.GetOk("ip_address"); ok {
+		body.IpAddress = expandIPAddress(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("modules"); ok {
+		body.Modules = expandRsyslogModules(v.([]interface{}))
+	}
+
+	request := &clustermgmtRequest.UpdateRsyslogServerByIdRequest{
+		ClusterExtId: utils.StringPtr(clusterExtID),
+		ExtId:        utils.StringPtr(extID),
+		Body:         body,
+	}
+
+	aJSON, _ := json.MarshalIndent(body, "", "  ")
+	log.Printf("[DEBUG] Update Rsyslog Server Request Body: %s", string(aJSON))
+
+	updateResp, err := conn.ClustersServiceAPI.UpdateRsyslogServerById(ctx, request, args)
+	if err != nil {
+		return diag.Errorf("error while updating Rsyslog Server: %v", err)
+	}
+
+	taskRef := updateResp.Data.GetValue().(prismConfig.TaskReference)
+	taskUUID := taskRef.ExtId
+	log.Printf("[DEBUG] Update Rsyslog Server Task UUID: %s", utils.StringValue(taskUUID))
+
+	taskconn := meta.(*conns.Client).PrismAPI
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"QUEUED", "RUNNING", "PENDING"},
+		Target:  []string{"SUCCEEDED"},
+		Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, taskconn, utils.StringValue(taskUUID)),
+		Timeout: 5 * time.Minute,
+	}
+	if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
+		return diag.Errorf("error waiting for rsyslog server to update: %s", errWaitTask)
+	}
+
+	return resourceNutanixRsyslogServerV2Read(ctx, d, meta)
+}
+
+func resourceNutanixRsyslogServerV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).ClusterMgmtAPI
+
+	clusterExtID := d.Get("cluster_ext_id").(string)
+	extID := d.Id()
+
+	request := &clustermgmtRequest.DeleteRsyslogServerByIdRequest{
+		ClusterExtId: utils.StringPtr(clusterExtID),
+		ExtId:        utils.StringPtr(extID),
+	}
+
+	deleteResp, err := conn.ClustersServiceAPI.DeleteRsyslogServerById(ctx, request)
+	if err != nil {
+		return diag.Errorf("error while deleting Rsyslog Server: %v", err)
+	}
+
+	taskRef := deleteResp.Data.GetValue().(prismConfig.TaskReference)
+	taskUUID := taskRef.ExtId
+	log.Printf("[DEBUG] Delete Rsyslog Server Task UUID: %s", utils.StringValue(taskUUID))
+
+	taskconn := meta.(*conns.Client).PrismAPI
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"QUEUED", "RUNNING", "PENDING"},
+		Target:  []string{"SUCCEEDED"},
+		Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, taskconn, utils.StringValue(taskUUID)),
+		Timeout: 5 * time.Minute,
+	}
+	if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
+		return diag.Errorf("error waiting for rsyslog server to delete: %s", errWaitTask)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/nutanix/services/cluster_managementv2/resource_nutanix_rsyslog_server_v2_test.go
+++ b/nutanix/services/cluster_managementv2/resource_nutanix_rsyslog_server_v2_test.go
@@ -1,0 +1,175 @@
+package cluster_managementv2_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const resourceNameRsyslogServer = "nutanix_rsyslog_server_v2.test"
+const dataSourceNameRsyslogServer = "data.nutanix_rsyslog_server_v2.test"
+const dataSourceNameRsyslogServers = "data.nutanix_rsyslog_servers_v2.test"
+
+func TestAccV2NutanixRsyslogServerResource_Basic(t *testing.T) {
+	clusterExtID := testVars.ClusterExtID
+	if clusterExtID == "" {
+		clusterExtID = os.Getenv("NUTANIX_CLUSTER_EXT_ID")
+	}
+	if clusterExtID == "" {
+		t.Skip("NUTANIX_CLUSTER_EXT_ID must be set for this test")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testRsyslogServerResourceConfig(clusterExtID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameRsyslogServer, "ext_id"),
+					resource.TestCheckResourceAttr(resourceNameRsyslogServer, "cluster_ext_id", clusterExtID),
+					resource.TestCheckResourceAttr(resourceNameRsyslogServer, "server_name", "tf-test-rsyslog-server"),
+					resource.TestCheckResourceAttr(resourceNameRsyslogServer, "port", "514"),
+					resource.TestCheckResourceAttr(resourceNameRsyslogServer, "network_protocol", "UDP"),
+					resource.TestCheckResourceAttr(resourceNameRsyslogServer, "ip_address.0.ipv4.0.value", "10.0.0.1"),
+					resource.TestCheckResourceAttr(resourceNameRsyslogServer, "modules.0.name", "CASSANDRA"),
+					resource.TestCheckResourceAttr(resourceNameRsyslogServer, "modules.0.log_severity_level", "INFO"),
+					resource.TestCheckResourceAttr(resourceNameRsyslogServer, "modules.0.should_log_monitor_files", "true"),
+				),
+			},
+			{
+				Config: testRsyslogServerResourceConfigUpdate(clusterExtID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameRsyslogServer, "ext_id"),
+					resource.TestCheckResourceAttr(resourceNameRsyslogServer, "cluster_ext_id", clusterExtID),
+					resource.TestCheckResourceAttr(resourceNameRsyslogServer, "server_name", "tf-test-rsyslog-server"),
+					resource.TestCheckResourceAttr(resourceNameRsyslogServer, "port", "1514"),
+					resource.TestCheckResourceAttr(resourceNameRsyslogServer, "network_protocol", "TCP"),
+					resource.TestCheckResourceAttr(resourceNameRsyslogServer, "ip_address.0.ipv4.0.value", "10.0.0.2"),
+					resource.TestCheckResourceAttr(resourceNameRsyslogServer, "modules.0.name", "PRISM"),
+					resource.TestCheckResourceAttr(resourceNameRsyslogServer, "modules.0.log_severity_level", "WARNING"),
+					resource.TestCheckResourceAttr(resourceNameRsyslogServer, "modules.0.should_log_monitor_files", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixRsyslogServerDatasource_Basic(t *testing.T) {
+	clusterExtID := testVars.ClusterExtID
+	if clusterExtID == "" {
+		clusterExtID = os.Getenv("NUTANIX_CLUSTER_EXT_ID")
+	}
+	if clusterExtID == "" {
+		t.Skip("NUTANIX_CLUSTER_EXT_ID must be set for this test")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testRsyslogServerResourceConfig(clusterExtID) + testRsyslogServerDatasourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceNameRsyslogServer, "ext_id"),
+					resource.TestCheckResourceAttr(dataSourceNameRsyslogServer, "server_name", "tf-test-rsyslog-server"),
+					resource.TestCheckResourceAttr(dataSourceNameRsyslogServer, "port", "514"),
+					resource.TestCheckResourceAttr(dataSourceNameRsyslogServer, "network_protocol", "UDP"),
+					resource.TestCheckResourceAttr(dataSourceNameRsyslogServer, "ip_address.0.ipv4.0.value", "10.0.0.1"),
+					resource.TestCheckResourceAttr(dataSourceNameRsyslogServer, "modules.0.name", "CASSANDRA"),
+					resource.TestCheckResourceAttr(dataSourceNameRsyslogServer, "modules.0.log_severity_level", "INFO"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixRsyslogServersDatasource_Basic(t *testing.T) {
+	clusterExtID := testVars.ClusterExtID
+	if clusterExtID == "" {
+		clusterExtID = os.Getenv("NUTANIX_CLUSTER_EXT_ID")
+	}
+	if clusterExtID == "" {
+		t.Skip("NUTANIX_CLUSTER_EXT_ID must be set for this test")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testRsyslogServerResourceConfig(clusterExtID) + testRsyslogServersDatasourceConfig(clusterExtID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceNameRsyslogServers, "rsyslog_servers.#"),
+				),
+			},
+		},
+	})
+}
+
+func testRsyslogServerResourceConfig(clusterExtID string) string {
+	return fmt.Sprintf(`
+resource "nutanix_rsyslog_server_v2" "test" {
+  cluster_ext_id   = "%s"
+  server_name      = "tf-test-rsyslog-server"
+  port             = 514
+  network_protocol = "UDP"
+
+  ip_address {
+    ipv4 {
+      value = "10.0.0.1"
+    }
+  }
+
+  modules {
+    name                    = "CASSANDRA"
+    log_severity_level      = "INFO"
+    should_log_monitor_files = true
+  }
+}
+`, clusterExtID)
+}
+
+func testRsyslogServerResourceConfigUpdate(clusterExtID string) string {
+	return fmt.Sprintf(`
+resource "nutanix_rsyslog_server_v2" "test" {
+  cluster_ext_id   = "%s"
+  server_name      = "tf-test-rsyslog-server"
+  port             = 1514
+  network_protocol = "TCP"
+
+  ip_address {
+    ipv4 {
+      value = "10.0.0.2"
+    }
+  }
+
+  modules {
+    name                    = "PRISM"
+    log_severity_level      = "WARNING"
+    should_log_monitor_files = false
+  }
+}
+`, clusterExtID)
+}
+
+func testRsyslogServerDatasourceConfig() string {
+	return `
+data "nutanix_rsyslog_server_v2" "test" {
+  cluster_ext_id = nutanix_rsyslog_server_v2.test.cluster_ext_id
+  ext_id         = nutanix_rsyslog_server_v2.test.id
+}
+`
+}
+
+func testRsyslogServersDatasourceConfig(clusterExtID string) string {
+	return fmt.Sprintf(`
+data "nutanix_rsyslog_servers_v2" "test" {
+  cluster_ext_id = "%s"
+  depends_on     = [nutanix_rsyslog_server_v2.test]
+}
+`, clusterExtID)
+}

--- a/website/docs/d/rsyslog_server_v2.html.markdown
+++ b/website/docs/d/rsyslog_server_v2.html.markdown
@@ -1,0 +1,60 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_rsyslog_server_v2"
+sidebar_current: "docs-nutanix-datasource-rsyslog-server-v2"
+description: |-
+  Fetches the RSYSLOG server configuration identified by {extId} associated with the cluster identified by {clusterExtId}.
+---
+
+# nutanix_rsyslog_server_v2
+
+Fetches the RSYSLOG server configuration identified by {extId} associated with the cluster identified by {clusterExtId}.
+
+## Example Usage
+
+```hcl
+data "nutanix_rsyslog_server_v2" "example" {
+  cluster_ext_id = "00000000-0000-0000-0000-000000000000"
+  ext_id         = "00000000-0000-0000-0000-000000000001"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_ext_id` - (Required) Indicates the UUID of a cluster.
+* `ext_id` - (Required) RSYSLOG server UUID.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `tenant_id` - A globally unique identifier that represents the tenant that owns this entity.
+* `links` - A HATEOAS style link for the response.
+* `ip_address` - IP address of the RSYSLOG server.
+* `server_name` - RSYSLOG server name.
+* `port` - RSYSLOG server port.
+* `network_protocol` - Network protocol for RSYSLOG server. Valid values are `UDP`, `TCP`, `RELP`.
+* `modules` - List of modules registered to RSYSLOG server.
+
+### links
+
+* `href` - The URL at which the entity described by the link can be accessed.
+* `rel` - A name that identifies the relationship of the link to the object that is returned by the URL.
+
+### ip_address
+
+* `ipv4` - IPv4 address.
+* `ipv6` - IPv6 address.
+
+### ipv4, ipv6
+
+* `value` - The IP address value.
+* `prefix_length` - The prefix length of the network to which this host address belongs.
+
+### modules
+
+* `name` - Module name. Valid values are `CASSANDRA`, `CEREBRO`, `CURATOR`, `GENESIS`, `PRISM`, `STARGATE`, `SYSLOG_MODULE`, `ZOOKEEPER`, `UHARA`, `LAZAN`, `API_AUDIT`, `AUDIT`, `CALM`, `EPSILON`, `ACROPOLIS`, `MINERVA_CVM`, `FLOW`, `FLOW_SERVICE_LOGS`, `LCM`, `APLOS`, `NCM_AIOPS`.
+* `log_severity_level` - Log severity level. Valid values are `EMERGENCY`, `ALERT`, `CRITICAL`, `ERROR`, `WARNING`, `NOTICE`, `INFO`, `DEBUG`.
+* `should_log_monitor_files` - Option to log, monitor/output files of a module.

--- a/website/docs/d/rsyslog_servers_v2.html.markdown
+++ b/website/docs/d/rsyslog_servers_v2.html.markdown
@@ -1,0 +1,63 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_rsyslog_servers_v2"
+sidebar_current: "docs-nutanix-datasource-rsyslog-servers-v2"
+description: |-
+  Lists the RSYSLOG server configurations associated with the cluster identified by {clusterExtId}.
+---
+
+# nutanix_rsyslog_servers_v2
+
+Lists the RSYSLOG server configurations associated with the cluster identified by {clusterExtId}.
+
+## Example Usage
+
+```hcl
+data "nutanix_rsyslog_servers_v2" "example" {
+  cluster_ext_id = "00000000-0000-0000-0000-000000000000"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_ext_id` - (Required) Indicates the UUID of a cluster.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `rsyslog_servers` - List of RSYSLOG server configurations.
+
+### rsyslog_servers
+
+* `ext_id` - A globally unique identifier of an instance that is suitable for external consumption.
+* `tenant_id` - A globally unique identifier that represents the tenant that owns this entity.
+* `links` - A HATEOAS style link for the response.
+* `ip_address` - IP address of the RSYSLOG server.
+* `server_name` - RSYSLOG server name.
+* `port` - RSYSLOG server port.
+* `network_protocol` - Network protocol for RSYSLOG server. Valid values are `UDP`, `TCP`, `RELP`.
+* `modules` - List of modules registered to RSYSLOG server.
+
+### links
+
+* `href` - The URL at which the entity described by the link can be accessed.
+* `rel` - A name that identifies the relationship of the link to the object that is returned by the URL.
+
+### ip_address
+
+* `ipv4` - IPv4 address.
+* `ipv6` - IPv6 address.
+
+### ipv4, ipv6
+
+* `value` - The IP address value.
+* `prefix_length` - The prefix length of the network to which this host address belongs.
+
+### modules
+
+* `name` - Module name. Valid values are `CASSANDRA`, `CEREBRO`, `CURATOR`, `GENESIS`, `PRISM`, `STARGATE`, `SYSLOG_MODULE`, `ZOOKEEPER`, `UHARA`, `LAZAN`, `API_AUDIT`, `AUDIT`, `CALM`, `EPSILON`, `ACROPOLIS`, `MINERVA_CVM`, `FLOW`, `FLOW_SERVICE_LOGS`, `LCM`, `APLOS`, `NCM_AIOPS`.
+* `log_severity_level` - Log severity level. Valid values are `EMERGENCY`, `ALERT`, `CRITICAL`, `ERROR`, `WARNING`, `NOTICE`, `INFO`, `DEBUG`.
+* `should_log_monitor_files` - Option to log, monitor/output files of a module.

--- a/website/docs/r/rsyslog_server_v2.html.markdown
+++ b/website/docs/r/rsyslog_server_v2.html.markdown
@@ -1,0 +1,82 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_rsyslog_server_v2"
+sidebar_current: "docs-nutanix-resource-rsyslog-server-v2"
+description: |-
+  Adds RSYSLOG server configuration to the cluster identified by {clusterExtId}.
+---
+
+# nutanix_rsyslog_server_v2
+
+Adds RSYSLOG server configuration to the cluster identified by {clusterExtId}. Supports create, read, update, and delete operations.
+
+## Example Usage
+
+```hcl
+resource "nutanix_rsyslog_server_v2" "example" {
+  cluster_ext_id   = "00000000-0000-0000-0000-000000000000"
+  server_name      = "example-rsyslog-server"
+  port             = 514
+  network_protocol = "UDP"
+
+  ip_address {
+    ipv4 {
+      value = "10.0.0.100"
+    }
+  }
+
+  modules {
+    name                     = "CASSANDRA"
+    log_severity_level       = "INFO"
+    should_log_monitor_files = true
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster_ext_id` - (Required) Indicates the UUID of a cluster.
+* `server_name` - (Required) RSYSLOG server name. This is the primary key of the entity and cannot be updated.
+* `port` - (Required) RSYSLOG server port.
+* `network_protocol` - (Required) Network protocol for RSYSLOG server. Valid values are `UDP`, `TCP`, `RELP`.
+* `ip_address` - (Required) IP address of the RSYSLOG server.
+* `modules` - (Optional) List of modules registered to RSYSLOG server.
+
+### ip_address
+
+* `ipv4` - (Optional) IPv4 address.
+* `ipv6` - (Optional) IPv6 address.
+
+### ipv4, ipv6
+
+* `value` - (Required) The IP address value.
+* `prefix_length` - (Optional) The prefix length of the network to which this host address belongs.
+
+### modules
+
+* `name` - (Required) Module name. Valid values are `CASSANDRA`, `CEREBRO`, `CURATOR`, `GENESIS`, `PRISM`, `STARGATE`, `SYSLOG_MODULE`, `ZOOKEEPER`, `UHARA`, `LAZAN`, `API_AUDIT`, `AUDIT`, `CALM`, `EPSILON`, `ACROPOLIS`, `MINERVA_CVM`, `FLOW`, `FLOW_SERVICE_LOGS`, `LCM`, `APLOS`, `NCM_AIOPS`.
+* `log_severity_level` - (Required) Log severity level. Valid values are `EMERGENCY`, `ALERT`, `CRITICAL`, `ERROR`, `WARNING`, `NOTICE`, `INFO`, `DEBUG`.
+* `should_log_monitor_files` - (Optional) Option to log, monitor/output files of a module.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `ext_id` - A globally unique identifier of an instance that is suitable for external consumption.
+* `tenant_id` - A globally unique identifier that represents the tenant that owns this entity.
+* `links` - A HATEOAS style link for the response.
+
+### links
+
+* `href` - The URL at which the entity described by the link can be accessed.
+* `rel` - A name that identifies the relationship of the link to the object that is returned by the URL.
+
+## Import
+
+Rsyslog Server can be imported using the format `cluster_ext_id/ext_id`:
+
+```shell
+terraform import nutanix_rsyslog_server_v2.example 00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000001
+```


### PR DESCRIPTION
## Summary

Auto-generated Terraform provider code for the **cluster_management** namespace, entity
**RsyslogServer**, based on the inline `sdk_info.json` (see prompt). One PR per code-gen run.

- SDK module: `github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4@v4.2.2`  (read from `go.mod`)
- API methods covered: `5`
- Datasources generated: `2` (`nutanix_rsyslog_server_v2`, `nutanix_rsyslog_servers_v2`)
- Resources generated:   `1` (`nutanix_rsyslog_server_v2`)

## Files changed

- **nutanix/sdks/v4/cluster_management/**
  - `cluster_management.go` — New SDK client wrapper for ClustersServiceApi
- **nutanix/services/cluster_managementv2/**
  - `helpers.go` — Shared schema definitions, flatten/expand helpers
  - `data_source_nutanix_rsyslog_server_v2.go` — Singular datasource (GetRsyslogServerById)
  - `data_source_nutanix_rsyslog_servers_v2.go` — Plural datasource (ListRsyslogServersByClusterId)
  - `resource_nutanix_rsyslog_server_v2.go` — Resource with full CRUD
  - `main_test.go` — Test setup
  - `resource_nutanix_rsyslog_server_v2_test.go` — Acceptance tests
- **nutanix/config.go** — Added ClusterMgmtAPI client field
- **nutanix/provider/provider.go** — Registered new datasources and resource
- **examples/cluster_management_v2/RsyslogServer/**
  - `main.tf`, `variables.tf`, `terraform.tfvars`
- **website/docs/d/**
  - `rsyslog_server_v2.html.markdown`, `rsyslog_servers_v2.html.markdown`
- **website/docs/r/**
  - `rsyslog_server_v2.html.markdown`

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `TF_ACC=1 go test ./nutanix/services/cluster_managementv2 -v "-run=TestAccV2NutanixRsyslogServer" -timeout 500m` |
| Total testcases     | `3`                                            |
| Passed              | `3`                                            |
| Failed              | `0`                                            |
| Skipped             | `0`                                            |
| Wall-clock duration | `0:00:22`                                      |
| Cluster (PC)        | `10.44.76.93`                                  |

### Analysis

All 3 tests passed:
- `TestAccV2NutanixRsyslogServerResource_Basic` — PASS (10.53s): Creates, updates (port/protocol/IP/modules), and deletes an RSYSLOG server.
- `TestAccV2NutanixRsyslogServerDatasource_Basic` — PASS (6.44s): Reads a singular RSYSLOG server datasource.
- `TestAccV2NutanixRsyslogServersDatasource_Basic` — PASS (6.02s): Lists all RSYSLOG servers for a cluster.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
2026/05/17 06:08:25 Setting up cluster_managementv2 tests
=== RUN   TestAccV2NutanixRsyslogServerResource_Basic
--- PASS: TestAccV2NutanixRsyslogServerResource_Basic (10.53s)
=== RUN   TestAccV2NutanixRsyslogServerDatasource_Basic
--- PASS: TestAccV2NutanixRsyslogServerDatasource_Basic (6.44s)
=== RUN   TestAccV2NutanixRsyslogServersDatasource_Basic
--- PASS: TestAccV2NutanixRsyslogServersDatasource_Basic (6.02s)
PASS
coverage: 75.2% of statements
ok  	github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/cluster_managementv2	21.851s
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` are stored only in the agent transcript;
  no `sdk_info.json` is committed to this branch.
