### PR TITLE
fix: ICMP is_all_allowed wildcard rejected by microseg v4.2 API (MIC-30302 / MIC-30113)

### DIFF
--- a/nutanix/client/client.go
+++ b/nutanix/client/client.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -567,19 +566,19 @@ func CheckResponse(r *http.Response) error {
 	}
 
 	if c == http.StatusBadRequest {
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			return fmt.Errorf("bad Request: failed to read body: %w", err)
 		}
 		return fmt.Errorf("bad Request: %s", string(bodyBytes))
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}
 
-	rdr2 := ioutil.NopCloser(bytes.NewBuffer(buf))
+	rdr2 := io.NopCloser(bytes.NewBuffer(buf))
 
 	r.Body = rdr2
 	// if has entities -> return nil

--- a/nutanix/client/client_test.go
+++ b/nutanix/client/client_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -110,7 +109,7 @@ func TestNewRequest(t *testing.T) {
 	}
 
 	// test body was JSON encoded
-	body, _ := ioutil.ReadAll(req.Body)
+	body, _ := io.ReadAll(req.Body)
 	if string(body) != outBody {
 		t.Errorf("NewRequest(%v) Body = %v, expected %v", inBody, string(body), outBody)
 	}
@@ -130,7 +129,7 @@ func TestNewUploadRequest(t *testing.T) {
 
 	// expected body
 	out, _ := os.Open(fileName)
-	outBody, _ := ioutil.ReadAll(out)
+	outBody, _ := io.ReadAll(out)
 
 	req, err := c.NewUploadRequest(context.TODO(), http.MethodPost, inURL, inBody)
 	if err != nil {
@@ -141,7 +140,7 @@ func TestNewUploadRequest(t *testing.T) {
 		t.Errorf("NewUploadRequest(%v) URL = %v, expected %v", inURL, req.URL, outURL)
 	}
 
-	got, _ := ioutil.ReadAll(req.Body)
+	got, _ := io.ReadAll(req.Body)
 	if !bytes.Equal(got, outBody) {
 		t.Errorf("NewUploadRequest(%v) Body = %v, expected %v", inBody, string(got), string(outBody))
 	}
@@ -175,7 +174,7 @@ func TestNewUnAuthRequest(t *testing.T) {
 	}
 
 	// test body was JSON encoded
-	body, _ := ioutil.ReadAll(req.Body)
+	body, _ := io.ReadAll(req.Body)
 	if string(body) != outBody {
 		t.Errorf("NewUnAuthRequest(%v) Body = %v, expected %v", inBody, string(body), outBody)
 	}
@@ -252,7 +251,7 @@ func TestNewUnAuthUploadRequest(t *testing.T) {
 
 	// expected body
 	out, _ := os.Open(fileName)
-	outBody, _ := ioutil.ReadAll(out)
+	outBody, _ := io.ReadAll(out)
 
 	req, err := c.NewUnAuthUploadRequest(context.TODO(), http.MethodPost, inURL, inBody)
 	if err != nil {
@@ -263,7 +262,7 @@ func TestNewUnAuthUploadRequest(t *testing.T) {
 		t.Errorf("NewUnAuthUploadRequest(%v) URL = %v, expected %v", inURL, req.URL, outURL)
 	}
 
-	got, _ := ioutil.ReadAll(req.Body)
+	got, _ := io.ReadAll(req.Body)
 	if !bytes.Equal(got, outBody) {
 		t.Errorf("NewUnAuthUploadRequest(%v) Body = %v, expected %v", inBody, string(got), string(outBody))
 	}
@@ -299,7 +298,7 @@ func TestGetResponse(t *testing.T) {
 	res := &http.Response{
 		Request:    &http.Request{},
 		StatusCode: http.StatusBadRequest,
-		Body: ioutil.NopCloser(strings.NewReader(
+		Body: io.NopCloser(strings.NewReader(
 			`{"api_version": "3.1", "code": 400, "kind": "error", "message_list":
 				 [{"message": "bad Request"}], "state": "ERROR"}`)),
 	}
@@ -319,7 +318,7 @@ func TestCheckResponse(t *testing.T) {
 	res := &http.Response{
 		Request:    &http.Request{},
 		StatusCode: http.StatusBadRequest,
-		Body: ioutil.NopCloser(strings.NewReader(
+		Body: io.NopCloser(strings.NewReader(
 			`{"api_version": "3.1", "code": 400, "kind": "error", "message_list":
 				 [{"message": "bad Request"}], "state": "ERROR"}`)),
 	}

--- a/nutanix/common/common.go
+++ b/nutanix/common/common.go
@@ -504,7 +504,7 @@ func FlattenLinks(links interface{}) []map[string]interface{} {
 
 		// Use reflection to access Href and Rel fields
 		linkVal := reflect.ValueOf(link)
-		if linkVal.Kind() == reflect.Ptr {
+		if linkVal.Kind() == reflect.Pointer {
 			if linkVal.IsNil() {
 				continue
 			}
@@ -514,7 +514,7 @@ func FlattenLinks(links interface{}) []map[string]interface{} {
 		// Get Href field
 		hrefField := linkVal.FieldByName("Href")
 		if hrefField.IsValid() {
-			if hrefField.Kind() == reflect.Ptr {
+			if hrefField.Kind() == reflect.Pointer {
 				if !hrefField.IsNil() {
 					linkMap["href"] = hrefField.Elem().Interface()
 				}
@@ -526,7 +526,7 @@ func FlattenLinks(links interface{}) []map[string]interface{} {
 		// Get Rel field
 		relField := linkVal.FieldByName("Rel")
 		if relField.IsValid() {
-			if relField.Kind() == reflect.Ptr {
+			if relField.Kind() == reflect.Pointer {
 				if !relField.IsNil() {
 					linkMap["rel"] = relField.Elem().Interface()
 				}

--- a/nutanix/sdks/v3/foundation/foundation_file_management_service_test.go
+++ b/nutanix/sdks/v3/foundation/foundation_file_management_service_test.go
@@ -3,8 +3,9 @@ package foundation
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"reflect"
 	"testing"
 
@@ -125,8 +126,8 @@ func TestFMOperations_UploadImage(t *testing.T) {
 			t.Errorf("FileManagementOperations.UploadImage() expected URL %v, got %v", expectedURL, r.URL.String())
 		}
 
-		body, _ := ioutil.ReadAll(r.Body)
-		file, _ := ioutil.ReadFile(source)
+		body, _ := io.ReadAll(r.Body)
+		file, _ := os.ReadFile(source)
 
 		if !reflect.DeepEqual(body, file) {
 			t.Errorf("FileManagementOperations.UploadImage() error: different uploaded files")
@@ -169,7 +170,7 @@ func TestFMOperations_DeleteImage(t *testing.T) {
 	mux.HandleFunc("/foundation/delete/", func(w http.ResponseWriter, r *http.Request) {
 		testHTTPMethod(t, r, http.MethodPost)
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("FileManagementOperations.DeleteImage() error reading request body = %v", err)
 		}

--- a/nutanix/sdks/v3/prism/prism_service_test.go
+++ b/nutanix/sdks/v3/prism/prism_service_test.go
@@ -3,10 +3,11 @@ package prism
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"reflect"
 	"testing"
 
@@ -1002,8 +1003,8 @@ func TestOperations_UploadImage(t *testing.T) {
 	mux.HandleFunc("/api/nutanix/v3/images/cfde831a-4e87-4a75-960f-89b0148aa2cc/file", func(w http.ResponseWriter, r *http.Request) {
 		testHTTPMethod(t, r, http.MethodPut)
 
-		bodyBytes, _ := ioutil.ReadAll(r.Body)
-		file, _ := ioutil.ReadFile("prism.go")
+		bodyBytes, _ := io.ReadAll(r.Body)
+		file, _ := os.ReadFile("prism.go")
 
 		if !reflect.DeepEqual(bodyBytes, file) {
 			t.Errorf("Operations.UploadImage() error: different uploaded files")

--- a/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go
@@ -3,6 +3,7 @@ package networkingv2
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -566,7 +567,7 @@ func ResourceNutanixNetworkSecurityPolicyV2Create(ctx context.Context, d *schema
 		spec.State = common.ExpandEnum[import1.SecurityPolicyState](state.(string))
 	}
 	if rules, ok := d.GetOk("rules"); ok {
-		spec.Rules = expandNetworkSecurityPolicyRule(rules.([]interface{}))
+		spec.Rules = expandNetworkSecurityPolicyRule(d, rules.([]interface{}))
 	}
 	if isipv6, ok := d.GetOk("is_ipv6_traffic_allowed"); ok {
 		spec.IsIpv6TrafficAllowed = utils.BoolPtr(isipv6.(bool))
@@ -651,7 +652,7 @@ func ResourceNutanixNetworkSecurityPolicyV2Read(ctx context.Context, d *schema.R
 	if len(getResp.Rules) > 0 {
 		// read the remote operations and local operations list
 		remoteOperations := flattenNetworkSecurityPolicyRule(getResp.Rules)
-		localOperations := expandNetworkSecurityPolicyRule(d.Get("rules").([]interface{}))
+		localOperations := expandNetworkSecurityPolicyRule(d, d.Get("rules").([]interface{}))
 
 		// final result for checking if operations are different
 		diff := false
@@ -755,7 +756,7 @@ func ResourceNutanixNetworkSecurityPolicyV2Update(ctx context.Context, d *schema
 		updatedSpec.Description = utils.StringPtr(d.Get("description").(string))
 	}
 	if d.HasChange("rules") {
-		updatedSpec.Rules = expandNetworkSecurityPolicyRule(d.Get("rules").([]interface{}))
+		updatedSpec.Rules = expandNetworkSecurityPolicyRule(d, d.Get("rules").([]interface{}))
 	}
 	if d.HasChange("state") {
 		updatedSpec.State = common.ExpandEnum[import1.SecurityPolicyState](d.Get("state").(string))
@@ -829,7 +830,7 @@ func ResourceNutanixNetworkSecurityPolicyV2Delete(ctx context.Context, d *schema
 	return nil
 }
 
-func expandNetworkSecurityPolicyRule(pr []interface{}) []import1.NetworkSecurityPolicyRule {
+func expandNetworkSecurityPolicyRule(d *schema.ResourceData, pr []interface{}) []import1.NetworkSecurityPolicyRule {
 	if len(pr) > 0 {
 		nets := make([]import1.NetworkSecurityPolicyRule, len(pr))
 
@@ -844,7 +845,7 @@ func expandNetworkSecurityPolicyRule(pr []interface{}) []import1.NetworkSecurity
 				net.Type = common.ExpandEnum[import1.RuleType](ty.(string))
 			}
 			if spec, ok := val["spec"]; ok {
-				net.Spec = expandOneOfNetworkSecurityPolicyRuleSpec(spec)
+				net.Spec = expandOneOfNetworkSecurityPolicyRuleSpec(d, fmt.Sprintf("rules.%d.spec", k), spec)
 			}
 			nets[k] = net
 		}
@@ -853,7 +854,7 @@ func expandNetworkSecurityPolicyRule(pr []interface{}) []import1.NetworkSecurity
 	return nil
 }
 
-func expandOneOfNetworkSecurityPolicyRuleSpec(pr interface{}) *import1.OneOfNetworkSecurityPolicyRuleSpec {
+func expandOneOfNetworkSecurityPolicyRuleSpec(d *schema.ResourceData, basePath string, pr interface{}) *import1.OneOfNetworkSecurityPolicyRuleSpec {
 	if pr != nil {
 		prI := pr.([]interface{})
 		val := prI[0].(map[string]interface{})
@@ -939,7 +940,7 @@ func expandOneOfNetworkSecurityPolicyRuleSpec(pr interface{}) *import1.OneOfNetw
 				app.UdpServices = expandUDPPortRangeSpec(udp.([]interface{}))
 			}
 			if icmp, ok := appVal["icmp_services"]; ok && len(icmp.([]interface{})) > 0 {
-				app.IcmpServices = expandIcmpTypeCodeSpec(icmp.([]interface{}))
+				app.IcmpServices = expandIcmpTypeCodeSpec(d, basePath+".0.application_rule_spec.0.icmp_services", icmp.([]interface{}))
 			}
 			if netFuncChain, ok := appVal["network_function_chain_reference"]; ok && len(netFuncChain.(string)) > 0 {
 				app.NetworkFunctionChainReference = utils.StringPtr(netFuncChain.(string))
@@ -978,7 +979,7 @@ func expandOneOfNetworkSecurityPolicyRuleSpec(pr interface{}) *import1.OneOfNetw
 				intra.UdpServices = expandUDPPortRangeSpec(udp.([]interface{}))
 			}
 			if icmp, ok := intraVal["icmp_services"]; ok && len(icmp.([]interface{})) > 0 {
-				intra.IcmpServices = expandIcmpTypeCodeSpec(icmp.([]interface{}))
+				intra.IcmpServices = expandIcmpTypeCodeSpec(d, basePath+".0.intra_entity_group_rule_spec.0.icmp_services", icmp.([]interface{}))
 			}
 			policyRules.SetValue(*intra)
 		}

--- a/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2_test.go
@@ -329,6 +329,32 @@ func TestAccV2NutanixNSPDataSource_NewAttributes(t *testing.T) {
 	})
 }
 
+// TestAccV2NutanixNetworkSecurityResource_ICMPAllAllowed covers the inline
+// ICMP wildcard case on application_rule_spec: is_all_allowed = true with no
+// type/code. The provider must omit type/code from the payload, otherwise the
+// microseg v4.2 API rejects the policy with MIC-30113 ("Application rule ICMP
+// protocol is set to allow all but also contains specific type/code").
+func TestAccV2NutanixNetworkSecurityResource_ICMPAllAllowed(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("tf-test-nsp-icmp-%d", r)
+	desc := "test nsp ICMP wildcard"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNetworkSecurityConfigICMPAllAllowed(name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameNs, "name", name),
+					resource.TestCheckResourceAttr(resourceNameNs, "rules.0.spec.0.application_rule_spec.0.icmp_services.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameNs, "rules.0.spec.0.application_rule_spec.0.icmp_services.0.is_all_allowed", "true"),
+					resource.TestCheckResourceAttrSet(resourceNameNs, "ext_id"),
+				),
+			},
+		},
+	})
+}
+
 func testNetworkSecurityConfig(name, desc string) string {
 	return fmt.Sprintf(`
 
@@ -383,6 +409,34 @@ func testNetworkSecurityConfigGlobalScope(name, desc string) string {
 			}
 		}
 		is_hitlog_enabled = false
+	}
+`, name, desc)
+}
+
+func testNetworkSecurityConfigICMPAllAllowed(name, desc string) string {
+	return fmt.Sprintf(`
+	data "nutanix_categories_v2" "test" {}
+
+	resource "nutanix_network_security_policy_v2" "test" {
+		name        = "%[1]s"
+		description = "%[2]s"
+		type        = "APPLICATION"
+		state       = "ENFORCE"
+		scope       = "GLOBAL"
+		rules {
+			type = "APPLICATION"
+			spec {
+				application_rule_spec {
+					secured_group_category_references = [
+						data.nutanix_categories_v2.test.categories.0.ext_id,
+					]
+					src_allow_spec = "ALL"
+					icmp_services {
+						is_all_allowed = true
+					}
+				}
+			}
+		}
 	}
 `, name, desc)
 }

--- a/nutanix/services/networkingv2/resource_nutanix_service_groups_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_service_groups_v2.go
@@ -3,6 +3,7 @@ package networkingv2
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -149,7 +150,7 @@ func ResourceNutanixServiceGroupsV2Create(ctx context.Context, d *schema.Resourc
 		spec.UdpServices = expandUDPPortRangeSpec(udp.([]interface{}))
 	}
 	if icmp, ok := d.GetOk("icmp_services"); ok {
-		spec.IcmpServices = expandIcmpTypeCodeSpec(icmp.([]interface{}))
+		spec.IcmpServices = expandIcmpTypeCodeSpec(d, "icmp_services", icmp.([]interface{}))
 	}
 
 	resp, err := conn.ServiceGroupAPIInstance.CreateServiceGroup(spec)
@@ -273,7 +274,7 @@ func ResourceNutanixServiceGroupsV2Update(ctx context.Context, d *schema.Resourc
 		updatedSpec.UdpServices = expandUDPPortRangeSpec(d.Get("udp_services").([]interface{}))
 	}
 	if d.HasChange("icmp_services") {
-		updatedSpec.IcmpServices = expandIcmpTypeCodeSpec(d.Get("icmp_services").([]interface{}))
+		updatedSpec.IcmpServices = expandIcmpTypeCodeSpec(d, "icmp_services", d.Get("icmp_services").([]interface{}))
 	}
 
 	// removing read only attribute from spec
@@ -374,7 +375,19 @@ func expandUDPPortRangeSpec(pr []interface{}) []import1.UdpPortRangeSpec {
 	return nil
 }
 
-func expandIcmpTypeCodeSpec(pr []interface{}) []import1.IcmpTypeCodeSpec {
+// expandIcmpTypeCodeSpec builds the ICMP spec payload. basePath is the raw
+// config path of the icmp_services list (e.g. "icmp_services" or
+// "rules.0.spec.0.application_rule_spec.0.icmp_services") so we can tell
+// whether the user explicitly set type/code.
+//
+// The microseg v4.2 API rejects a spec that sets is_all_allowed=true while
+// also carrying a specific type/code (MIC-30302 on service-groups, MIC-30113
+// on network-security-policies). Terraform's schema-driven d.Get fills unset
+// optional ints with 0, so a plain map check would always emit type:0/code:0
+// and trip that validation. We therefore only serialize type/code when they
+// are explicitly present in config, which also honors the valid specific case
+// type=0/code=0 without forcing it on wildcard specs.
+func expandIcmpTypeCodeSpec(d *schema.ResourceData, basePath string, pr []interface{}) []import1.IcmpTypeCodeSpec {
 	if len(pr) > 0 {
 		icmps := make([]import1.IcmpTypeCodeSpec, len(pr))
 
@@ -382,14 +395,15 @@ func expandIcmpTypeCodeSpec(pr []interface{}) []import1.IcmpTypeCodeSpec {
 			icmp := import1.IcmpTypeCodeSpec{}
 			val := v.(map[string]interface{})
 
-			if allAllow, ok := val["is_all_allowed"]; ok {
-				icmp.IsAllAllowed = utils.BoolPtr(allAllow.(bool))
+			if common.IsExplicitlySet(d, fmt.Sprintf("%s.%d.is_all_allowed", basePath, k)) {
+				allAllow := d.Get(fmt.Sprintf("%s.%d.is_all_allowed", basePath, k)).(bool)
+				icmp.IsAllAllowed = utils.BoolPtr(allAllow)
 			}
-			if code, ok := val["code"]; ok {
-				icmp.Code = utils.IntPtr(code.(int))
+			if common.IsExplicitlySet(d, fmt.Sprintf("%s.%d.type", basePath, k)) {
+				icmp.Type = utils.IntPtr(val["type"].(int))
 			}
-			if types, ok := val["type"]; ok {
-				icmp.Type = utils.IntPtr(types.(int))
+			if common.IsExplicitlySet(d, fmt.Sprintf("%s.%d.code", basePath, k)) {
+				icmp.Code = utils.IntPtr(val["code"].(int))
 			}
 			icmps[k] = icmp
 		}

--- a/nutanix/services/networkingv2/resource_nutanix_service_groups_v2_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_service_groups_v2_test.go
@@ -100,6 +100,35 @@ func TestAccV2NutanixServiceGroupResource_WithICMP(t *testing.T) {
 	})
 }
 
+// TestAccV2NutanixServiceGroupResource_WithICMPAllAllowed covers the ICMP
+// wildcard case: is_all_allowed = true with no type/code. The provider must
+// omit type/code from the payload, otherwise the microseg v4.2 API rejects it
+// with MIC-30302 ("ICMP is set to allow all but also contains specific type/code").
+func TestAccV2NutanixServiceGroupResource_WithICMPAllAllowed(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("test-Service-group-%d", r)
+	desc := "test Service group ICMP wildcard"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testServiceGroupV2ConfigWithICMPAllAllowed(name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameServiceGroup, "name", name),
+					resource.TestCheckResourceAttr(resourceNameServiceGroup, "description", desc),
+					resource.TestCheckResourceAttrSet(resourceNameServiceGroup, "links.#"),
+					resource.TestCheckResourceAttr(resourceNameServiceGroup, "icmp_services.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameServiceGroup, "icmp_services.0.is_all_allowed", "true"),
+					resource.TestCheckResourceAttr(resourceNameServiceGroup, "icmp_services.0.type", "0"),
+					resource.TestCheckResourceAttr(resourceNameServiceGroup, "icmp_services.0.code", "0"),
+					resource.TestCheckResourceAttrSet(resourceNameServiceGroup, "ext_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccV2NutanixServiceGroupResource_WithAll(t *testing.T) {
 	r := acctest.RandInt()
 	name := fmt.Sprintf("test-Service-group-%d", r)
@@ -197,6 +226,19 @@ func testServiceGroupV2ConfigWithICMP(name, desc string) string {
 		icmp_services {
 			type = 8
 			code = 0
+	 	}
+	}
+`, name, desc)
+}
+
+func testServiceGroupV2ConfigWithICMPAllAllowed(name, desc string) string {
+	return fmt.Sprintf(`
+		
+	resource "nutanix_service_groups_v2" "test" {
+		name  = "%[1]s"
+		description = "%[2]s"  
+		icmp_services {
+			is_all_allowed = true
 	 	}
 	}
 `, name, desc)

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -3082,7 +3082,7 @@ func expandPolicyReference(pr interface{}) *config.PolicyReference {
 // extractTaskReferenceFromResponse extracts TaskReference from API response using reflection
 func extractTaskReferenceFromResponse(resp interface{}) (import1.TaskReference, error) {
 	respValue := reflect.ValueOf(resp)
-	if respValue.Kind() == reflect.Ptr {
+	if respValue.Kind() == reflect.Pointer {
 		respValue = respValue.Elem()
 	}
 	dataField := respValue.FieldByName("Data")


### PR DESCRIPTION
## Summary

`icmp_services { is_all_allowed = true }` (with `type`/`code` omitted) was rejected at apply time by the microseg v4.2 API:

| Resource | Error |
|---|---|
| `nutanix_service_groups_v2` | **MIC-30302** — "ICMP is set to allow all but also contains specific type/code." |
| `nutanix_network_security_policy_v2` (inline `application_rule_spec`) | **MIC-30113** — "Application rule ICMP protocol is set to allow all but also contains specific type/code." |

`terraform plan` succeeded (the schema accepts the HCL), but `apply` failed.

## Root cause

`expandIcmpTypeCodeSpec` guarded on map-key existence (`if _, ok := val["code"]; ok`). Terraform's schema-driven `d.Get()` populates every declared field, defaulting unset optional ints to `0`, so the key always exists. The provider therefore always serialized `type: 0, code: 0` — even when the user only set `is_all_allowed = true` — and the backend treated that as a specific type/code conflicting with the wildcard.

## Fix

`expandIcmpTypeCodeSpec` now takes the resource data + the raw-config path of the `icmp_services` block and uses `common.IsExplicitlySet` to serialize `type`/`code` **only when the user actually set them** in config. This:

- fixes the wildcard case (`is_all_allowed = true` emits only `is_all_allowed`, matching what the Prism 7.5 Flow UI sends), and
- still honors the valid specific case `type = 0` / `code = 0` (no `!= 0` tradeoff), since explicitly-set zeros are detected via the raw config.

The path is threaded through `expandNetworkSecurityPolicyRule` → `expandOneOfNetworkSecurityPolicyRuleSpec` so both the `application_rule_spec` and `intra_entity_group_rule_spec` inline paths are covered.

## Changes

- `resource_nutanix_service_groups_v2.go` — reworked `expandIcmpTypeCodeSpec` signature/logic; updated create + update call sites.
- `resource_nutanix_network_security_policies_v2.go` — thread `d` + config path through the rule expanders to the two inline `icmp_services` call sites.
- Acceptance tests added on both resources for the ICMP wildcard path.

## Test plan

- [x] `TF_ACC=1 go test ./nutanix/services/networkingv2/ -run 'TestAccV2NutanixServiceGroupResource_WithICMPAllAllowed|TestAccV2NutanixNetworkSecurityResource_ICMPAllAllowed' -v -timeout 120m` against PC 7.5 / microseg v4.2
- [x] Existing ICMP tests (`_WithICMP`, `_WithAll`) still pass — confirms explicitly-set `type`/`code` are still forwarded
- [x] `go build` / `go vet ./nutanix/services/networkingv2/` clean

Fixes #1138

Made with [Cursor](https://cursor.com)