### PR TITLE
fix(networkingv2): allow secured_group_entity_group_reference on network security policy rules

### DIFF
--- a/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go
+++ b/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2.go
@@ -3,8 +3,10 @@ package networkingv2
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -26,6 +28,11 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 		ReadContext:   ResourceNutanixNetworkSecurityPolicyV2Read,
 		UpdateContext: ResourceNutanixNetworkSecurityPolicyV2Update,
 		DeleteContext: ResourceNutanixNetworkSecurityPolicyV2Delete,
+		// The backend (MIC-30142) allows only one of secured_group_category_references and
+		// secured_group_entity_group_reference to be present on a rule spec. The SDK's
+		// ExactlyOneOf cannot express this because the fields live under the multi-instance
+		// "rules" TypeList, so enforce mutual exclusivity here at plan time instead.
+		CustomizeDiff: securedGroupReferencesCustomizeDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -107,7 +114,8 @@ func ResourceNutanixNetworkSecurityPolicyV2() *schema.Resource {
 												},
 												"secured_group_category_references": {
 													Type:     schema.TypeList,
-													Required: true,
+													Optional: true,
+													Computed: true,
 													Elem: &schema.Schema{
 														Type: schema.TypeString,
 													},
@@ -1112,4 +1120,113 @@ func indexOf(slice []string, target string) int {
 		}
 	}
 	return -1
