### PR TITLE
feat: add DirectoryServerConfig resource and datasources for microseg

### DIFF
--- a/examples/directory_server_config_v2/main.tf
+++ b/examples/directory_server_config_v2/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = ">=2.0"
+    }
+  }
+}
+
+provider "nutanix" {
+  username = var.nutanix_username
+  password = var.nutanix_password
+  endpoint = var.nutanix_endpoint
+  insecure = true
+}
+
+# Create a Directory Server Config
+resource "nutanix_directory_server_config_v2" "example" {
+  directory_service_reference = var.directory_service_ext_id
+
+  matching_criterias {
+    match_entity = "VM"
+    match_field  = "NAME"
+    match_type   = "ALL"
+  }
+
+  is_default_category_enabled           = true
+  should_keep_default_category_on_login = false
+}
+
+# Read a single Directory Server Config
+data "nutanix_directory_server_config_v2" "example" {
+  ext_id = nutanix_directory_server_config_v2.example.ext_id
+}
+
+# List all Directory Server Configs
+data "nutanix_directory_server_configs_v2" "all" {
+  depends_on = [nutanix_directory_server_config_v2.example]
+}
+
+# List all Category Mappings
+data "nutanix_category_mappings_v2" "all" {}

--- a/examples/directory_server_config_v2/terraform.tfvars
+++ b/examples/directory_server_config_v2/terraform.tfvars
@@ -1,0 +1,4 @@
+nutanix_username         = "<username>"
+nutanix_password         = "<password>"
+nutanix_endpoint         = "<prism-central-ip>"
+directory_service_ext_id = "<directory-service-ext-id>"

--- a/examples/directory_server_config_v2/variables.tf
+++ b/examples/directory_server_config_v2/variables.tf
@@ -1,0 +1,17 @@
+variable "nutanix_username" {
+  type = string
+}
+
+variable "nutanix_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "nutanix_endpoint" {
+  type = string
+}
+
+variable "directory_service_ext_id" {
+  type        = string
+  description = "The ExtID of the directory service to use for mapping."
+}

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/iam"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/iamv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/lcmv2"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/microsegv2"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/ndb"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/networking"
 	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/networkingv2"
@@ -285,6 +286,10 @@ func Provider() *schema.Provider {
 			"nutanix_service_groups_v2":                       networkingv2.DatasourceNutanixServiceGroupsV2(),
 			"nutanix_address_group_v2":                        networkingv2.DatasourceNutanixAddressGroupV2(),
 			"nutanix_address_groups_v2":                       networkingv2.DatasourceNutanixAddressGroupsV2(),
+			"nutanix_directory_server_config_v2":              microsegv2.DatasourceNutanixDirectoryServerConfigV2(),
+			"nutanix_directory_server_configs_v2":             microsegv2.DatasourceNutanixDirectoryServerConfigsV2(),
+			"nutanix_category_mapping_v2":                    microsegv2.DatasourceNutanixCategoryMappingV2(),
+			"nutanix_category_mappings_v2":                   microsegv2.DatasourceNutanixCategoryMappingsV2(),
 			"nutanix_directory_service_v2":                    iamv2.DatasourceNutanixDirectoryServiceV2(),
 			"nutanix_directory_services_v2":                   iamv2.DatasourceNutanixDirectoryServicesV2(),
 			"nutanix_saml_identity_provider_v2":               iamv2.DatasourceNutanixSamlIDPV2(),
@@ -428,6 +433,7 @@ func Provider() *schema.Provider {
 			"nutanix_pbr_v2":                                  networkingv2.ResourceNutanixPbrsV2(),
 			"nutanix_service_groups_v2":                       networkingv2.ResourceNutanixServiceGroupsV2(),
 			"nutanix_address_groups_v2":                       networkingv2.ResourceNutanixAddressGroupsV2(),
+			"nutanix_directory_server_config_v2":              microsegv2.ResourceNutanixDirectoryServerConfigV2(),
 			"nutanix_directory_services_v2":                   iamv2.ResourceNutanixDirectoryServicesV2(),
 			"nutanix_user_groups_v2":                          iamv2.ResourceNutanixUserGroupsV2(),
 			"nutanix_roles_v2":                                iamv2.ResourceNutanixRolesV2(),

--- a/nutanix/sdks/v4/iam/iam.go
+++ b/nutanix/sdks/v4/iam/iam.go
@@ -40,6 +40,8 @@ func NewIamClient(credentials client.Credentials) (*Client, error) {
 		OperationsAPIInstance:       api.NewOperationsServiceApi(baseClient),
 		UsersAPIInstance:            api.NewUsersServiceApi(baseClient),
 		AuthAPIInstance:             api.NewAuthorizationPoliciesServiceApi(baseClient),
-		APIClientInstance:           iam.NewApiClient(),
-	}, nil
+		APIClientInstance:           baseClient,
+	}
+
+	return f, nil
 }

