### PR TITLE
code-gen(volumes/VmAttachmentsByVolumeGroupId): terraform v2 provider code

### DIFF
--- a/examples/volume_group_vms_v2/main.tf
+++ b/examples/volume_group_vms_v2/main.tf
@@ -1,0 +1,73 @@
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = "2.0.0"
+    }
+  }
+}
+
+#defining nutanix configuration
+provider "nutanix" {
+  username = var.nutanix_username
+  password = var.nutanix_password
+  endpoint = var.nutanix_endpoint
+  port     = 9440
+  insecure = true
+}
+
+# pull cluster data
+data "nutanix_clusters_v2" "clusters" {}
+
+# pull the desired (non Prism Central) cluster
+locals {
+  cluster_ext_id = [
+    for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+    cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+  ][0]
+}
+
+# create a volume group
+resource "nutanix_volume_group_v2" "example" {
+  name                               = var.volume_group_name
+  description                        = "volume group for VM attachments list example"
+  should_load_balance_vm_attachments = false
+  sharing_status                     = "SHARED"
+  created_by                         = "example"
+  cluster_reference                  = local.cluster_ext_id
+  usage_type                         = "USER"
+  is_hidden                          = false
+}
+
+# create a VM to attach to the volume group
+resource "nutanix_virtual_machine_v2" "example" {
+  name              = var.vm_name
+  num_sockets       = 1
+  memory_size_bytes = 4 * 1024 * 1024 * 1024
+  cluster {
+    ext_id = local.cluster_ext_id
+  }
+  power_state = "OFF"
+}
+
+# attach the VM to the volume group (index on the SCSI bus is optional)
+resource "nutanix_volume_group_vm_v2" "example" {
+  volume_group_ext_id = nutanix_volume_group_v2.example.id
+  vm_ext_id           = nutanix_virtual_machine_v2.example.id
+  index               = 1
+}
+
+# List datasource — query all VM attachments for the volume group.
+# NOTE: This API has been deprecated.
+data "nutanix_volume_group_vms_v2" "attachments" {
+  volume_group_ext_id = nutanix_volume_group_v2.example.id
+  depends_on          = [nutanix_volume_group_vm_v2.example]
+}
+
+# List datasource with pagination / filter query parameters
+data "nutanix_volume_group_vms_v2" "filtered-attachments" {
+  volume_group_ext_id = nutanix_volume_group_v2.example.id
+  page                = 0
+  limit               = 10
+  depends_on          = [nutanix_volume_group_vm_v2.example]
+}

--- a/examples/volume_group_vms_v2/terraform.tfvars
+++ b/examples/volume_group_vms_v2/terraform.tfvars
@@ -1,0 +1,6 @@
+#define values to the variables to be used in terraform file
+nutanix_username  = "admin"
+nutanix_password  = "password"
+nutanix_endpoint  = "10.xx.xx.xx"
+volume_group_name = "vg-vms-example"
+vm_name           = "tf-vg-vms-example"