+}
+
+// securedGroupReferencesCustomizeDiff enforces, at plan time, that a rule's
+// secured group is referenced either by categories or by an entity group, but
+// never by both. The backend rejects rules that set both with error MIC-30142.
+//
+// This cannot be expressed with the SDK's ExactlyOneOf because those fields are
+// nested under the "rules" TypeList (which allows more than one element), and
+// ExactlyOneOf only supports paths whose intermediate blocks are MaxItems: 1.
+//
+//   - application_rule_spec: exactly one of the two must be set (a secured group
+//     is mandatory for an application rule).
+//   - intra_entity_group_rule_spec: the two are mutually exclusive, but neither
+//     is mandatory, so only reject the case where both are set.
+func securedGroupReferencesCustomizeDiff(_ context.Context, rd *schema.ResourceDiff, _ interface{}) error {
+	rawConfig := rd.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.IsKnown() {
+		return nil
+	}
+
+	rules := rawConfig.GetAttr("rules")
+	if rules.IsNull() || !rules.IsKnown() {
+		return nil
+	}
+
+	ruleIdx := 0
+	for ruleIt := rules.ElementIterator(); ruleIt.Next(); ruleIdx++ {
+		_, rule := ruleIt.Element()
+		if rule.IsNull() || !rule.IsKnown() {
+			continue
+		}
+
+		specs := rule.GetAttr("spec")
+		if specs.IsNull() || !specs.IsKnown() {
+			continue
+		}
+
+		for specIt := specs.ElementIterator(); specIt.Next(); {
+			_, spec := specIt.Element()
+			if spec.IsNull() || !spec.IsKnown() {
+				continue
+			}
+
+			if err := checkSecuredGroupExclusivity(spec, "application_rule_spec", ruleIdx, true); err != nil {
+				return err
+			}
+			if err := checkSecuredGroupExclusivity(spec, "intra_entity_group_rule_spec", ruleIdx, false); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkSecuredGroupExclusivity validates the secured group references of a given
+// rule spec block. When required is true, exactly one reference must be set;
+// otherwise the two references are only checked for not being set together.
+func checkSecuredGroupExclusivity(spec cty.Value, block string, ruleIdx int, required bool) error {
+	blockVal := spec.GetAttr(block)
+	if blockVal.IsNull() || !blockVal.IsKnown() {
+		return nil
+	}
+
+	for it := blockVal.ElementIterator(); it.Next(); {
+		_, cfg := it.Element()
+		if cfg.IsNull() || !cfg.IsKnown() {
+			continue
+		}
+
+		categorySet := ctyAttrIsSet(cfg, "secured_group_category_references")
+		entityGroupSet := ctyAttrIsSet(cfg, "secured_group_entity_group_reference")
+
+		if categorySet && entityGroupSet {
+			return fmt.Errorf(
+				"rules[%d].spec.%s: only one of `secured_group_category_references` and "+
+					"`secured_group_entity_group_reference` can be specified", ruleIdx, block)
+		}
+		if required && !categorySet && !entityGroupSet {
+			return fmt.Errorf(
+				"rules[%d].spec.%s: one of `secured_group_category_references` or "+
+					"`secured_group_entity_group_reference` must be specified", ruleIdx, block)
+		}
+	}
+
+	return nil
+}
+
+// ctyAttrIsSet reports whether the named attribute was provided in the config.
+// An unknown value (e.g. an unresolved reference to another resource) counts as
+// set, while a null value or an empty list/string counts as unset.
+func ctyAttrIsSet(obj cty.Value, name string) bool {
+	v := obj.GetAttr(name)
+	if v.IsNull() {
+		return false
+	}
+	if !v.IsKnown() {
+		return true
+	}
+
+	t := v.Type()
+	switch {
+	case t.IsListType() || t.IsTupleType() || t.IsSetType():
+		return v.LengthInt() > 0
+	case t == cty.String:
+		return v.AsString() != ""
+	default:
+		return true
+	}
 }

--- a/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2_internal_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2_internal_test.go
@@ -1,0 +1,113 @@
+package networkingv2
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+)
+
+func appSpec(category, entityGroup cty.Value) cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{
+		"application_rule_spec": cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"secured_group_category_references":    category,
+				"secured_group_entity_group_reference": entityGroup,
+			}),
+		}),
+	})
+}
+
+func TestCheckSecuredGroupExclusivity_ApplicationRuleSpec(t *testing.T) {
+	catList := cty.ListVal([]cty.Value{cty.StringVal("cat-ext-id")})
+	emptyCat := cty.ListValEmpty(cty.String)
+	nullCat := cty.NullVal(cty.List(cty.String))
+	entityGroup := cty.StringVal("eg-ext-id")
+	nullEG := cty.NullVal(cty.String)
+	emptyEG := cty.StringVal("")
+
+	tests := []struct {
+		name      string
+		category  cty.Value
+		eg        cty.Value
+		wantError bool
+	}{
+		{"scenario C - category only", catList, nullEG, false},
+		{"scenario B - entity group only", nullCat, entityGroup, false},
+		{"scenario A - both set", catList, entityGroup, true},
+		{"neither set (null)", nullCat, nullEG, true},
+		{"neither set (empty)", emptyCat, emptyEG, true},
+		{"category set, empty entity group", catList, emptyEG, false},
+		{"empty category, entity group set", emptyCat, entityGroup, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := appSpec(tt.category, tt.eg)
+			err := checkSecuredGroupExclusivity(spec, "application_rule_spec", 0, true)
+			if tt.wantError && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestCheckSecuredGroupExclusivity_NotRequired(t *testing.T) {
+	catList := cty.ListVal([]cty.Value{cty.StringVal("cat-ext-id")})
+	nullCat := cty.NullVal(cty.List(cty.String))
+	entityGroup := cty.StringVal("eg-ext-id")
+	nullEG := cty.NullVal(cty.String)
+
+	// When not required, neither being set is allowed.
+	spec := cty.ObjectVal(map[string]cty.Value{
+		"intra_entity_group_rule_spec": cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"secured_group_category_references":    nullCat,
+				"secured_group_entity_group_reference": nullEG,
+			}),
+		}),
+	})
+	if err := checkSecuredGroupExclusivity(spec, "intra_entity_group_rule_spec", 0, false); err != nil {
+		t.Fatalf("expected no error when neither set and not required, got %v", err)
+	}
+
+	// Both set is still rejected.
+	specBoth := cty.ObjectVal(map[string]cty.Value{
+		"intra_entity_group_rule_spec": cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"secured_group_category_references":    catList,
+				"secured_group_entity_group_reference": entityGroup,
+			}),
+		}),
+	})
+	if err := checkSecuredGroupExclusivity(specBoth, "intra_entity_group_rule_spec", 0, false); err == nil {
+		t.Fatalf("expected error when both set, got nil")
+	}
+}
+
+func TestCheckSecuredGroupExclusivity_UnknownValuesCountAsSet(t *testing.T) {
+	// References to other resources are unknown at plan time; both unknown must
+	// still be detected as the "both set" conflict.
+	unknownCat := cty.UnknownVal(cty.List(cty.String))
+	unknownEG := cty.UnknownVal(cty.String)
+
+	spec := appSpec(unknownCat, unknownEG)
+	if err := checkSecuredGroupExclusivity(spec, "application_rule_spec", 0, true); err == nil {
+		t.Fatalf("expected error when both references are unknown but set, got nil")
+	}
+}
+
+func TestCheckSecuredGroupExclusivity_BlockAbsent(t *testing.T) {
+	// A rule that uses a different spec block must not trigger validation.
+	spec := cty.ObjectVal(map[string]cty.Value{
+		"application_rule_spec": cty.ListValEmpty(cty.Object(map[string]cty.Type{
+			"secured_group_category_references":    cty.List(cty.String),
+			"secured_group_entity_group_reference": cty.String,
+		})),
+	})
+	if err := checkSecuredGroupExclusivity(spec, "application_rule_spec", 0, true); err != nil {
+		t.Fatalf("expected no error when block absent, got %v", err)
+	}
+}