--- a/nutanix/sdks/v4/microseg/microseg.go
+++ b/nutanix/sdks/v4/microseg/microseg.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Client struct {
-	AddressGroupAPIInstance    *api.AddressGroupsServiceApi
-	ServiceGroupAPIInstance    *api.ServiceGroupsServiceApi
-	NetworkingSecurityInstance *api.NetworkSecurityPoliciesServiceApi
-	EntityGroupsAPIInstance    *api.EntityGroupsServiceApi
+	AddressGroupAPIInstance           *api.AddressGroupsServiceApi
+	ServiceGroupAPIInstance           *api.ServiceGroupsServiceApi
+	NetworkingSecurityInstance        *api.NetworkSecurityPoliciesServiceApi
+	EntityGroupsAPIInstance           *api.EntityGroupsServiceApi
+	DirectoryServerConfigsAPIInstance *api.DirectoryServerConfigsServiceApi
 }
 
 func NewMicrosegClient(credentials client.Credentials) (*Client, error) {
@@ -29,10 +30,11 @@ func NewMicrosegClient(credentials client.Credentials) (*Client, error) {
 	}
 
 	f := &Client{
-		AddressGroupAPIInstance:    api.NewAddressGroupsServiceApi(baseClient),
-		ServiceGroupAPIInstance:    api.NewServiceGroupsServiceApi(baseClient),
-		NetworkingSecurityInstance: api.NewNetworkSecurityPoliciesServiceApi(baseClient),
-		EntityGroupsAPIInstance:    api.NewEntityGroupsServiceApi(baseClient),
+		AddressGroupAPIInstance:           api.NewAddressGroupsServiceApi(baseClient),
+		ServiceGroupAPIInstance:           api.NewServiceGroupsServiceApi(baseClient),
+		NetworkingSecurityInstance:        api.NewNetworkSecurityPoliciesServiceApi(baseClient),
+		EntityGroupsAPIInstance:           api.NewEntityGroupsServiceApi(baseClient),
+		DirectoryServerConfigsAPIInstance: api.NewDirectoryServerConfigsServiceApi(baseClient),
 	}
 
 	return f, nil

--- a/nutanix/services/microsegv2/data_source_nutanix_category_mapping_v2.go
+++ b/nutanix/services/microsegv2/data_source_nutanix_category_mapping_v2.go
@@ -1,0 +1,90 @@
+package microsegv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	import2 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/config"
+	import3 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/request/directoryserverconfigs"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixCategoryMappingV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DatasourceNutanixCategoryMappingV2Read,
+		Schema: map[string]*schema.Schema{
+			"ext_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"links": schemaForLinks(),
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"category_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"category_value": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ad_info": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     schemaForAdInfoComputed(),
+			},
+			"project_ext_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func DatasourceNutanixCategoryMappingV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MicroSegAPI
+
+	extID := d.Get("ext_id").(string)
+	req := import3.GetDsCategoryMappingByIdRequest{
+		ExtId: utils.StringPtr(extID),
+	}
+	resp, err := conn.DirectoryServerConfigsAPIInstance.GetDsCategoryMappingById(ctx, &req)
+	if err != nil {
+		return diag.Errorf("error while fetching Category Mapping: %s", err)
+	}
+
+	getResp := resp.Data.GetValue().(import2.CategoryMapping)
+
+	if err := d.Set("tenant_id", getResp.TenantId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("links", flattenLinksDSC(getResp.Links)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("name", getResp.Name); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("category_name", getResp.CategoryName); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("category_value", getResp.CategoryValue); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("ad_info", flattenAdInfo(getResp.AdInfo)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("project_ext_id", getResp.ProjectExtId); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(*getResp.ExtId)
+	return nil
+}

--- a/nutanix/services/microsegv2/data_source_nutanix_category_mappings_v2.go
+++ b/nutanix/services/microsegv2/data_source_nutanix_category_mappings_v2.go
@@ -1,0 +1,126 @@
+package microsegv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	import2 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/config"
+	import3 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/request/directoryserverconfigs"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixCategoryMappingsV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DatasourceNutanixCategoryMappingsV2Read,
+		Schema: map[string]*schema.Schema{
+			"page": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"limit": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"order_by": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"select": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"category_mappings": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ext_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"links": schemaForLinks(),
+						"tenant_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"category_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"category_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ad_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     schemaForAdInfoComputed(),
+						},
+						"project_ext_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func DatasourceNutanixCategoryMappingsV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MicroSegAPI
+
+	req := import3.ListCategoryMappingsRequest{}
+
+	if v, ok := d.GetOk("page"); ok {
+		req.Page_ = utils.IntPtr(v.(int))
+	}
+	if v, ok := d.GetOk("limit"); ok {
+		req.Limit_ = utils.IntPtr(v.(int))
+	}
+	if v, ok := d.GetOk("filter"); ok {
+		req.Filter_ = utils.StringPtr(v.(string))
+	}
+	if v, ok := d.GetOk("order_by"); ok {
+		req.Orderby_ = utils.StringPtr(v.(string))
+	}
+	if v, ok := d.GetOk("select"); ok {
+		req.Select_ = utils.StringPtr(v.(string))
+	}
+
+	resp, err := conn.DirectoryServerConfigsAPIInstance.ListCategoryMappings(ctx, &req)
+	if err != nil {
+		return diag.Errorf("error while listing Category Mappings: %s", err)
+	}
+
+	if resp.Data == nil {
+		if err := d.Set("category_mappings", []map[string]interface{}{}); err != nil {
+			return diag.Errorf("error setting Category Mappings: %s", err)
+		}
+		d.SetId(utils.GenUUID())
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "No data found.",
+			Detail:   "The API returned an empty list of category mappings.",
+		}}
+	}
+
+	getResp := resp.Data.GetValue().([]import2.CategoryMapping)
+
+	if err := d.Set("category_mappings", flattenCategoryMappings(getResp)); err != nil {
+		return diag.Errorf("error setting Category Mappings: %s", err)
+	}
+
+	d.SetId(utils.GenUUID())
+	return nil
+}

--- a/nutanix/services/microsegv2/data_source_nutanix_directory_server_config_v2.go
+++ b/nutanix/services/microsegv2/data_source_nutanix_directory_server_config_v2.go
@@ -1,0 +1,98 @@
+package microsegv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	import2 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/config"
+	import3 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/request/directoryserverconfigs"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixDirectoryServerConfigV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DatasourceNutanixDirectoryServerConfigV2Read,
+		Schema: map[string]*schema.Schema{
+			"ext_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"links": schemaForLinks(),
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"directory_service_reference": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_controllers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     schemaForIPAddressOrFQDNComputed(),
+			},
+			"is_default_category_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"matching_criterias": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     schemaForMatchingCriteriaComputed(),
+			},
+			"should_keep_default_category_on_login": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"project_ext_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func DatasourceNutanixDirectoryServerConfigV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MicroSegAPI
+
+	extID := d.Get("ext_id").(string)
+	req := import3.GetDirectoryServerConfigByIdRequest{
+		ExtId: utils.StringPtr(extID),
+	}
+	resp, err := conn.DirectoryServerConfigsAPIInstance.GetDirectoryServerConfigById(ctx, &req)
+	if err != nil {
+		return diag.Errorf("error while fetching Directory Server Config: %s", err)
+	}
+
+	getResp := resp.Data.GetValue().(import2.DirectoryServerConfig)
+
+	if err := d.Set("tenant_id", getResp.TenantId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("links", flattenLinksDSC(getResp.Links)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("directory_service_reference", getResp.DirectoryServiceReference); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("domain_controllers", flattenDomainControllers(getResp.DomainControllers)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_default_category_enabled", getResp.IsDefaultCategoryEnabled); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("matching_criterias", flattenMatchingCriterias(getResp.MatchingCriterias)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("should_keep_default_category_on_login", getResp.ShouldKeepDefaultCategoryOnLogin); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("project_ext_id", getResp.ProjectExtId); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(*getResp.ExtId)
+	return nil
+}

--- a/nutanix/services/microsegv2/data_source_nutanix_directory_server_configs_v2.go
+++ b/nutanix/services/microsegv2/data_source_nutanix_directory_server_configs_v2.go
@@ -1,0 +1,103 @@
+package microsegv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	import2 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/config"
+	import3 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/request/directoryserverconfigs"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func DatasourceNutanixDirectoryServerConfigsV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DatasourceNutanixDirectoryServerConfigsV2Read,
+		Schema: map[string]*schema.Schema{
+			"select": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"directory_server_configs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ext_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"links": schemaForLinks(),
+						"tenant_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"directory_service_reference": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain_controllers": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     schemaForIPAddressOrFQDNComputed(),
+						},
+						"is_default_category_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"matching_criterias": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     schemaForMatchingCriteriaComputed(),
+						},
+						"should_keep_default_category_on_login": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"project_ext_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func DatasourceNutanixDirectoryServerConfigsV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MicroSegAPI
+
+	req := import3.ListDirectoryServerConfigsRequest{}
+
+	if v, ok := d.GetOk("select"); ok {
+		req.Select_ = utils.StringPtr(v.(string))
+	}
+
+	resp, err := conn.DirectoryServerConfigsAPIInstance.ListDirectoryServerConfigs(ctx, &req)
+	if err != nil {
+		return diag.Errorf("error while listing Directory Server Configs: %s", err)
+	}
+
+	if resp.Data == nil {
+		if err := d.Set("directory_server_configs", []map[string]interface{}{}); err != nil {
+			return diag.Errorf("error setting Directory Server Configs: %s", err)
+		}
+		d.SetId(utils.GenUUID())
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "No data found.",
+			Detail:   "The API returned an empty list of directory server configs.",
+		}}
+	}
+
+	getResp := resp.Data.GetValue().([]import2.DirectoryServerConfig)
+
+	if err := d.Set("directory_server_configs", flattenDirectoryServerConfigs(getResp)); err != nil {
+		return diag.Errorf("error setting Directory Server Configs: %s", err)
+	}
+
+	d.SetId(utils.GenUUID())
+	return nil
+}