--- a/examples/volume_group_vms_v2/variables.tf
+++ b/examples/volume_group_vms_v2/variables.tf
@@ -1,0 +1,26 @@
+#define the type of variables to be used in terraform file
+variable "nutanix_username" {
+  description = "Prism Central username."
+  type        = string
+}
+
+variable "nutanix_password" {
+  description = "Prism Central password."
+  type        = string
+  sensitive   = true
+}
+
+variable "nutanix_endpoint" {
+  description = "Prism Central endpoint (IP or FQDN)."
+  type        = string
+}
+
+variable "volume_group_name" {
+  description = "Name of the volume group to create."
+  type        = string
+}
+
+variable "vm_name" {
+  description = "Name of the virtual machine to create and attach."
+  type        = string
+}

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -326,6 +326,7 @@ func Provider() *schema.Provider {
 			"nutanix_volume_group_disk_v2":                    volumesv2.DatasourceNutanixVolumeDiskV2(),
 			"nutanix_volume_iscsi_clients_v2":                 volumesv2.DatasourceNutanixVolumeIscsiClientsV2(),
 			"nutanix_volume_iscsi_client_v2":                  volumesv2.DatasourceNutanixVolumeIscsiClientV2(),
+			"nutanix_volume_group_vms_v2":                     volumesv2.DatasourceNutanixVolumeGroupVmsV2(),
 			"nutanix_recovery_point_v2":                       dataprotectionv2.DatasourceNutanixRecoveryPointV2(),
 			"nutanix_recovery_points_v2":                      dataprotectionv2.DatasourceNutanixRecoveryPointsV2(),
 			"nutanix_vm_recovery_point_info_v2":               dataprotectionv2.DatasourceNutanixVMRecoveryPointInfoV2(),

--- a/nutanix/services/volumesv2/data_source_nutanix_volume_group_vms_v2.go
+++ b/nutanix/services/volumesv2/data_source_nutanix_volume_group_vms_v2.go
@@ -1,0 +1,149 @@
+package volumesv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	volumesClient "github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4/models/volumes/v4/config"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+// DatasourceNutanixVolumeGroupVmsV2 lists the VM attachments for a Volume Group.
+//
+// Deprecated: This API has been deprecated.
+func DatasourceNutanixVolumeGroupVmsV2() *schema.Resource {
+	return &schema.Resource{
+		Description: "Query the list of VM attachments for a Volume Group identified by {extId}. Deprecated: This API has been deprecated.",
+		ReadContext: DatasourceNutanixVolumeGroupVmsV2Read,
+		Schema: map[string]*schema.Schema{
+			"volume_group_ext_id": {
+				Description: "The external identifier of a Volume Group.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"page": {
+				Description: "A URL query parameter that specifies the page number of the result set. It must be a positive integer between 0 and the maximum number of pages that are available for that resource. Any number out of this range might lead to no results.",
+				Type:        schema.TypeInt,
+				Optional:    true,
+			},
+			"limit": {
+				Description: "A URL query parameter that specifies the total number of records returned in the result set. Must be a positive integer between 1 and 100. Any number out of this range will lead to a validation error. If the limit is not provided, a default value of 50 records will be returned in the result set.",
+				Type:        schema.TypeInt,
+				Optional:    true,
+			},
+			"filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"orderby": {
+				Description: "A URL query parameter that allows clients to specify the sort criteria for the returned list of objects. Resources can be sorted in ascending order using asc or descending order using desc. If asc or desc are not specified, the resources will be sorted in ascending order by default.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"attachments": {
+				Description: "List of VM attachments for a Volume Group identified by {extId}.",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ext_id": {
+							Description: "The external identifier of the VM.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"index": {
+							Description: "The index on the SCSI bus to attach the VM to the Volume Group. This is an optional field.",
+							Type:        schema.TypeInt,
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func DatasourceNutanixVolumeGroupVmsV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).VolumeAPI
+
+	var filter, orderBy *string
+	var page, limit *int
+
+	volumeGroupExtID := d.Get("volume_group_ext_id")
+
+	// initialize the query parameters
+	if pagef, ok := d.GetOk("page"); ok {
+		page = utils.IntPtr(pagef.(int))
+	} else {
+		page = nil
+	}
+	if limitf, ok := d.GetOk("limit"); ok {
+		limit = utils.IntPtr(limitf.(int))
+	} else {
+		limit = nil
+	}
+	if filterf, ok := d.GetOk("filter"); ok {
+		filter = utils.StringPtr(filterf.(string))
+	} else {
+		filter = nil
+	}
+	if order, ok := d.GetOk("orderby"); ok {
+		orderBy = utils.StringPtr(order.(string))
+	} else {
+		orderBy = nil
+	}
+
+	// get the VM attachments response
+	resp, err := conn.VolumeAPIInstance.ListVmAttachmentsByVolumeGroupId(utils.StringPtr(volumeGroupExtID.(string)), page, limit, filter, orderBy)
+	if err != nil {
+		return diag.Errorf("error while fetching VM attachments for the volume group : %v", err)
+	}
+
+	// extract the VM attachments data from the response
+	if resp.Data == nil {
+		if err := d.Set("attachments", make([]interface{}, 0)); err != nil {
+			return diag.FromErr(err)
+		}
+
+		d.SetId(utils.GenUUID())
+
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "🫙 No data found.",
+			Detail:   "The API returned an empty list of VM attachments.",
+		}}
+	}
+
+	getResp := resp.Data.GetValue().([]volumesClient.VmAttachment)
+	// set the VM attachments data in the terraform resource
+	if err := d.Set("attachments", flattenVMAttachmentEntities(getResp)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(resource.UniqueId())
+	return nil
+}
+
+func flattenVMAttachmentEntities(vmAttachments []volumesClient.VmAttachment) []interface{} {
+	if len(vmAttachments) > 0 {
+		vmAttachmentList := make([]interface{}, len(vmAttachments))
+
+		for k, v := range vmAttachments {
+			vmAttachment := make(map[string]interface{})
+
+			if v.ExtId != nil {
+				vmAttachment["ext_id"] = v.ExtId
+			}
+			if v.Index != nil {
+				vmAttachment["index"] = v.Index
+			}
+
+			vmAttachmentList[k] = vmAttachment
+		}
+		return vmAttachmentList
+	}
+	return nil
+}

--- a/nutanix/services/volumesv2/data_source_nutanix_volume_group_vms_v2_test.go
+++ b/nutanix/services/volumesv2/data_source_nutanix_volume_group_vms_v2_test.go
@@ -1,0 +1,112 @@
+package volumesv2_test
+
+// Test plan for the nutanix_volume_group_vms_v2 (ListVmAttachmentsByVolumeGroupId) datasource.
+//
+// The datasource wraps the deprecated ListVmAttachmentsByVolumeGroupId API which
+// returns the list of VM attachments (extId + optional SCSI bus index) for a
+// Volume Group identified by {volumeGroupExtId}.
+//
+// Because this is a List datasource (no Create/Update/Delete), the datasource
+// steps live in this file and compose the shared prerequisite configs:
+//   - a Volume Group (nutanix_volume_group_v2)
+//   - a VM (nutanix_virtual_machine_v2)
+//   - a VM attachment (nutanix_volume_group_vm_v2)
+//
+// Scenarios covered:
+//   1. WithAttachment  — create VG + VM + attachment, then read the list
+//      datasource by volume_group_ext_id and assert:
+//        * attachments.# == "1"
+//        * attachments.0.ext_id is set (the attached VM ext_id)
+//        * volume_group_ext_id matches the created VG
+//   2. WithInvalidVolumeGroupID — query the datasource for a random,
+//      non-existent volume group ext_id and expect the API to error out
+//      (not-found), validating the error path of the read handler.
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const datasourceVolumeGroupVms = "data.nutanix_volume_group_vms_v2.test"
+
+func TestAccV2NutanixVolumeGroupVmsDatasource_WithAttachment(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("test-volume-group-vms-%d", r)
+	desc := "test volume group VM attachments list datasource"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVolumeGroupVmsDatasourceConfig(name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceVolumeGroupVms, "volume_group_ext_id"),
+					resource.TestCheckResourceAttr(datasourceVolumeGroupVms, "attachments.#", "1"),
+					resource.TestCheckResourceAttrSet(datasourceVolumeGroupVms, "attachments.0.ext_id"),
+					resource.TestCheckResourceAttrPair(datasourceVolumeGroupVms, "attachments.0.ext_id",
+						"nutanix_virtual_machine_v2.test", "id"),
+					resource.TestCheckResourceAttrPair(datasourceVolumeGroupVms, "volume_group_ext_id",
+						"nutanix_volume_group_v2.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixVolumeGroupVmsDatasource_WithInvalidVolumeGroupID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccVolumeGroupVmsDatasourceInvalidVGConfig(),
+				ExpectError: regexp.MustCompile(`error while fetching VM attachments for the volume group`),
+			},
+		},
+	})
+}
+
+func testAccVolumeGroupVmsDatasourceConfig(name, desc string) string {
+	return testAccVolumeGroupResourceConfig(name, desc) + fmt.Sprintf(`
+		resource "nutanix_virtual_machine_v2" "test" {
+			name                 = "tf-test-vg-vms-%[1]s"
+			description          = "%[2]s"
+			num_cores_per_socket = 1
+			num_sockets          = 1
+			cluster {
+				ext_id = local.cluster1
+			}
+			lifecycle {
+				ignore_changes = [
+					disks
+				]
+			}
+		}
+
+		resource "nutanix_volume_group_vm_v2" "test" {
+			volume_group_ext_id = resource.nutanix_volume_group_v2.test.id
+			vm_ext_id           = resource.nutanix_virtual_machine_v2.test.id
+			index               = 1
+			depends_on          = [resource.nutanix_volume_group_v2.test]
+		}
+
+		data "nutanix_volume_group_vms_v2" "test" {
+			volume_group_ext_id = resource.nutanix_volume_group_v2.test.id
+			depends_on          = [resource.nutanix_volume_group_vm_v2.test]
+		}
+	`, name, desc)
+}
+
+func testAccVolumeGroupVmsDatasourceInvalidVGConfig() string {
+	return `
+		data "nutanix_volume_group_vms_v2" "test" {
+			volume_group_ext_id = "00000000-0000-0000-0000-000000000000"
+		}
+	`
+}