--- a/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2_test.go
+++ b/nutanix/services/networkingv2/resource_nutanix_network_security_policies_v2_test.go
@@ -329,6 +329,185 @@ func TestAccV2NutanixNSPDataSource_NewAttributes(t *testing.T) {
 	})
 }
 
+// TestAccV2NutanixNetworkSecurityResource_WithEntityGroupReference covers the fix for
+// issue #1183: an application_rule_spec that references its secured group via
+// secured_group_entity_group_reference only (no secured_group_category_references).
+// Before the fix the schema made secured_group_category_references Required, so this
+// config could not even be planned.
+func TestAccV2NutanixNetworkSecurityResource_WithEntityGroupReference(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("tf-test-nsp-eg-%d", r)
+	desc := "test nsp with secured_group_entity_group_reference only"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testNetworkSecurityConfigWithEntityGroupReference(name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameNs, "name", name),
+					resource.TestCheckResourceAttr(resourceNameNs, "description", desc),
+					resource.TestCheckResourceAttr(resourceNameNs, "state", "SAVE"),
+					resource.TestCheckResourceAttr(resourceNameNs, "type", "APPLICATION"),
+					resource.TestCheckResourceAttr(resourceNameNs, "scope", "GLOBAL"),
+					resource.TestCheckResourceAttr(resourceNameNs, "rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameNs, "rules.0.type", "APPLICATION"),
+					resource.TestCheckResourceAttrSet(resourceNameNs, "ext_id"),
+					resource.TestCheckResourceAttrPair(
+						resourceNameNs,
+						"rules.0.spec.0.application_rule_spec.0.secured_group_entity_group_reference",
+						"nutanix_entity_group_v2.test",
+						"id",
+					),
+				),
+			},
+		},
+	})
+}
+
+// TestAccV2NutanixNetworkSecurityResource_SecuredGroupBothSet_PlanError verifies that
+// setting both secured_group_category_references and secured_group_entity_group_reference
+// on an application_rule_spec is rejected at plan time (matching backend error MIC-30142),
+// instead of failing later during apply.
+func TestAccV2NutanixNetworkSecurityResource_SecuredGroupBothSet_PlanError(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("tf-test-nsp-both-%d", r)
+	desc := "test nsp both secured group references set"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testNetworkSecurityConfigSecuredGroupBothSet(name, desc),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?s)only one of.*secured_group_entity_group_reference.*can be specified`),
+			},
+		},
+	})
+}
+
+// TestAccV2NutanixNetworkSecurityResource_SecuredGroupNeitherSet_PlanError verifies that
+// an application_rule_spec with neither secured_group_category_references nor
+// secured_group_entity_group_reference is rejected at plan time.
+func TestAccV2NutanixNetworkSecurityResource_SecuredGroupNeitherSet_PlanError(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("tf-test-nsp-neither-%d", r)
+	desc := "test nsp neither secured group reference set"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testNetworkSecurityConfigSecuredGroupNeitherSet(name, desc),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?s)one of.*secured_group_entity_group_reference.*must be specified`),
+			},
+		},
+	})
+}
+
+func testNetworkSecurityConfigWithEntityGroupReference(name, desc string) string {
+	return fmt.Sprintf(`
+	data "nutanix_categories_v2" "test" {}
+
+	resource "nutanix_entity_group_v2" "test" {
+		name        = "%[1]s-eg"
+		description = "entity group for %[1]s"
+		allowed_config {
+			entities {
+				type              = "VM"
+				selected_by       = "CATEGORY_EXT_ID"
+				reference_ext_ids = [
+					data.nutanix_categories_v2.test.categories.0.ext_id,
+					data.nutanix_categories_v2.test.categories.1.ext_id,
+				]
+			}
+		}
+	}
+
+	resource "nutanix_network_security_policy_v2" "test" {
+		name        = "%[1]s"
+		description = "%[2]s"
+		state       = "SAVE"
+		type        = "APPLICATION"
+		scope       = "GLOBAL"
+		rules {
+			type = "APPLICATION"
+			spec {
+				application_rule_spec {
+					secured_group_entity_group_reference = nutanix_entity_group_v2.test.id
+					dest_allow_spec                      = "ALL"
+					is_all_protocol_allowed              = true
+				}
+			}
+		}
+		depends_on = [nutanix_entity_group_v2.test]
+	}
+`, name, desc)
+}
+
+func testNetworkSecurityConfigSecuredGroupBothSet(name, desc string) string {
+	return fmt.Sprintf(`
+	data "nutanix_categories_v2" "test" {}
+
+	resource "nutanix_entity_group_v2" "test" {
+		name        = "%[1]s-eg"
+		description = "entity group for %[1]s"
+		allowed_config {
+			entities {
+				type              = "VM"
+				selected_by       = "CATEGORY_EXT_ID"
+				reference_ext_ids = [
+					data.nutanix_categories_v2.test.categories.0.ext_id,
+					data.nutanix_categories_v2.test.categories.1.ext_id,
+				]
+			}
+		}
+	}
+
+	resource "nutanix_network_security_policy_v2" "test" {
+		name        = "%[1]s"
+		description = "%[2]s"
+		state       = "SAVE"
+		type        = "APPLICATION"
+		scope       = "GLOBAL"
+		rules {
+			type = "APPLICATION"
+			spec {
+				application_rule_spec {
+					secured_group_category_references    = [data.nutanix_categories_v2.test.categories.0.ext_id]
+					secured_group_entity_group_reference = nutanix_entity_group_v2.test.id
+					dest_allow_spec                      = "ALL"
+					is_all_protocol_allowed              = true
+				}
+			}
+		}
+		depends_on = [nutanix_entity_group_v2.test]
+	}
+`, name, desc)
+}
+
+func testNetworkSecurityConfigSecuredGroupNeitherSet(name, desc string) string {
+	return fmt.Sprintf(`
+	resource "nutanix_network_security_policy_v2" "test" {
+		name        = "%[1]s"
+		description = "%[2]s"
+		state       = "SAVE"
+		type        = "APPLICATION"
+		scope       = "GLOBAL"
+		rules {
+			type = "APPLICATION"
+			spec {
+				application_rule_spec {
+					dest_allow_spec         = "ALL"
+					is_all_protocol_allowed = true
+				}
+			}
+		}
+	}
+`, name, desc)
+}
+
 func testNetworkSecurityConfig(name, desc string) string {
 	return fmt.Sprintf(`
 

--- a/website/docs/r/network_security_policy_v2.html.markdown
+++ b/website/docs/r/network_security_policy_v2.html.markdown
@@ -90,8 +90,8 @@ One of below rules spec.
 ### application_rule_spec
 
 - `secured_group_category_associated_entity_type`: (Optional) Entity type for the secured group category. Acceptable values are "SUBNET", "VM", "VPC". Default is "VM".
-- `secured_group_category_references`: (Required) A set of network endpoints which is protected by a Network Security Policy and defined as a list of categories.
-- `secured_group_entity_group_reference`: (Optional) Reference to the secured group entity group.
+- `secured_group_category_references`: (Optional) A set of network endpoints which is protected by a Network Security Policy and defined as a list of categories. Exactly one of `secured_group_category_references` and `secured_group_entity_group_reference` must be set.
+- `secured_group_entity_group_reference`: (Optional) Reference to the secured group entity group. Exactly one of `secured_group_category_references` and `secured_group_entity_group_reference` must be set.
 - `src_allow_spec`: (Optional) A specification to how allow mode traffic should be applied, either ALL or NONE.
 - `dest_allow_spec`: (Optional) A specification to how allow mode traffic should be applied, either ALL or NONE.
 - `src_category_associated_entity_type`: (Optional) Entity type for the source category. Acceptable values are "SUBNET", "VM", "VPC". Default is "VM".


### PR DESCRIPTION
## Summary

Fixes the `nutanix_network_security_policy_v2` resource so a rule's secured group can be referenced by an **entity group** instead of categories.

Previously `secured_group_category_references` was `Required` on `application_rule_spec`, which made `secured_group_entity_group_reference` unusable on any rule shape:

- **Both fields set** → plan OK, but apply failed with backend error `MIC-30142` ("only one of `securedGroupCategoryReferences` and `securedGroupEntityGroupReference` can be present").
- **`entity_group_reference` only** → plan failed with `Missing required argument: "secured_group_category_references"`.

### Changes

- Made `secured_group_category_references` `Optional` + `Computed` (was `Required`) on `application_rule_spec`.
- Added a `CustomizeDiff` (`securedGroupReferencesCustomizeDiff`) that enforces mutual exclusivity of the two secured-group references at **plan time**:
  - `application_rule_spec`: exactly one of the two must be set.
  - `intra_entity_group_rule_spec`: the two are mutually exclusive (both-set rejected), but neither is mandatory.
- Unknown values (unresolved references to other resources) are treated as "set", so the both-set case is caught at plan time even when values are interpolated.
- Updated resource docs.

### Why `CustomizeDiff` and not `ExactlyOneOf`

The SDK's `ExactlyOneOf` requires every intermediate block in the attribute path to be `MaxItems: 1`. These fields live under the `rules` `TypeList`, which legitimately allows multiple rules, so `ExactlyOneOf` fails `InternalValidate` with `can only be used with TypeList and MaxItems: 1 configuration blocks`. `CustomizeDiff` is the only way to express this constraint here.

## Test plan

- [x] `go build ./...`, `go vet ./nutanix/services/networkingv2/`
- [x] Provider `InternalValidate()` passes
- [x] Unit tests (`TestCheckSecuredGroupExclusivity_*`): category-only, entity-group-only, both-set, neither-set, unknown-value handling, absent block
- [ ] Acceptance tests (require live PC; `TF_ACC=1`):
  - [ ] `TestAccV2NutanixNetworkSecurityResource_WithEntityGroupReference` — entity-group-only rule applies successfully
  - [ ] `TestAccV2NutanixNetworkSecurityResource_SecuredGroupBothSet_PlanError` — both set rejected at plan
  - [ ] `TestAccV2NutanixNetworkSecurityResource_SecuredGroupNeitherSet_PlanError` — neither set rejected at plan

Made with [Cursor](https://cursor.com)