--- a/nutanix/services/microsegv2/data_source_nutanix_entity_group_v2.go
+++ b/nutanix/services/microsegv2/data_source_nutanix_entity_group_v2.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	import1 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/common/v1/config"
+	import1 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/config"
 	import2 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/common/v1/response"
 	import3 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/request/entitygroups"
 	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
@@ -211,7 +211,7 @@ func flattenAllowedEntities(entities []import1.AllowedEntity) []map[string]inter
 				entityMap["select_by"] = flattenAllowedSelectBy(entity.SelectBy)
 			}
 			if entity.Type != nil {
-				entityMap["type"] = utils.StringValue(entity.Type)
+				entityMap["type"] = entity.Type.GetName()
 			}
 			entityList = append(entityList, entityMap)
 		}

--- a/nutanix/services/microsegv2/data_source_nutanix_entity_groups_v2.go
+++ b/nutanix/services/microsegv2/data_source_nutanix_entity_groups_v2.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	import1 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/common/v1/config"
+	import1 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/config"
 	import2 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/request/entitygroups"
 	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
 	"github.com/terraform-providers/terraform-provider-nutanix/utils"

--- a/nutanix/services/microsegv2/directory_server_config_helper.go
+++ b/nutanix/services/microsegv2/directory_server_config_helper.go
@@ -1,0 +1,247 @@
+package microsegv2
+
+import (
+	commonconfig "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/common/v1/config"
+	import1 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/common/v1/response"
+	import2 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/config"
+	commonUtils "github.com/terraform-providers/terraform-provider-nutanix/nutanix/common"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func expandDomainControllers(l []interface{}) []commonconfig.IPAddressOrFQDN {
+	if len(l) == 0 {
+		return nil
+	}
+	out := make([]commonconfig.IPAddressOrFQDN, 0, len(l))
+	for _, item := range l {
+		m := item.(map[string]interface{})
+		dc := commonconfig.IPAddressOrFQDN{}
+		if v, ok := m["fqdn"].([]interface{}); ok && len(v) > 0 {
+			fqdnMap := v[0].(map[string]interface{})
+			fqdn := commonconfig.NewFQDN()
+			if val, ok := fqdnMap["value"].(string); ok && val != "" {
+				fqdn.Value = utils.StringPtr(val)
+			}
+			dc.Fqdn = fqdn
+		}
+		if v, ok := m["ipv4"].([]interface{}); ok && len(v) > 0 {
+			ipv4Map := v[0].(map[string]interface{})
+			ipv4 := commonconfig.NewIPv4Address()
+			if val, ok := ipv4Map["value"].(string); ok && val != "" {
+				ipv4.Value = utils.StringPtr(val)
+			}
+			if val, ok := ipv4Map["prefix_length"].(int); ok && val > 0 {
+				ipv4.PrefixLength = utils.IntPtr(val)
+			}
+			dc.Ipv4 = ipv4
+		}
+		if v, ok := m["ipv6"].([]interface{}); ok && len(v) > 0 {
+			ipv6Map := v[0].(map[string]interface{})
+			ipv6 := commonconfig.NewIPv6Address()
+			if val, ok := ipv6Map["value"].(string); ok && val != "" {
+				ipv6.Value = utils.StringPtr(val)
+			}
+			if val, ok := ipv6Map["prefix_length"].(int); ok && val > 0 {
+				ipv6.PrefixLength = utils.IntPtr(val)
+			}
+			dc.Ipv6 = ipv6
+		}
+		out = append(out, dc)
+	}
+	return out
+}
+
+func expandMatchingCriterias(l []interface{}) []import2.MatchingCriteria {
+	if len(l) == 0 {
+		return nil
+	}
+	out := make([]import2.MatchingCriteria, 0, len(l))
+	for _, item := range l {
+		m := item.(map[string]interface{})
+		mc := import2.MatchingCriteria{}
+		if v, ok := m["criteria"].(string); ok && v != "" {
+			mc.Criteria = utils.StringPtr(v)
+		}
+		if v, ok := m["match_entity"].(string); ok && v != "" {
+			mc.MatchEntity = commonUtils.ExpandEnum[import2.MatchEntity](v)
+		}
+		if v, ok := m["match_field"].(string); ok && v != "" {
+			mc.MatchField = commonUtils.ExpandEnum[import2.MatchField](v)
+		}
+		if v, ok := m["match_type"].(string); ok && v != "" {
+			mc.MatchType = commonUtils.ExpandEnum[import2.MatchType](v)
+		}
+		out = append(out, mc)
+	}
+	return out
+}
+
+func expandAdInfo(l []interface{}) *import2.AdInfo {
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+	m := l[0].(map[string]interface{})
+	ai := import2.NewAdInfo()
+	if v, ok := m["directory_service_reference"].(string); ok && v != "" {
+		ai.DirectoryServiceReference = utils.StringPtr(v)
+	}
+	if v, ok := m["object_identifier"].(string); ok && v != "" {
+		ai.ObjectIdentifier = utils.StringPtr(v)
+	}
+	if v, ok := m["object_path"].(string); ok && v != "" {
+		ai.ObjectPath = utils.StringPtr(v)
+	}
+	if v, ok := m["status"].(string); ok && v != "" {
+		ai.Status = commonUtils.ExpandEnum[import2.AdStatus](v)
+	}
+	return ai
+}
+
+func flattenDomainControllers(dcs []commonconfig.IPAddressOrFQDN) []map[string]interface{} {
+	if len(dcs) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, 0, len(dcs))
+	for _, dc := range dcs {
+		m := map[string]interface{}{}
+		if dc.Fqdn != nil {
+			m["fqdn"] = []map[string]interface{}{
+				{"value": utils.StringValue(dc.Fqdn.Value)},
+			}
+		} else {
+			m["fqdn"] = []map[string]interface{}{}
+		}
+		if dc.Ipv4 != nil {
+			ipv4Map := map[string]interface{}{
+				"value": utils.StringValue(dc.Ipv4.Value),
+			}
+			if dc.Ipv4.PrefixLength != nil {
+				ipv4Map["prefix_length"] = *dc.Ipv4.PrefixLength
+			} else {
+				ipv4Map["prefix_length"] = 0
+			}
+			m["ipv4"] = []map[string]interface{}{ipv4Map}
+		} else {
+			m["ipv4"] = []map[string]interface{}{}
+		}
+		if dc.Ipv6 != nil {
+			ipv6Map := map[string]interface{}{
+				"value": utils.StringValue(dc.Ipv6.Value),
+			}
+			if dc.Ipv6.PrefixLength != nil {
+				ipv6Map["prefix_length"] = *dc.Ipv6.PrefixLength
+			} else {
+				ipv6Map["prefix_length"] = 0
+			}
+			m["ipv6"] = []map[string]interface{}{ipv6Map}
+		} else {
+			m["ipv6"] = []map[string]interface{}{}
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+func flattenMatchingCriterias(mcs []import2.MatchingCriteria) []map[string]interface{} {
+	if len(mcs) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, 0, len(mcs))
+	for _, mc := range mcs {
+		m := map[string]interface{}{
+			"criteria": utils.StringValue(mc.Criteria),
+		}
+		if mc.MatchEntity != nil {
+			m["match_entity"] = mc.MatchEntity.GetName()
+		} else {
+			m["match_entity"] = ""
+		}
+		if mc.MatchField != nil {
+			m["match_field"] = mc.MatchField.GetName()
+		} else {
+			m["match_field"] = ""
+		}
+		if mc.MatchType != nil {
+			m["match_type"] = mc.MatchType.GetName()
+		} else {
+			m["match_type"] = ""
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+func flattenAdInfo(ai *import2.AdInfo) []map[string]interface{} {
+	if ai == nil {
+		return nil
+	}
+	m := map[string]interface{}{
+		"directory_service_reference": utils.StringValue(ai.DirectoryServiceReference),
+		"object_identifier":           utils.StringValue(ai.ObjectIdentifier),
+		"object_path":                 utils.StringValue(ai.ObjectPath),
+	}
+	if ai.Status != nil {
+		m["status"] = ai.Status.GetName()
+	} else {
+		m["status"] = ""
+	}
+	return []map[string]interface{}{m}
+}
+
+func flattenLinksDSC(links []import1.ApiLink) []map[string]interface{} {
+	if len(links) == 0 {
+		return nil
+	}
+	result := make([]map[string]interface{}, 0, len(links))
+	for _, link := range links {
+		m := map[string]interface{}{
+			"href": utils.StringValue(link.Href),
+			"rel":  utils.StringValue(link.Rel),
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+func flattenDirectoryServerConfigs(configs []import2.DirectoryServerConfig) []map[string]interface{} {
+	if len(configs) == 0 {
+		return []map[string]interface{}{}
+	}
+	result := make([]map[string]interface{}, 0, len(configs))
+	for _, c := range configs {
+		m := map[string]interface{}{
+			"ext_id":                                utils.StringValue(c.ExtId),
+			"directory_service_reference":           utils.StringValue(c.DirectoryServiceReference),
+			"domain_controllers":                    flattenDomainControllers(c.DomainControllers),
+			"is_default_category_enabled":           utils.BoolValue(c.IsDefaultCategoryEnabled),
+			"matching_criterias":                    flattenMatchingCriterias(c.MatchingCriterias),
+			"should_keep_default_category_on_login": utils.BoolValue(c.ShouldKeepDefaultCategoryOnLogin),
+			"tenant_id":                             utils.StringValue(c.TenantId),
+			"links":                                 flattenLinksDSC(c.Links),
+			"project_ext_id":                        utils.StringValue(c.ProjectExtId),
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+func flattenCategoryMappings(mappings []import2.CategoryMapping) []map[string]interface{} {
+	if len(mappings) == 0 {
+		return []map[string]interface{}{}
+	}
+	result := make([]map[string]interface{}, 0, len(mappings))
+	for _, cm := range mappings {
+		m := map[string]interface{}{
+			"ext_id":         utils.StringValue(cm.ExtId),
+			"name":           utils.StringValue(cm.Name),
+			"category_name":  utils.StringValue(cm.CategoryName),
+			"category_value": utils.StringValue(cm.CategoryValue),
+			"ad_info":        flattenAdInfo(cm.AdInfo),
+			"tenant_id":      utils.StringValue(cm.TenantId),
+			"links":          flattenLinksDSC(cm.Links),
+			"project_ext_id": utils.StringValue(cm.ProjectExtId),
+		}
+		result = append(result, m)
+	}
+	return result
+}

--- a/nutanix/services/microsegv2/directory_server_config_schema.go
+++ b/nutanix/services/microsegv2/directory_server_config_schema.go
@@ -1,0 +1,218 @@
+package microsegv2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func schemaForIPAddressOrFQDN() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"fqdn": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"value": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"ipv4": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"value": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"prefix_length": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"ipv6": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"value": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"prefix_length": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemaForIPAddressOrFQDNComputed() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"fqdn": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"ipv4": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"prefix_length": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"ipv6": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"prefix_length": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemaForMatchingCriteria() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"criteria": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"match_entity": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"match_field": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"match_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func schemaForMatchingCriteriaComputed() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"criteria": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"match_entity": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"match_field": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"match_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func schemaForAdInfo() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"directory_service_reference": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"object_identifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"object_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func schemaForAdInfoComputed() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"directory_service_reference": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"object_identifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"object_path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}

--- a/nutanix/services/microsegv2/resource_nutanix_directory_server_config_v2.go
+++ b/nutanix/services/microsegv2/resource_nutanix_directory_server_config_v2.go
@@ -1,0 +1,296 @@
+package microsegv2
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	import2 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/config"
+	import3 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/request/directoryserverconfigs"
+	import4 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/prism/v4/config"
+	prismConfig "github.com/nutanix-core/ntnx-api-golang-sdk-internal/prism-go-client/v17/models/prism/v4/config"
+	import5 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/prism-go-client/v17/models/prism/v4/request/tasks"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	commonUtils "github.com/terraform-providers/terraform-provider-nutanix/nutanix/common"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func ResourceNutanixDirectoryServerConfigV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNutanixDirectoryServerConfigV2Create,
+		ReadContext:   resourceNutanixDirectoryServerConfigV2Read,
+		UpdateContext: resourceNutanixDirectoryServerConfigV2Update,
+		DeleteContext: resourceNutanixDirectoryServerConfigV2Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"ext_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"links": schemaForLinks(),
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"directory_service_reference": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"domain_controllers": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     schemaForIPAddressOrFQDN(),
+			},
+			"is_default_category_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"matching_criterias": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     schemaForMatchingCriteria(),
+			},
+			"should_keep_default_category_on_login": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"project_ext_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceNutanixDirectoryServerConfigV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MicroSegAPI
+
+	bodySpec := import2.NewDirectoryServerConfig()
+
+	bodySpec.DirectoryServiceReference = utils.StringPtr(d.Get("directory_service_reference").(string))
+
+	if v, ok := d.GetOk("domain_controllers"); ok {
+		bodySpec.DomainControllers = expandDomainControllers(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("is_default_category_enabled"); ok {
+		bodySpec.IsDefaultCategoryEnabled = utils.BoolPtr(v.(bool))
+	}
+	if v, ok := d.GetOk("matching_criterias"); ok {
+		bodySpec.MatchingCriterias = expandMatchingCriterias(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("should_keep_default_category_on_login"); ok {
+		bodySpec.ShouldKeepDefaultCategoryOnLogin = utils.BoolPtr(v.(bool))
+	}
+
+	aJSON, _ := json.MarshalIndent(bodySpec, "", "  ")
+	log.Printf("[DEBUG] Create Directory Server Config Body Spec: %s", string(aJSON))
+
+	req := import3.CreateDirectoryServerConfigRequest{
+		Body: bodySpec,
+	}
+	resp, err := conn.DirectoryServerConfigsAPIInstance.CreateDirectoryServerConfig(ctx, &req)
+	if err != nil {
+		return diag.Errorf("error while creating Directory Server Config: %v", err)
+	}
+
+	TaskRef := resp.Data.GetValue().(import4.TaskReference)
+	taskUUID := TaskRef.ExtId
+
+	taskconn := meta.(*conns.Client).PrismAPI
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"QUEUED", "RUNNING", "PENDING"},
+		Target:  []string{"SUCCEEDED"},
+		Refresh: commonUtils.TaskStateRefreshPrismTaskGroupFunc(ctx, taskconn, utils.StringValue(taskUUID)),
+		Timeout: d.Timeout(schema.TimeoutCreate),
+	}
+
+	if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
+		return diag.Errorf("error waiting for Directory Server Config (%s) to create: %s", utils.StringValue(taskUUID), errWaitTask)
+	}
+
+	getTaskByIdRequest := import5.GetTaskByIdRequest{
+		ExtId: utils.StringPtr(*taskUUID),
+	}
+	taskResp, err := taskconn.TaskRefAPI.GetTaskById(ctx, &getTaskByIdRequest)
+	if err != nil {
+		return diag.Errorf("error while fetching Directory Server Config Task: %v", err)
+	}
+	taskDetails := taskResp.Data.GetValue().(prismConfig.Task)
+	aJSON, _ = json.MarshalIndent(taskDetails, "", "  ")
+	log.Printf("[DEBUG] Create Directory Server Config Task Response Details: %s", string(aJSON))
+
+	uuid := taskDetails.CompletionDetails[0].Value.GetValue().(string)
+
+	d.SetId(uuid)
+	return resourceNutanixDirectoryServerConfigV2Read(ctx, d, meta)
+}
+
+func resourceNutanixDirectoryServerConfigV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MicroSegAPI
+
+	extID := d.Id()
+	req := import3.GetDirectoryServerConfigByIdRequest{
+		ExtId: utils.StringPtr(extID),
+	}
+	resp, err := conn.DirectoryServerConfigsAPIInstance.GetDirectoryServerConfigById(ctx, &req)
+	if err != nil {
+		return diag.Errorf("error while fetching Directory Server Config: %s", err)
+	}
+
+	getResp := resp.Data.GetValue().(import2.DirectoryServerConfig)
+
+	aJSON, _ := json.MarshalIndent(getResp, "", "  ")
+	log.Printf("[DEBUG] Read Directory Server Config Response Details: %s", string(aJSON))
+
+	if err := d.Set("ext_id", getResp.ExtId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("tenant_id", getResp.TenantId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("links", flattenLinksDSC(getResp.Links)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("directory_service_reference", getResp.DirectoryServiceReference); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("domain_controllers", flattenDomainControllers(getResp.DomainControllers)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("is_default_category_enabled", getResp.IsDefaultCategoryEnabled); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("matching_criterias", flattenMatchingCriterias(getResp.MatchingCriterias)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("should_keep_default_category_on_login", getResp.ShouldKeepDefaultCategoryOnLogin); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("project_ext_id", getResp.ProjectExtId); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceNutanixDirectoryServerConfigV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MicroSegAPI
+
+	getReq := import3.GetDirectoryServerConfigByIdRequest{
+		ExtId: utils.StringPtr(d.Id()),
+	}
+	readResp, err := conn.DirectoryServerConfigsAPIInstance.GetDirectoryServerConfigById(ctx, &getReq)
+	if err != nil {
+		return diag.Errorf("error while fetching Directory Server Config: %v", err)
+	}
+
+	args := make(map[string]interface{})
+	etag := conn.DirectoryServerConfigsAPIInstance.ApiClient.GetEtag(readResp)
+	args["If-Match"] = utils.StringPtr(etag)
+
+	updateSpec := import2.NewDirectoryServerConfig()
+
+	if v, ok := d.GetOk("directory_service_reference"); ok {
+		updateSpec.DirectoryServiceReference = utils.StringPtr(v.(string))
+	}
+	if v, ok := d.GetOk("domain_controllers"); ok {
+		updateSpec.DomainControllers = expandDomainControllers(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("is_default_category_enabled"); ok {
+		updateSpec.IsDefaultCategoryEnabled = utils.BoolPtr(v.(bool))
+	}
+	if v, ok := d.GetOk("matching_criterias"); ok {
+		updateSpec.MatchingCriterias = expandMatchingCriterias(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("should_keep_default_category_on_login"); ok {
+		updateSpec.ShouldKeepDefaultCategoryOnLogin = utils.BoolPtr(v.(bool))
+	}
+
+	updateReq := import3.UpdateDirectoryServerConfigByIdRequest{
+		ExtId: utils.StringPtr(d.Id()),
+		Body:  updateSpec,
+	}
+	resp, err := conn.DirectoryServerConfigsAPIInstance.UpdateDirectoryServerConfigById(ctx, &updateReq, args)
+	if err != nil {
+		return diag.Errorf("error while updating Directory Server Config: %v", err)
+	}
+
+	TaskRef := resp.Data.GetValue().(import4.TaskReference)
+	taskUUID := TaskRef.ExtId
+
+	taskconn := meta.(*conns.Client).PrismAPI
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"QUEUED", "RUNNING", "PENDING"},
+		Target:  []string{"SUCCEEDED"},
+		Refresh: commonUtils.TaskStateRefreshPrismTaskGroupFunc(ctx, taskconn, utils.StringValue(taskUUID)),
+		Timeout: d.Timeout(schema.TimeoutUpdate),
+	}
+
+	if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
+		return diag.Errorf("error waiting for Directory Server Config (%s) to update: %s", utils.StringValue(taskUUID), errWaitTask)
+	}
+
+	getTaskByIdRequest := import5.GetTaskByIdRequest{
+		ExtId: utils.StringPtr(*taskUUID),
+	}
+	taskResp, err := taskconn.TaskRefAPI.GetTaskById(ctx, &getTaskByIdRequest)
+	if err != nil {
+		return diag.Errorf("error while fetching Directory Server Config Task: %v", err)
+	}
+
+	taskDetails := taskResp.Data.GetValue().(prismConfig.Task)
+	aJSON, _ := json.MarshalIndent(taskDetails, "", "  ")
+	log.Printf("[DEBUG] Update Directory Server Config Task Response Details: %s", string(aJSON))
+
+	return resourceNutanixDirectoryServerConfigV2Read(ctx, d, meta)
+}
+
+func resourceNutanixDirectoryServerConfigV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).MicroSegAPI
+
+	deleteReq := import3.DeleteDirectoryServerConfigByIdRequest{
+		ExtId: utils.StringPtr(d.Id()),
+	}
+	resp, err := conn.DirectoryServerConfigsAPIInstance.DeleteDirectoryServerConfigById(ctx, &deleteReq)
+	if err != nil {
+		return diag.Errorf("error while deleting Directory Server Config: %v", err)
+	}
+
+	TaskRef := resp.Data.GetValue().(import4.TaskReference)
+	taskUUID := TaskRef.ExtId
+
+	taskconn := meta.(*conns.Client).PrismAPI
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"QUEUED", "RUNNING", "PENDING"},
+		Target:  []string{"SUCCEEDED"},
+		Refresh: commonUtils.TaskStateRefreshPrismTaskGroupFunc(ctx, taskconn, utils.StringValue(taskUUID)),
+		Timeout: d.Timeout(schema.TimeoutDelete),
+	}
+
+	if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
+		return diag.Errorf("error waiting for Directory Server Config (%s) to delete: %s", utils.StringValue(taskUUID), errWaitTask)
+	}
+
+	getTaskByIdRequest := import5.GetTaskByIdRequest{
+		ExtId: utils.StringPtr(*taskUUID),
+	}
+	taskResp, err := taskconn.TaskRefAPI.GetTaskById(ctx, &getTaskByIdRequest)
+	if err != nil {
+		return diag.Errorf("error while deleting Directory Server Config Task: %v", err)
+	}
+	taskDetails := taskResp.Data.GetValue().(prismConfig.Task)
+	aJSON, _ := json.MarshalIndent(taskDetails, "", "  ")
+	log.Printf("[DEBUG] Delete Directory Server Config Task Response Details: %s", string(aJSON))
+
+	return nil
+}

--- a/nutanix/services/microsegv2/resource_nutanix_directory_server_config_v2_test.go
+++ b/nutanix/services/microsegv2/resource_nutanix_directory_server_config_v2_test.go
@@ -1,0 +1,203 @@
+package microsegv2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const resourceNameDSC = "nutanix_directory_server_config_v2.test"
+const datasourceNameDSC = "data.nutanix_directory_server_config_v2.test"
+const datasourceNameDSCs = "data.nutanix_directory_server_configs_v2.test"
+
+func TestAccV2NutanixDirectoryServerConfigResource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDirectoryServerConfigV2Basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameDSC, "ext_id"),
+					resource.TestCheckResourceAttrSet(resourceNameDSC, "directory_service_reference"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixDirectoryServerConfigResource_WithUpdate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDirectoryServerConfigV2Basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameDSC, "ext_id"),
+					resource.TestCheckResourceAttrSet(resourceNameDSC, "directory_service_reference"),
+				),
+			},
+			{
+				Config: testDirectoryServerConfigV2Update(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameDSC, "ext_id"),
+					resource.TestCheckResourceAttr(resourceNameDSC, "is_default_category_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixDirectoryServerConfigResource_ImportState(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDirectoryServerConfigV2Basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceNameDSC, "ext_id"),
+				),
+			},
+			{
+				ResourceName:      resourceNameDSC,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixDirectoryServerConfigDatasource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDirectoryServerConfigV2DatasourceBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameDSC, "ext_id"),
+					resource.TestCheckResourceAttrSet(datasourceNameDSC, "directory_service_reference"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixDirectoryServerConfigsDatasource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDirectoryServerConfigsV2DatasourceBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAttrListNotEmpty(datasourceNameDSCs, "directory_server_configs"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAttrListNotEmpty(resourceName, attr string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+		attrKey := fmt.Sprintf("%s.#", attr)
+		val, ok := rs.Primary.Attributes[attrKey]
+		if !ok {
+			return fmt.Errorf("attribute %s not found", attrKey)
+		}
+		if val == "0" {
+			return fmt.Errorf("expected %s to be non-empty", attrKey)
+		}
+		return nil
+	}
+}
+
+func testDirectoryServerConfigV2Basic() string {
+	return `
+    variable "directory_service_ext_id" {
+      type    = string
+      default = ""
+    }
+
+    resource "nutanix_directory_server_config_v2" "test" {
+      directory_service_reference = var.directory_service_ext_id
+      matching_criterias {
+        match_entity = "VM"
+        match_field  = "NAME"
+        match_type   = "ALL"
+      }
+    }
+  `
+}
+
+func testDirectoryServerConfigV2Update() string {
+	return `
+    variable "directory_service_ext_id" {
+      type    = string
+      default = ""
+    }
+
+    resource "nutanix_directory_server_config_v2" "test" {
+      directory_service_reference = var.directory_service_ext_id
+      is_default_category_enabled = true
+      matching_criterias {
+        match_entity = "VM"
+        match_field  = "NAME"
+        match_type   = "ALL"
+      }
+    }
+  `
+}
+
+func testDirectoryServerConfigV2DatasourceBasic() string {
+	return `
+    variable "directory_service_ext_id" {
+      type    = string
+      default = ""
+    }
+
+    resource "nutanix_directory_server_config_v2" "test" {
+      directory_service_reference = var.directory_service_ext_id
+      matching_criterias {
+        match_entity = "VM"
+        match_field  = "NAME"
+        match_type   = "ALL"
+      }
+    }
+
+    data "nutanix_directory_server_config_v2" "test" {
+      ext_id = nutanix_directory_server_config_v2.test.ext_id
+    }
+  `
+}
+
+func testDirectoryServerConfigsV2DatasourceBasic() string {
+	return `
+    variable "directory_service_ext_id" {
+      type    = string
+      default = ""
+    }
+
+    resource "nutanix_directory_server_config_v2" "test" {
+      directory_service_reference = var.directory_service_ext_id
+      matching_criterias {
+        match_entity = "VM"
+        match_field  = "NAME"
+        match_type   = "ALL"
+      }
+    }
+
+    data "nutanix_directory_server_configs_v2" "test" {
+      depends_on = [nutanix_directory_server_config_v2.test]
+    }
+  `
+}

--- a/nutanix/services/microsegv2/resource_nutanix_entity_group_v2.go
+++ b/nutanix/services/microsegv2/resource_nutanix_entity_group_v2.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	import1 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/common/v1/config"
+	import1 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/config"
 	import4 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/microseg/v4/request/entitygroups"
 	import3 "github.com/nutanix-core/ntnx-api-golang-sdk-internal/microseg-go-client/v17/models/prism/v4/config"
 	prismConfig "github.com/nutanix-core/ntnx-api-golang-sdk-internal/prism-go-client/v17/models/prism/v4/config"
@@ -409,12 +409,10 @@ func expandAllowedSelectBy(selectBy []interface{}) *import1.AllowedSelectBy {
 	}
 
 	selectByVal := selectBy[0].(map[string]interface{})
-	selectBySpec := import1.NewAllowedSelectBy()
-
-	// Add fields based on AllowedSelectBy struct if needed
 	_ = selectByVal
 
-	return selectBySpec
+	var s import1.AllowedSelectBy
+	return &s
 }
 
 func expandAllowedType(entityType string) *import1.AllowedType {
@@ -422,10 +420,6 @@ func expandAllowedType(entityType string) *import1.AllowedType {
 		return nil
 	}
 
-	// Map string to AllowedType enum
-	// This is a placeholder - adjust based on actual enum values
 	var allowedType import1.AllowedType
-	// Add enum mapping logic here based on actual AllowedType enum values
-
 	return &allowedType
 }

--- a/website/docs/d/category_mapping_v2.html.markdown
+++ b/website/docs/d/category_mapping_v2.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_category_mapping_v2"
+sidebar_current: "docs-nutanix-datasource-category-mapping-v2"
+description: |-
+  Gets the category to directory configuration information by ExtID.
+---
+
+# nutanix_category_mapping_v2
+
+Gets the category to directory configuration information by ExtID.
+
+## Example Usage
+
+```hcl
+data "nutanix_category_mapping_v2" "example" {
+  ext_id = "<ext-id>"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ext_id` - (Required) The external identifier of the category mapping.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `tenant_id` - The tenant identifier.
+* `links` - A HATEOAS style link for the response.
+* `name` - Name of the category mapping.
+* `category_name` - The name for the category that this mapping is for.
+* `category_value` - The value for the category that this mapping is for.
+* `ad_info` - Active Directory information for the mapping.
+  * `directory_service_reference` - The ExtID of the directory service.
+  * `object_identifier` - The objectGUID for the object in AD.
+  * `object_path` - The path for the mapped object in AD.
+  * `status` - The mapping status. Values: `USABLE`, `DELETED`, `DIRECTORY_NOT_CONFIGURED`.
+* `project_ext_id` - The external identifier of the associated project.

--- a/website/docs/d/category_mappings_v2.html.markdown
+++ b/website/docs/d/category_mappings_v2.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_category_mappings_v2"
+sidebar_current: "docs-nutanix-datasource-category-mappings-v2"
+description: |-
+  Gets the list of Directory Server Category Mappings.
+---
+
+# nutanix_category_mappings_v2
+
+Gets the list of Directory Server Category Mappings.
+
+## Example Usage
+
+```hcl
+data "nutanix_category_mappings_v2" "all" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `page` - (Optional) Page number for pagination.
+* `limit` - (Optional) Number of items per page.
+* `filter` - (Optional) OData filter expression.
+* `order_by` - (Optional) OData order by expression.
+* `select` - (Optional) OData select expression.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `category_mappings` - List of category mappings. Each element contains:
+  * `ext_id` - The external identifier.
+  * `tenant_id` - The tenant identifier.
+  * `links` - A HATEOAS style link for the response.
+  * `name` - Name of the category mapping.
+  * `category_name` - The name for the category.
+  * `category_value` - The value for the category.
+  * `ad_info` - Active Directory information for the mapping.
+  * `project_ext_id` - The external identifier of the associated project.

--- a/website/docs/d/directory_server_config_v2.html.markdown
+++ b/website/docs/d/directory_server_config_v2.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_directory_server_config_v2"
+sidebar_current: "docs-nutanix-datasource-directory-server-config-v2"
+description: |-
+  Gets the Directory Server configuration by ExtID.
+---
+
+# nutanix_directory_server_config_v2
+
+Gets the Directory Server configuration by ExtID.
+
+## Example Usage
+
+```hcl
+data "nutanix_directory_server_config_v2" "example" {
+  ext_id = "<ext-id>"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ext_id` - (Required) The external identifier of the directory server config.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `tenant_id` - A globally unique identifier that represents the tenant.
+* `links` - A HATEOAS style link for the response.
+* `directory_service_reference` - The ExtID of the directory service used for mapping.
+* `domain_controllers` - List of domain controllers used for event scraping.
+  * `fqdn` - Fully qualified domain name.
+    * `value` - The FQDN value.
+  * `ipv4` - IPv4 address.
+    * `value` - The IPv4 address.
+    * `prefix_length` - The prefix length.
+  * `ipv6` - IPv6 address.
+    * `value` - The IPv6 address.
+    * `prefix_length` - The prefix length.
+* `is_default_category_enabled` - Enablement status of the default category.
+* `matching_criterias` - The matching criteria for identity categorization.
+  * `criteria` - The criteria string for matching.
+  * `match_entity` - The entity to match.
+  * `match_field` - The field to match on.
+  * `match_type` - The type of match.
+* `should_keep_default_category_on_login` - Retain default category on user login.
+* `project_ext_id` - The external identifier of the associated project.

--- a/website/docs/d/directory_server_configs_v2.html.markdown
+++ b/website/docs/d/directory_server_configs_v2.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_directory_server_configs_v2"
+sidebar_current: "docs-nutanix-datasource-directory-server-configs-v2"
+description: |-
+  Gets the list of Directory Server configurations.
+---
+
+# nutanix_directory_server_configs_v2
+
+Gets the list of Directory Server configurations.
+
+## Example Usage
+
+```hcl
+data "nutanix_directory_server_configs_v2" "all" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `select` - (Optional) A URL query parameter that allows clients to request a specific set of properties for each entity.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `directory_server_configs` - List of directory server configurations. Each element contains:
+  * `ext_id` - The external identifier.
+  * `tenant_id` - The tenant identifier.
+  * `links` - A HATEOAS style link for the response.
+  * `directory_service_reference` - The ExtID of the directory service.
+  * `domain_controllers` - List of domain controllers.
+  * `is_default_category_enabled` - Enablement status of the default category.
+  * `matching_criterias` - The matching criteria for identity categorization.
+  * `should_keep_default_category_on_login` - Retain default category on login.
+  * `project_ext_id` - The external identifier of the associated project.

--- a/website/docs/r/directory_server_config_v2.html.markdown
+++ b/website/docs/r/directory_server_config_v2.html.markdown
@@ -1,0 +1,67 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_directory_server_config_v2"
+sidebar_current: "docs-nutanix-resource-directory-server-config-v2"
+description: |-
+  Configures various aspects of identity categorization for a Directory Server.
+---
+
+# nutanix_directory_server_config_v2
+
+Configures various aspects of identity categorization for a Directory Server.
+
+## Example Usage
+
+```hcl
+resource "nutanix_directory_server_config_v2" "example" {
+  directory_service_reference = "<directory-service-ext-id>"
+
+  matching_criterias {
+    match_entity = "VM"
+    match_field  = "NAME"
+    match_type   = "ALL"
+  }
+
+  is_default_category_enabled           = true
+  should_keep_default_category_on_login = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `directory_service_reference` - (Required, ForceNew) The ExtID of the directory service that will be used for mapping.
+* `domain_controllers` - (Optional) List of domain controllers to be used for event scraping. Each element supports the following:
+  * `fqdn` - (Optional) Fully qualified domain name.
+    * `value` - (Optional) The FQDN value.
+  * `ipv4` - (Optional) IPv4 address.
+    * `value` - (Optional) The IPv4 address.
+    * `prefix_length` - (Optional) The prefix length.
+  * `ipv6` - (Optional) IPv6 address.
+    * `value` - (Optional) The IPv6 address.
+    * `prefix_length` - (Optional) The prefix length.
+* `is_default_category_enabled` - (Optional) Enablement status of the default category.
+* `matching_criterias` - (Optional) The matching criteria used to determine whether an entity will be categorized. Each element supports the following:
+  * `criteria` - (Optional) The criteria to use for matching entities.
+  * `match_entity` - (Optional) The entity to match. Valid values: `VM`.
+  * `match_field` - (Optional) The field to match on. Valid values: `NAME`.
+  * `match_type` - (Optional) The type of match. Valid values: `CONTAINS`, `ALL`.
+* `should_keep_default_category_on_login` - (Optional) Retain default category on user login.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `ext_id` - The external identifier of the directory server config.
+* `tenant_id` - A globally unique identifier that represents the tenant.
+* `links` - A HATEOAS style link for the response.
+* `project_ext_id` - The external identifier of the associated project.
+
+## Import
+
+Directory Server Config can be imported using the `ext_id`:
+
+```shell
+terraform import nutanix_directory_server_config_v2.example <ext_id>
+```


### PR DESCRIPTION
## Summary
- Add `nutanix_directory_server_config_v2` resource with full CRUD operations (create, read, update, delete) and import support
- Add `nutanix_directory_server_config_v2` (singular) and `nutanix_directory_server_configs_v2` (plural) datasources for reading directory server configurations
- Add `nutanix_category_mapping_v2` (singular) and `nutanix_category_mappings_v2` (plural) datasources for reading category mappings
- Extend microseg SDK client with `DirectoryServerConfigsAPIInstance`
- Include schema definitions, expand/flatten helpers, acceptance tests, examples, and documentation

## Test plan
- [ ] Run `go build ./...` to verify compilation (verified locally)
- [ ] Run `go vet ./nutanix/services/microsegv2/...` to verify code quality (verified locally)
- [ ] Run acceptance tests with `TF_ACC=1 go test ./nutanix/services/microsegv2/... -v -run TestAccV2NutanixDirectoryServerConfig`
- [ ] Verify resource creation with a valid directory service reference
- [ ] Verify resource update (e.g., toggling `is_default_category_enabled`)
- [ ] Verify resource import via `terraform import`
- [ ] Verify singular and plural datasources return expected data
- [ ] Verify category mapping datasources return expected data


Made with [Cursor](https://cursor.com)