--- a/website/docs/d/volume_group_vms_v2.html.markdown
+++ b/website/docs/d/volume_group_vms_v2.html.markdown
@@ -1,0 +1,53 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_volume_group_vms_v2"
+sidebar_current: "docs-nutanix-datasource-volume-group-vms-v2"
+description: |-
+  Query the list of VM attachments for a Volume Group. Deprecated: This API has been deprecated.
+---
+
+# nutanix_volume_group_vms_v2
+
+Query the list of VM attachments for a Volume Group identified by {extId}. Deprecated: This API has been deprecated.
+
+## Example Usage
+
+```hcl
+
+# List all the VM attachments for a Volume Group.
+data "nutanix_volume_group_vms_v2" "list-vm-attachments" {
+  volume_group_ext_id = "3770be9d-06be-4e25-b85d-3457d9b0ceb1"
+}
+
+# List all the VM attachments for a Volume Group with pagination.
+data "nutanix_volume_group_vms_v2" "list-vm-attachments-paginated" {
+  volume_group_ext_id = "3770be9d-06be-4e25-b85d-3457d9b0ceb1"
+  page                = 0
+  limit               = 10
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `volume_group_ext_id`: -(Required) The external identifier of a Volume Group.
+* `page`: - A URL query parameter that specifies the page number of the result set. It must be a positive integer between 0 and the maximum number of pages that are available for that resource. Any number out of this range might lead to no results.
+* `limit` : - A URL query parameter that specifies the total number of records returned in the result set. Must be a positive integer between 1 and 100. Any number out of this range will lead to a validation error. If the limit is not provided, a default value of 50 records will be returned in the result set.
+* `filter` : - A URL query parameter that allows clients to filter a collection of resources. The expression specified with \$filter is evaluated for each resource in the collection, and only items where the expression evaluates to true are included in the response.
+* `orderby` : - A URL query parameter that allows clients to specify the sort criteria for the returned list of objects. Resources can be sorted in ascending order using asc or descending order using desc. If asc or desc are not specified, the resources will be sorted in ascending order by default.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `attachments`: - List of VM attachments for a Volume Group identified by {extId}.
+
+### Attachments
+
+The `attachments` contains the list of VM attachments for the Volume Group. Each attachment contains the following attributes:
+
+* `ext_id`: - The external identifier of the VM.
+* `index`: - The index on the SCSI bus to attach the VM to the Volume Group. This is an optional field.
+
+See detailed information in [Nutanix List VM Attachments by Volume Group Id V4](https://developers.nutanix.com/api-reference?namespace=volumes&version=v4.2#tag/VolumeGroups/operation/listVmAttachmentsByVolumeGroupId).


### PR DESCRIPTION
## Summary

Auto-generated Terraform provider code for the **volumes** namespace, entity
**VmAttachmentsByVolumeGroupId**, based on the inline `sdk_info.json` (see prompt). One PR per code-gen run.

- SDK module: `github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4@v4.2.2` (read from `go.mod`)
- API methods covered: `1` (`ListVmAttachmentsByVolumeGroupId`)
- Datasources generated: `1` — `nutanix_volume_group_vms_v2` (plural/list)
- Resources generated:   `0` (Step 4 = N/A; the VM-attachment resource `nutanix_volume_group_vm_v2` already exists in the namespace)

## Files changed

- `nutanix/services/volumesv2/`
  - `data_source_nutanix_volume_group_vms_v2.go` (new) — List datasource wrapping `ListVmAttachmentsByVolumeGroupId`
  - `data_source_nutanix_volume_group_vms_v2_test.go` (new) — acceptance tests (list-with-attachment + invalid-VG negative test)
- `examples/volume_group_vms_v2/` (new) — `main.tf`, `variables.tf`, `terraform.tfvars`
- `website/docs/d/`
  - `volume_group_vms_v2.html.markdown` (new) — datasource documentation
- Registration
  - `nutanix/provider/provider.go` — registered `nutanix_volume_group_vms_v2` in `DataSourcesMap`

The SDK client (`nutanix/sdks/v4/volumes/volumes.go`) and provider config
(`nutanix/config.go`) already expose `VolumeGroupsApi.ListVmAttachmentsByVolumeGroupId`
via the `VolumeAPI` client, so Steps 1 and 2 required no changes.

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `TF_ACC=1 go test ./nutanix/services/volumesv2 -v -run=TestAccV2NutanixVolumeGroupVmsDatasource -timeout 120m -coverprofile $ARTIFACTS/c.out -covermode=count` |
| Total testcases     | `2`                                            |
| Passed              | `0`                                            |
| Failed              | `2` (environment-blocked, see analysis)        |
| Skipped             | `0`                                            |
| Wall-clock duration | `0:00:10`                                       |
| Cluster (PC)        | `10.102.194.88`                                |

### Analysis

Both acceptance tests fail at the framework bootstrap stage — before any HCL is
applied or any cluster call is made — with:

```
cannot run Terraform provider tests: unexpected Content-Type: "application/vnd+hashicorp.releases-api.v0+json"
```

This is an **environment limitation, not a code defect**: the SDKv2 acceptance
test harness cannot reach the HashiCorp releases API from this sandbox to
download the test provider binary. The failure is reproducible with a
pre-existing, unmodified test in the same package
(`TestAccV2NutanixVolumeGroupVmResource_Basic`), confirming it is unrelated to
the generated code.

Static verification that DID pass:
- `go build ./nutanix/...` — clean
- `go vet ./nutanix/services/volumesv2/...` — clean
- `gofmt` / `goimports` — clean on all new files
- `make website-lint` (misspell) — clean

**Known issues:** Acceptance tests could not execute in this environment due to
the provider-binary download failure above. The generated datasource has been
verified via compilation, vet, and lint; the test file is well-formed and ready
to run in a CI environment with network access to the releases API.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
2026/07/16 07:20:46 Do some crazy stuff before tests!
=== RUN   TestAccV2NutanixVolumeGroupVmsDatasource_WithAttachment
cannot run Terraform provider tests: unexpected Content-Type: "application/vnd+hashicorp.releases-api.v0+json"
FAIL	github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/volumesv2	0.485s
FAIL
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` are stored only in the agent transcript;
  no `sdk_info.json` is committed to this branch.
