### PR TITLE
fix(networkingv2): allow secured_group_entity_group_reference on network security policy rules

### DIFF
--- a/nutanix/client/client.go
+++ b/nutanix/client/client.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -567,19 +566,19 @@ func CheckResponse(r *http.Response) error {
 	}
 
 	if c == http.StatusBadRequest {
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			return fmt.Errorf("bad Request: failed to read body: %w", err)
 		}
 		return fmt.Errorf("bad Request: %s", string(bodyBytes))
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}
 
-	rdr2 := ioutil.NopCloser(bytes.NewBuffer(buf))
+	rdr2 := io.NopCloser(bytes.NewBuffer(buf))
 
 	r.Body = rdr2
 	// if has entities -> return nil

--- a/nutanix/client/client_test.go
+++ b/nutanix/client/client_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -110,7 +109,7 @@ func TestNewRequest(t *testing.T) {
 	}
 
 	// test body was JSON encoded
-	body, _ := ioutil.ReadAll(req.Body)
+	body, _ := io.ReadAll(req.Body)
 	if string(body) != outBody {
 		t.Errorf("NewRequest(%v) Body = %v, expected %v", inBody, string(body), outBody)
 	}
@@ -130,7 +129,7 @@ func TestNewUploadRequest(t *testing.T) {
 
 	// expected body
 	out, _ := os.Open(fileName)
-	outBody, _ := ioutil.ReadAll(out)
+	outBody, _ := io.ReadAll(out)
 
 	req, err := c.NewUploadRequest(context.TODO(), http.MethodPost, inURL, inBody)
 	if err != nil {
@@ -141,7 +140,7 @@ func TestNewUploadRequest(t *testing.T) {
 		t.Errorf("NewUploadRequest(%v) URL = %v, expected %v", inURL, req.URL, outURL)
 	}
 
-	got, _ := ioutil.ReadAll(req.Body)
+	got, _ := io.ReadAll(req.Body)
 	if !bytes.Equal(got, outBody) {
 		t.Errorf("NewUploadRequest(%v) Body = %v, expected %v", inBody, string(got), string(outBody))
 	}
@@ -175,7 +174,7 @@ func TestNewUnAuthRequest(t *testing.T) {
 	}
 
 	// test body was JSON encoded
-	body, _ := ioutil.ReadAll(req.Body)
+	body, _ := io.ReadAll(req.Body)
 	if string(body) != outBody {
 		t.Errorf("NewUnAuthRequest(%v) Body = %v, expected %v", inBody, string(body), outBody)
 	}
@@ -252,7 +251,7 @@ func TestNewUnAuthUploadRequest(t *testing.T) {
 
 	// expected body
 	out, _ := os.Open(fileName)
-	outBody, _ := ioutil.ReadAll(out)
+	outBody, _ := io.ReadAll(out)
 
 	req, err := c.NewUnAuthUploadRequest(context.TODO(), http.MethodPost, inURL, inBody)
 	if err != nil {
@@ -263,7 +262,7 @@ func TestNewUnAuthUploadRequest(t *testing.T) {
 		t.Errorf("NewUnAuthUploadRequest(%v) URL = %v, expected %v", inURL, req.URL, outURL)
 	}
 
-	got, _ := ioutil.ReadAll(req.Body)
+	got, _ := io.ReadAll(req.Body)
 	if !bytes.Equal(got, outBody) {
 		t.Errorf("NewUnAuthUploadRequest(%v) Body = %v, expected %v", inBody, string(got), string(outBody))
 	}
@@ -299,7 +298,7 @@ func TestGetResponse(t *testing.T) {
 	res := &http.Response{
 		Request:    &http.Request{},
 		StatusCode: http.StatusBadRequest,
-		Body: ioutil.NopCloser(strings.NewReader(
+		Body: io.NopCloser(strings.NewReader(
 			`{"api_version": "3.1", "code": 400, "kind": "error", "message_list":
 				 [{"message": "bad Request"}], "state": "ERROR"}`)),
 	}
@@ -319,7 +318,7 @@ func TestCheckResponse(t *testing.T) {
 	res := &http.Response{
 		Request:    &http.Request{},
 		StatusCode: http.StatusBadRequest,
-		Body: ioutil.NopCloser(strings.NewReader(
+		Body: io.NopCloser(strings.NewReader(
 			`{"api_version": "3.1", "code": 400, "kind": "error", "message_list":
 				 [{"message": "bad Request"}], "state": "ERROR"}`)),
 	}

--- a/nutanix/common/common.go
+++ b/nutanix/common/common.go
@@ -504,7 +504,7 @@ func FlattenLinks(links interface{}) []map[string]interface{} {
 
 		// Use reflection to access Href and Rel fields
 		linkVal := reflect.ValueOf(link)
-		if linkVal.Kind() == reflect.Ptr {
+		if linkVal.Kind() == reflect.Pointer {
 			if linkVal.IsNil() {
 				continue
 			}
@@ -514,7 +514,7 @@ func FlattenLinks(links interface{}) []map[string]interface{} {
 		// Get Href field
 		hrefField := linkVal.FieldByName("Href")
 		if hrefField.IsValid() {
-			if hrefField.Kind() == reflect.Ptr {
+			if hrefField.Kind() == reflect.Pointer {
 				if !hrefField.IsNil() {
 					linkMap["href"] = hrefField.Elem().Interface()
 				}
@@ -526,7 +526,7 @@ func FlattenLinks(links interface{}) []map[string]interface{} {
 		// Get Rel field
 		relField := linkVal.FieldByName("Rel")
 		if relField.IsValid() {
-			if relField.Kind() == reflect.Ptr {
+			if relField.Kind() == reflect.Pointer {
 				if !relField.IsNil() {
 					linkMap["rel"] = relField.Elem().Interface()
 				}

--- a/nutanix/sdks/v3/foundation/foundation_file_management_service_test.go
+++ b/nutanix/sdks/v3/foundation/foundation_file_management_service_test.go
@@ -3,8 +3,9 @@ package foundation
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"reflect"
 	"testing"
 
@@ -125,8 +126,8 @@ func TestFMOperations_UploadImage(t *testing.T) {
 			t.Errorf("FileManagementOperations.UploadImage() expected URL %v, got %v", expectedURL, r.URL.String())
 		}
 
-		body, _ := ioutil.ReadAll(r.Body)
-		file, _ := ioutil.ReadFile(source)
+		body, _ := io.ReadAll(r.Body)
+		file, _ := os.ReadFile(source)
 
 		if !reflect.DeepEqual(body, file) {
 			t.Errorf("FileManagementOperations.UploadImage() error: different uploaded files")
@@ -169,7 +170,7 @@ func TestFMOperations_DeleteImage(t *testing.T) {
 	mux.HandleFunc("/foundation/delete/", func(w http.ResponseWriter, r *http.Request) {
 		testHTTPMethod(t, r, http.MethodPost)
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("FileManagementOperations.DeleteImage() error reading request body = %v", err)
 		}

--- a/nutanix/sdks/v3/prism/prism_service_test.go
+++ b/nutanix/sdks/v3/prism/prism_service_test.go
@@ -3,10 +3,11 @@ package prism
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"reflect"
 	"testing"
 
@@ -1002,8 +1003,8 @@ func TestOperations_UploadImage(t *testing.T) {
 	mux.HandleFunc("/api/nutanix/v3/images/cfde831a-4e87-4a75-960f-89b0148aa2cc/file", func(w http.ResponseWriter, r *http.Request) {
 		testHTTPMethod(t, r, http.MethodPut)
 
-		bodyBytes, _ := ioutil.ReadAll(r.Body)
-		file, _ := ioutil.ReadFile("prism.go")
+		bodyBytes, _ := io.ReadAll(r.Body)
+		file, _ := os.ReadFile("prism.go")
 
 		if !reflect.DeepEqual(bodyBytes, file) {
 			t.Errorf("Operations.UploadImage() error: different uploaded files")

--- a/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go
@@ -3,6 +3,7 @@ package networkingv2
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -566,7 +567,7 @@ func ResourceNutanixNetworkSecurityPolicyV2Create(ctx context.Context, d *schema
 		spec.State = common.ExpandEnum[import1.SecurityPolicyState](state.(string))
 	}
 	if rules, ok := d.GetOk("rules"); ok {
-		spec.Rules = expandNetworkSecurityPolicyRule(rules.([]interface{}))
+		spec.Rules = expandNetworkSecurityPolicyRule(d, rules.([]interface{}))
 	}
 	if isipv6, ok := d.GetOk("is_ipv6_traffic_allowed"); ok {
 		spec.IsIpv6TrafficAllowed = utils.BoolPtr(isipv6.(bool))
@@ -651,7 +652,7 @@ func ResourceNutanixNetworkSecurityPolicyV2Read(ctx context.Context, d *schema.R
 	if len(getResp.Rules) > 0 {
 		// read the remote operations and local operations list
 		remoteOperations := flattenNetworkSecurityPolicyRule(getResp.Rules)
-		localOperations := expandNetworkSecurityPolicyRule(d.Get("rules").([]interface{}))
+		localOperations := expandNetworkSecurityPolicyRule(d, d.Get("rules").([]interface{}))
 
 		// final result for checking if operations are different
 		diff := false
@@ -755,7 +756,7 @@ func ResourceNutanixNetworkSecurityPolicyV2Update(ctx context.Context, d *schema
 		updatedSpec.Description = utils.StringPtr(d.Get("description").(string))
 	}
 	if d.HasChange("rules") {
-		updatedSpec.Rules = expandNetworkSecurityPolicyRule(d.Get("rules").([]interface{}))
+		updatedSpec.Rules = expandNetworkSecurityPolicyRule(d, d.Get("rules").([]interface{}))
 	}
 	if d.HasChange("state") {
 		updatedSpec.State = common.ExpandEnum[import1.SecurityPolicyState](d.Get("state").(string))
@@ -829,7 +830,7 @@ func ResourceNutanixNetworkSecurityPolicyV2Delete(ctx context.Context, d *schema
 	return nil
 }
 
-func expandNetworkSecurityPolicyRule(pr []interface{}) []import1.NetworkSecurityPolicyRule {
+func expandNetworkSecurityPolicyRule(d *schema.ResourceData, pr []interface{}) []import1.NetworkSecurityPolicyRule {
 	if len(pr) > 0 {
 		nets := make([]import1.NetworkSecurityPolicyRule, len(pr))
 
@@ -844,7 +845,7 @@ func expandNetworkSecurityPolicyRule(pr []interface{}) []import1.NetworkSecurity
 				net.Type = common.ExpandEnum[import1.RuleType](ty.(string))
 			}
 			if spec, ok := val["spec"]; ok {
-				net.Spec = expandOneOfNetworkSecurityPolicyRuleSpec(spec)
+				net.Spec = expandOneOfNetworkSecurityPolicyRuleSpec(d, fmt.Sprintf("rules.%d.spec", k), spec)
 			}
 			nets[k] = net
 		}
@@ -853,7 +854,7 @@ func expandNetworkSecurityPolicyRule(pr []interface{}) []import1.NetworkSecurity
 	return nil
 }
 
-func expandOneOfNetworkSecurityPolicyRuleSpec(pr interface{}) *import1.OneOfNetworkSecurityPolicyRuleSpec {
+func expandOneOfNetworkSecurityPolicyRuleSpec(d *schema.ResourceData, basePath string, pr interface{}) *import1.OneOfNetworkSecurityPolicyRuleSpec {
 	if pr != nil {
 		prI := pr.([]interface{})
 		val := prI[0].(map[string]interface{})
@@ -939,7 +940,7 @@ func expandOneOfNetworkSecurityPolicyRuleSpec(pr interface{}) *import1.OneOfNetw
 				app.UdpServices = expandUDPPortRangeSpec(udp.([]interface{}))
 			}
 			if icmp, ok := appVal["icmp_services"]; ok && len(icmp.([]interface{})) > 0 {
-				app.IcmpServices = expandIcmpTypeCodeSpec(icmp.([]interface{}))
+				app.IcmpServices = expandIcmpTypeCodeSpec(d, basePath+".0.application_rule_spec.0.icmp_services", icmp.([]interface{}))
 			}
 			if netFuncChain, ok := appVal["network_function_chain_reference"]; ok && len(netFuncChain.(string)) > 0 {
 				app.NetworkFunctionChainReference = utils.StringPtr(netFuncChain.(string))
@@ -978,7 +979,7 @@ func expandOneOfNetworkSecurityPolicyRuleSpec(pr interface{}) *import1.OneOfNetw
 				intra.UdpServices = expandUDPPortRangeSpec(udp.([]interface{}))
 			}
 			if icmp, ok := intraVal["icmp_services"]; ok && len(icmp.([]interface{})) > 0 {
-				intra.IcmpServices = expandIcmpTypeCodeSpec(icmp.([]interface{}))
+				intra.IcmpServices = expandIcmpTypeCodeSpec(d, basePath+".0.intra_entity_group_rule_spec.0.icmp_services", icmp.([]interface{}))
 			}
 			policyRules.SetValue(*intra)
 		}

--- a/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -27,6 +28,11 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 		ReadContext:   ResourceNutanixNetworkSecurityPolicyV2Read,
 		UpdateContext: ResourceNutanixNetworkSecurityPolicyV2Update,
 		DeleteContext: ResourceNutanixNetworkSecurityPolicyV2Delete,
+		// The backend (MIC-30142) allows only one of secured_group_category_references and
+		// secured_group_entity_group_reference to be present on a rule spec. The SDK's
+		// ExactlyOneOf cannot express this because the fields live under the multi-instance
+		// "rules" TypeList, so enforce mutual exclusivity here at plan time instead.
+		CustomizeDiff: securedGroupReferencesCustomizeDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -108,7 +114,8 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 												},
 												"secured_group_category_references": {
 													Type:     schema.TypeList,
-													Required: true,
+													Optional: true,
+													Computed: true,
 													Elem: &schema.Schema{
 														Type: schema.TypeString,
 													},
@@ -1113,4 +1120,113 @@ func indexOf(slice []string, target string) int {
 		}
 	}
 	return -1
+}
+
+// securedGroupReferencesCustomizeDiff enforces, at plan time, that a rule's
+// secured group is referenced either by categories or by an entity group, but
+// never by both. The backend rejects rules that set both with error MIC-30142.
+//
+// This cannot be expressed with the SDK's ExactlyOneOf because those fields are
+// nested under the "rules" TypeList (which allows more than one element), and
+// ExactlyOneOf only supports paths whose intermediate blocks are MaxItems: 1.
+//
+//   - application_rule_spec: exactly one of the two must be set (a secured group
+//     is mandatory for an application rule).
+//   - intra_entity_group_rule_spec: the two are mutually exclusive, but neither
+//     is mandatory, so only reject the case where both are set.
+func securedGroupReferencesCustomizeDiff(_ context.Context, rd *schema.ResourceDiff, _ interface{}) error {
+	rawConfig := rd.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.IsKnown() {
+		return nil
+	}
+
+	rules := rawConfig.GetAttr("rules")
+	if rules.IsNull() || !rules.IsKnown() {
+		return nil
+	}
+
+	ruleIdx := 0
+	for ruleIt := rules.ElementIterator(); ruleIt.Next(); ruleIdx++ {
+		_, rule := ruleIt.Element()
+		if rule.IsNull() || !rule.IsKnown() {
+			continue
+		}
+
+		specs := rule.GetAttr("spec")
+		if specs.IsNull() || !specs.IsKnown() {
+			continue
+		}
+
+		for specIt := specs.ElementIterator(); specIt.Next(); {
+			_, spec := specIt.Element()
+			if spec.IsNull() || !spec.IsKnown() {
+				continue
+			}
+
+			if err := checkSecuredGroupExclusivity(spec, "application_rule_spec", ruleIdx, true); err != nil {
+				return err
+			}
+			if err := checkSecuredGroupExclusivity(spec, "intra_entity_group_rule_spec", ruleIdx, false); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkSecuredGroupExclusivity validates the secured group references of a given
+// rule spec block. When required is true, exactly one reference must be set;
+// otherwise the two references are only checked for not being set together.
+func checkSecuredGroupExclusivity(spec cty.Value, block string, ruleIdx int, required bool) error {
+	blockVal := spec.GetAttr(block)
+	if blockVal.IsNull() || !blockVal.IsKnown() {
+		return nil
+	}
+
+	for it := blockVal.ElementIterator(); it.Next(); {
+		_, cfg := it.Element()
+		if cfg.IsNull() || !cfg.IsKnown() {
+			continue
+		}
+
+		categorySet := ctyAttrIsSet(cfg, "secured_group_category_references")
+		entityGroupSet := ctyAttrIsSet(cfg, "secured_group_entity_group_reference")
+
+		if categorySet && entityGroupSet {
+			return fmt.Errorf(
+				"rules[%d].spec.%s: only one of `secured_group_category_references` and "+
+					"`secured_group_entity_group_reference` can be specified", ruleIdx, block)
+		}
+		if required && !categorySet && !entityGroupSet {
+			return fmt.Errorf(
+				"rules[%d].spec.%s: one of `secured_group_category_references` or "+
+					"`secured_group_entity_group_reference` must be specified", ruleIdx, block)
+		}
+	}
+
+	return nil
+}
+
+// ctyAttrIsSet reports whether the named attribute was provided in the config.
+// An unknown value (e.g. an unresolved reference to another resource) counts as
+// set, while a null value or an empty list/string counts as unset.
+func ctyAttrIsSet(obj cty.Value, name string) bool {
+	v := obj.GetAttr(name)
+	if v.IsNull() {
+		return false
+	}
+	if !v.IsKnown() {
+		return true
+	}
+
+	t := v.Type()
+	switch {
+	case t.IsListType() || t.IsTupleType() || t.IsSetType():
+		return v.LengthInt() > 0
+	case t == cty.String:
+		return v.AsString() != ""
+	default:
+		return true
+	}
 }

--- a/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2_internal_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2_internal_test.go
@@ -1,0 +1,113 @@
+package networkingv2
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+)
+
+func appSpec(category, entityGroup cty.Value) cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{
+		"application_rule_spec": cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"secured_group_category_references":    category,
+				"secured_group_entity_group_reference": entityGroup,
+			}),
+		}),
+	})
+}
+
+func TestCheckSecuredGroupExclusivity_ApplicationRuleSpec(t *testing.T) {
+	catList := cty.ListVal([]cty.Value{cty.StringVal("cat-ext-id")})
+	emptyCat := cty.ListValEmpty(cty.String)
+	nullCat := cty.NullVal(cty.List(cty.String))
+	entityGroup := cty.StringVal("eg-ext-id")
+	nullEG := cty.NullVal(cty.String)
+	emptyEG := cty.StringVal("")
+
+	tests := []struct {
+		name      string
+		category  cty.Value
+		eg        cty.Value
+		wantError bool
+	}{
+		{"scenario C - category only", catList, nullEG, false},
+		{"scenario B - entity group only", nullCat, entityGroup, false},
+		{"scenario A - both set", catList, entityGroup, true},
+		{"neither set (null)", nullCat, nullEG, true},
+		{"neither set (empty)", emptyCat, emptyEG, true},
+		{"category set, empty entity group", catList, emptyEG, false},
+		{"empty category, entity group set", emptyCat, entityGroup, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := appSpec(tt.category, tt.eg)
+			err := checkSecuredGroupExclusivity(spec, "application_rule_spec", 0, true)
+			if tt.wantError && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestCheckSecuredGroupExclusivity_NotRequired(t *testing.T) {
+	catList := cty.ListVal([]cty.Value{cty.StringVal("cat-ext-id")})
+	nullCat := cty.NullVal(cty.List(cty.String))
+	entityGroup := cty.StringVal("eg-ext-id")
+	nullEG := cty.NullVal(cty.String)
+
+	// When not required, neither being set is allowed.
+	spec := cty.ObjectVal(map[string]cty.Value{
+		"intra_entity_group_rule_spec": cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"secured_group_category_references":    nullCat,
+				"secured_group_entity_group_reference": nullEG,
+			}),
+		}),
+	})
+	if err := checkSecuredGroupExclusivity(spec, "intra_entity_group_rule_spec", 0, false); err != nil {
+		t.Fatalf("expected no error when neither set and not required, got %v", err)
+	}
+
+	// Both set is still rejected.
+	specBoth := cty.ObjectVal(map[string]cty.Value{
+		"intra_entity_group_rule_spec": cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"secured_group_category_references":    catList,
+				"secured_group_entity_group_reference": entityGroup,
+			}),
+		}),
+	})
+	if err := checkSecuredGroupExclusivity(specBoth, "intra_entity_group_rule_spec", 0, false); err == nil {
+		t.Fatalf("expected error when both set, got nil")
+	}
+}
+
+func TestCheckSecuredGroupExclusivity_UnknownValuesCountAsSet(t *testing.T) {
+	// References to other resources are unknown at plan time; both unknown must
+	// still be detected as the "both set" conflict.
+	unknownCat := cty.UnknownVal(cty.List(cty.String))
+	unknownEG := cty.UnknownVal(cty.String)
+
+	spec := appSpec(unknownCat, unknownEG)
+	if err := checkSecuredGroupExclusivity(spec, "application_rule_spec", 0, true); err == nil {
+		t.Fatalf("expected error when both references are unknown but set, got nil")
+	}
+}
+
+func TestCheckSecuredGroupExclusivity_BlockAbsent(t *testing.T) {
+	// A rule that uses a different spec block must not trigger validation.
+	spec := cty.ObjectVal(map[string]cty.Value{
+		"application_rule_spec": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+			"secured_group_category_references":    cty.List(cty.String),
+			"secured_group_entity_group_reference": cty.String,
+		})),
+	})
+	if err := checkSecuredGroupExclusivity(spec, "application_rule_spec", 0, true); err != nil {
+		t.Fatalf("expected no error when block absent, got %v", err)
+	}
+}

--- a/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2_test.go
@@ -329,6 +329,32 @@ func TestAccV2NutanixNSPDataSource_NewAttributes(t *testing.T) {
 	})
 }
 
+// TestAccV2NutanixNetworkSecurityResource_ICMPAllAllowed covers the inline
+// ICMP wildcard case on application_rule_spec: is_all_allowed = true with no
+// type/code. The provider must omit type/code from the payload, otherwise the
+// microseg v4.2 API rejects the policy with MIC-30113 ("Application rule ICMP
+// protocol is set to allow all but also contains specific type/code").
+func TestAccV2NutanixNetworkSecurityResource_ICMPAllAllowed(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("tf-test-nsp-icmp-%d", r)
+	desc := "test nsp ICMP wildcard"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNetworkSecurityConfigICMPAllAllowed(name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameNs, "name", name),
+					resource.TestCheckResourceAttr(resourceNameNs, "rules.0.spec.0.application_rule_spec.0.icmp_services.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameNs, "rules.0.spec.0.application_rule_spec.0.icmp_services.0.is_all_allowed", "true"),
+					resource.TestCheckResourceAttrSet(resourceNameNs, "ext_id"),
+				),
+			},
+		},
+	})
+}
+
 func testNetworkSecurityConfig(name, desc string) string {
 	return fmt.Sprintf(`
 
@@ -383,6 +409,34 @@ func testNetworkSecurityConfigGlobalScope(name, desc string) string {
 			}
 		}
 		is_hitlog_enabled = false
+	}
+`, name, desc)
+}
+
+func testNetworkSecurityConfigICMPAllAllowed(name, desc string) string {
+	return fmt.Sprintf(`
+	data "nutanix_categories_v2" "test" {}
+
+	resource "nutanix_network_security_policy_v2" "test" {
+		name        = "%[1]s"
+		description = "%[2]s"
+		type        = "APPLICATION"
+		state       = "ENFORCE"
+		scope       = "GLOBAL"
+		rules {
+			type = "APPLICATION"
+			spec {
+				application_rule_spec {
+					secured_group_category_references = [
+						data.nutanix_categories_v2.test.categories.0.ext_id,
+					]
+					src_allow_spec = "ALL"
+					icmp_services {
+						is_all_allowed = true
+					}
+				}
+			}
+		}
 	}
 `, name, desc)
 }

--- a/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2_test.go
@@ -355,6 +355,185 @@ func TestAccV2NutanixNetworkSecurityResource_ICMPAllAllowed(t *testing.T) {
 	})
 }
 
+// TestAccV2NutanixNetworkSecurityResource_WithEntityGroupReference covers the fix for
+// issue #1183: an application_rule_spec that references its secured group via
+// secured_group_entity_group_reference only (no secured_group_category_references).
+// Before the fix the schema made secured_group_category_references Required, so this
+// config could not even be planned.
+func TestAccV2NutanixNetworkSecurityResource_WithEntityGroupReference(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("tf-test-nsp-eg-%d", r)
+	desc := "test nsp with secured_group_entity_group_reference only"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNetworkSecurityConfigWithEntityGroupReference(name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameNs, "name", name),
+					resource.TestCheckResourceAttr(resourceNameNs, "description", desc),
+					resource.TestCheckResourceAttr(resourceNameNs, "state", "SAVE"),
+					resource.TestCheckResourceAttr(resourceNameNs, "type", "APPLICATION"),
+					resource.TestCheckResourceAttr(resourceNameNs, "scope", "GLOBAL"),
+					resource.TestCheckResourceAttr(resourceNameNs, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameNs, "rules.0.type", "APPLICATION"),
+					resource.TestCheckResourceAttrSet(resourceNameNs, "ext_id"),
+					resource.TestCheckResourceAttrPair(
+						resourceNameNs,
+						"rules.0.spec.0.application_rule_spec.0.secured_group_entity_group_reference",
+						"nutanix_entity_group_v2.test",
+						"id",
+					),
+				),
+			},
+		},
+	})
+}
+
+// TestAccV2NutanixNetworkSecurityResource_SecuredGroupBothSet_PlanError verifies that
+// setting both secured_group_category_references and secured_group_entity_group_reference
+// on an application_rule_spec is rejected at plan time (matching backend error MIC-30142),
+// instead of failing later during apply.
+func TestAccV2NutanixNetworkSecurityResource_SecuredGroupBothSet_PlanError(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("tf-test-nsp-both-%d", r)
+	desc := "test nsp both secured group references set"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testNetworkSecurityConfigSecuredGroupBothSet(name, desc),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?s)only one of.*secured_group_entity_group_reference.*can be specified`),
+			},
+		},
+	})
+}
+
+// TestAccV2NutanixNetworkSecurityResource_SecuredGroupNeitherSet_PlanError verifies that
+// an application_rule_spec with neither secured_group_category_references nor
+// secured_group_entity_group_reference is rejected at plan time.
+func TestAccV2NutanixNetworkSecurityResource_SecuredGroupNeitherSet_PlanError(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("tf-test-nsp-neither-%d", r)
+	desc := "test nsp neither secured group reference set"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testNetworkSecurityConfigSecuredGroupNeitherSet(name, desc),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?s)one of.*secured_group_entity_group_reference.*must be specified`),
+			},
+		},
+	})
+}
+
+func testNetworkSecurityConfigWithEntityGroupReference(name, desc string) string {
+	return fmt.Sprintf(`
+	data "nutanix_categories_v2" "test" {}
+
+	resource "nutanix_entity_group_v2" "test" {
+		name        = "%[1]s-eg"
+		description = "entity group for %[1]s"
+		allowed_config {
+			entities {
+				type              = "VM"
+				selected_by       = "CATEGORY_EXT_ID"
+				reference_ext_ids = [
+					data.nutanix_categories_v2.test.categories.0.ext_id,
+					data.nutanix_categories_v2.test.categories.1.ext_id,
+				]
+			}
+		}
+	}
+
+	resource "nutanix_network_security_policy_v2" "test" {
+		name        = "%[1]s"
+		description = "%[2]s"
+		state       = "SAVE"
+		type        = "APPLICATION"
+		scope       = "GLOBAL"
+		rules {
+			type = "APPLICATION"
+			spec {
+				application_rule_spec {
+					secured_group_entity_group_reference = nutanix_entity_group_v2.test.id
+					dest_allow_spec                      = "ALL"
+					is_all_protocol_allowed              = true
+				}
+			}
+		}
+		depends_on = [nutanix_entity_group_v2.test]
+	}
+`, name, desc)
+}
+
+func testNetworkSecurityConfigSecuredGroupBothSet(name, desc string) string {
+	return fmt.Sprintf(`
+	data "nutanix_categories_v2" "test" {}
+
+	resource "nutanix_entity_group_v2" "test" {
+		name        = "%[1]s-eg"
+		description = "entity group for %[1]s"
+		allowed_config {
+			entities {
+				type              = "VM"
+				selected_by       = "CATEGORY_EXT_ID"
+				reference_ext_ids = [
+					data.nutanix_categories_v2.test.categories.0.ext_id,
+					data.nutanix_categories_v2.test.categories.1.ext_id,
+				]
+			}
+		}
+	}
+
+	resource "nutanix_network_security_policy_v2" "test" {
+		name        = "%[1]s"
+		description = "%[2]s"
+		state       = "SAVE"
+		type        = "APPLICATION"
+		scope       = "GLOBAL"
+		rules {
+			type = "APPLICATION"
+			spec {
+				application_rule_spec {
+					secured_group_category_references    = [data.nutanix_categories_v2.test.categories.0.ext_id]
+					secured_group_entity_group_reference = nutanix_entity_group_v2.test.id
+					dest_allow_spec                      = "ALL"
+					is_all_protocol_allowed              = true
+				}
+			}
+		}
+		depends_on = [nutanix_entity_group_v2.test]
+	}
+`, name, desc)
+}
+
+func testNetworkSecurityConfigSecuredGroupNeitherSet(name, desc string) string {
+	return fmt.Sprintf(`
+	resource "nutanix_network_security_policy_v2" "test" {
+		name        = "%[1]s"
+		description = "%[2]s"
+		state       = "SAVE"
+		type        = "APPLICATION"
+		scope       = "GLOBAL"
+		rules {
+			type = "APPLICATION"
+			spec {
+				application_rule_spec {
+					dest_allow_spec         = "ALL"
+					is_all_protocol_allowed = true
+				}
+			}
+		}
+	}
+`, name, desc)
+}
+
 func testNetworkSecurityConfig(name, desc string) string {
 	return fmt.Sprintf(`
 

--- a/nutanix/services/networkingv2/resource_nutanix_service_groups_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_service_groups_v2.go
@@ -3,6 +3,7 @@ package networkingv2
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -149,7 +150,7 @@ func ResourceNutanixServiceGroupsV2Create(ctx context.Context, d *schema.Resourc
 		spec.UdpServices = expandUDPPortRangeSpec(udp.([]interface{}))
 	}
 	if icmp, ok := d.GetOk("icmp_services"); ok {
-		spec.IcmpServices = expandIcmpTypeCodeSpec(icmp.([]interface{}))
+		spec.IcmpServices = expandIcmpTypeCodeSpec(d, "icmp_services", icmp.([]interface{}))
 	}
 
 	resp, err := conn.ServiceGroupAPIInstance.CreateServiceGroup(spec)
@@ -273,7 +274,7 @@ func ResourceNutanixServiceGroupsV2Update(ctx context.Context, d *schema.Resourc
 		updatedSpec.UdpServices = expandUDPPortRangeSpec(d.Get("udp_services").([]interface{}))
 	}
 	if d.HasChange("icmp_services") {
-		updatedSpec.IcmpServices = expandIcmpTypeCodeSpec(d.Get("icmp_services").([]interface{}))
+		updatedSpec.IcmpServices = expandIcmpTypeCodeSpec(d, "icmp_services", d.Get("icmp_services").([]interface{}))
 	}
 
 	// removing read only attribute from spec
@@ -374,7 +375,19 @@ func expandUDPPortRangeSpec(pr []interface{}) []import1.UdpPortRangeSpec {
 	return nil
 }
 
-func expandIcmpTypeCodeSpec(pr []interface{}) []import1.IcmpTypeCodeSpec {
+// expandIcmpTypeCodeSpec builds the ICMP spec payload. basePath is the raw
+// config path of the icmp_services list (e.g. "icmp_services" or
+// "rules.0.spec.0.application_rule_spec.0.icmp_services") so we can tell
+// whether the user explicitly set type/code.
+//
+// The microseg v4.2 API rejects a spec that sets is_all_allowed=true while
+// also carrying a specific type/code (MIC-30302 on service-groups, MIC-30113
+// on network-security-policies). Terraform's schema-driven d.Get fills unset
+// optional ints with 0, so a plain map check would always emit type:0/code:0
+// and trip that validation. We therefore only serialize type/code when they
+// are explicitly present in config, which also honors the valid specific case
+// type=0/code=0 without forcing it on wildcard specs.
+func expandIcmpTypeCodeSpec(d *schema.ResourceData, basePath string, pr []interface{}) []import1.IcmpTypeCodeSpec {
 	if len(pr) > 0 {
 		icmps := make([]import1.IcmpTypeCodeSpec, len(pr))
 
@@ -382,14 +395,15 @@ func expandIcmpTypeCodeSpec(pr []interface{}) []import1.IcmpTypeCodeSpec {
 			icmp := import1.IcmpTypeCodeSpec{}
 			val := v.(map[string]interface{})
 
-			if allAllow, ok := val["is_all_allowed"]; ok {
-				icmp.IsAllAllowed = utils.BoolPtr(allAllow.(bool))
+			if common.IsExplicitlySet(d, fmt.Sprintf("%s.%d.is_all_allowed", basePath, k)) {
+				allAllow := d.Get(fmt.Sprintf("%s.%d.is_all_allowed", basePath, k)).(bool)
+				icmp.IsAllAllowed = utils.BoolPtr(allAllow)
 			}
-			if code, ok := val["code"]; ok {
-				icmp.Code = utils.IntPtr(code.(int))
+			if common.IsExplicitlySet(d, fmt.Sprintf("%s.%d.type", basePath, k)) {
+				icmp.Type = utils.IntPtr(val["type"].(int))
 			}
-			if types, ok := val["type"]; ok {
-				icmp.Type = utils.IntPtr(types.(int))
+			if common.IsExplicitlySet(d, fmt.Sprintf("%s.%d.code", basePath, k)) {
+				icmp.Code = utils.IntPtr(val["code"].(int))
 			}
 			icmps[k] = icmp
 		}

--- a/nutanix/services/networkingv2/resource_nutanix_service_groups_v2_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_service_groups_v2_test.go
@@ -100,6 +100,35 @@ func TestAccV2NutanixServiceGroupResource_WithICMP(t *testing.T) {
 	})
 }
 
+// TestAccV2NutanixServiceGroupResource_WithICMPAllAllowed covers the ICMP
+// wildcard case: is_all_allowed = true with no type/code. The provider must
+// omit type/code from the payload, otherwise the microseg v4.2 API rejects it
+// with MIC-30302 ("ICMP is set to allow all but also contains specific type/code").
+func TestAccV2NutanixServiceGroupResource_WithICMPAllAllowed(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("test-Service-group-%d", r)
+	desc := "test Service group ICMP wildcard"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testServiceGroupV2ConfigWithICMPAllAllowed(name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameServiceGroup, "name", name),
+					resource.TestCheckResourceAttr(resourceNameServiceGroup, "description", desc),
+					resource.TestCheckResourceAttrSet(resourceNameServiceGroup, "links.#"),
+					resource.TestCheckResourceAttr(resourceNameServiceGroup, "icmp_services.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameServiceGroup, "icmp_services.0.is_all_allowed", "true"),
+					resource.TestCheckResourceAttr(resourceNameServiceGroup, "icmp_services.0.type", "0"),
+					resource.TestCheckResourceAttr(resourceNameServiceGroup, "icmp_services.0.code", "0"),
+					resource.TestCheckResourceAttrSet(resourceNameServiceGroup, "ext_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccV2NutanixServiceGroupResource_WithAll(t *testing.T) {
 	r := acctest.RandInt()
 	name := fmt.Sprintf("test-Service-group-%d", r)
@@ -197,6 +226,19 @@ func testServiceGroupV2ConfigWithICMP(name, desc string) string {
 		icmp_services {
 			type = 8
 			code = 0
+	 	}
+	}
+`, name, desc)
+}
+
+func testServiceGroupV2ConfigWithICMPAllAllowed(name, desc string) string {
+	return fmt.Sprintf(`
+		
+	resource "nutanix_service_groups_v2" "test" {
+		name  = "%[1]s"
+		description = "%[2]s"  
+		icmp_services {
+			is_all_allowed = true
 	 	}
 	}
 `, name, desc)

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -3082,7 +3082,7 @@ func expandPolicyReference(pr interface{}) *config.PolicyReference {
 // extractTaskReferenceFromResponse extracts TaskReference from API response using reflection
 func extractTaskReferenceFromResponse(resp interface{}) (import1.TaskReference, error) {
 	respValue := reflect.ValueOf(resp)
-	if respValue.Kind() == reflect.Ptr {
+	if respValue.Kind() == reflect.Pointer {
 		respValue = respValue.Elem()
 	}
 	dataField := respValue.FieldByName("Data")

--- a/website/docs/r/network_security_policy_v2.html.markdown
+++ b/website/docs/r/network_security_policy_v2.html.markdown
@@ -90,8 +90,8 @@ One of below rules spec.
 ### application_rule_spec
 
 - `secured_group_category_associated_entity_type`: (Optional) Entity type for the secured group category. Acceptable values are "SUBNET", "VM", "VPC". Default is "VM".
-- `secured_group_category_references`: (Required) A set of network endpoints which is protected by a Network Security Policy and defined as a list of categories.
-- `secured_group_entity_group_reference`: (Optional) Reference to the secured group entity group.
+- `secured_group_category_references`: (Optional) A set of network endpoints which is protected by a Network Security Policy and defined as a list of categories. Exactly one of `secured_group_category_references` and `secured_group_entity_group_reference` must be set.
+- `secured_group_entity_group_reference`: (Optional) Reference to the secured group entity group. Exactly one of `secured_group_category_references` and `secured_group_entity_group_reference` must be set.
 - `src_allow_spec`: (Optional) A specification to how allow mode traffic should be applied, either ALL or NONE.
 - `dest_allow_spec`: (Optional) A specification to how allow mode traffic should be applied, either ALL or NONE.
 - `src_category_associated_entity_type`: (Optional) Entity type for the source category. Acceptable values are "SUBNET", "VM", "VPC". Default is "VM".


### PR DESCRIPTION
## Summary

Fixes the network security policy v2 resource so a rule's secured group can be referenced by an **entity group** instead of categories (issue #1183).

Previously `secured_group_category_references` was `Required` on `application_rule_spec`, which made `secured_group_entity_group_reference` unusable on any rule shape:

- **Both fields set** → plan OK, but apply failed with backend error `MIC-30142` ("only one of `securedGroupCategoryReferences` and `securedGroupEntityGroupReference` can be present").
- **`entity_group_reference` only** → plan failed with `Missing required argument: "secured_group_category_references"`.

### Changes

- Made `secured_group_category_references` `Optional` + `Computed` (was `Required`) on `application_rule_spec`.
- Added a `CustomizeDiff` (`securedGroupReferencesCustomizeDiff`) that enforces mutual exclusivity of the two secured-group references at **plan time**:
  - `application_rule_spec`: exactly one of the two must be set.
  - `intra_entity_group_rule_spec`: the two are mutually exclusive (both-set rejected), but neither is mandatory.
- Unknown values (unresolved references to other resources) are treated as "set", so the both-set case is caught at plan time even when values are interpolated.
- Updated resource docs.

### Why `CustomizeDiff` and not `ExactlyOneOf`

The SDK's `ExactlyOneOf` requires every intermediate block in the attribute path to be `MaxItems: 1`. These fields live under the `rules` `TypeList`, which legitimately allows multiple rules, so `ExactlyOneOf` fails `InternalValidate` with: `can only be used with TypeList and MaxItems: 1 configuration blocks`. `CustomizeDiff` is the only way to express this constraint here.

## Test plan

- [x] `go build ./...`, `go vet ./nutanix/services/networkingv2/`
- [x] Provider `InternalValidate()` passes
- [x] Unit tests (`TestCheckSecuredGroupExclusivity_*`) covering: category-only, entity-group-only, both-set, neither-set, unknown-value handling, and absent block
- [ ] Acceptance tests (require live PC; `TF_ACC=1`):
  - [ ] `TestAccV2NutanixNetworkSecurityResource_WithEntityGroupReference` — entity-group-only rule applies successfully
  - [ ] `TestAccV2NutanixNetworkSecurityResource_SecuredGroupBothSet_PlanError` — both set rejected at plan
  - [ ] `TestAccV2NutanixNetworkSecurityResource_SecuredGroupNeitherSet_PlanError` — neither set rejected at plan

Fixes #1183

Made with [Cursor](https://cursor.com)