### PR TITLE
code-gen(volumes/GetVolumeDiskStats): terraform v2 provider code

### DIFF
--- a/examples/volume_disk_stats_v2/main.tf
+++ b/examples/volume_disk_stats_v2/main.tf
@@ -1,0 +1,44 @@
+#############################################################################
+# Example main.tf for Nutanix + Terraform
+#
+# This script is a quick demo of how to use the following provider objects:
+# - providers
+#     - terraform-provider-nutanix
+# - data sources
+#     - nutanix_volume_disk_stats_v2
+#
+# Feel free to reuse, comment, and contribute, so that others may learn.
+#############################################################################
+
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = "2.0.0"
+    }
+  }
+}
+
+#defining nutanix configuration
+provider "nutanix" {
+  username = var.nutanix_username
+  password = var.nutanix_password
+  endpoint = var.nutanix_endpoint
+  port     = 9440
+  insecure = true
+}
+
+##########################
+### Data Sources
+##########################
+
+# Query the Volume Disk stats identified by {diskExtId} in the Volume Group
+# identified by {volumeGroupExtId} over the [start_time, end_time] window.
+data "nutanix_volume_disk_stats_v2" "example" {
+  volume_group_ext_id = var.volume_group_ext_id
+  ext_id              = var.volume_disk_ext_id
+  start_time          = var.start_time
+  end_time            = var.end_time
+  sampling_interval   = var.sampling_interval
+  stat_type           = var.stat_type
+}

--- a/examples/volume_disk_stats_v2/terraform.tfvars
+++ b/examples/volume_disk_stats_v2/terraform.tfvars
@@ -1,0 +1,11 @@
+#define values to the variables to be used in terraform file
+nutanix_username = "admin"
+nutanix_password = "password"
+nutanix_endpoint = "10.xx.xx.xx"
+
+volume_group_ext_id = "00000000-0000-0000-0000-000000000000"
+volume_disk_ext_id  = "00000000-0000-0000-0000-000000000000"
+start_time          = "2024-01-01T00:00:00Z"
+end_time            = "2024-01-01T01:00:00Z"
+sampling_interval   = 30
+stat_type           = "AVG"

--- a/examples/volume_disk_stats_v2/variables.tf
+++ b/examples/volume_disk_stats_v2/variables.tf
@@ -1,0 +1,49 @@
+#define the type of variables to be used in terraform file
+
+variable "nutanix_username" {
+  description = "Prism Central username."
+  type        = string
+}
+
+variable "nutanix_password" {
+  description = "Prism Central password."
+  type        = string
+  sensitive   = true
+}
+
+variable "nutanix_endpoint" {
+  description = "Prism Central endpoint (IP or FQDN)."
+  type        = string
+}
+
+variable "volume_group_ext_id" {
+  description = "The external identifier of the Volume Group that owns the disk."
+  type        = string
+}
+
+variable "volume_disk_ext_id" {
+  description = "The external identifier of the Volume Disk whose stats are queried."
+  type        = string
+}
+
+variable "start_time" {
+  description = "The start time (RFC-3339) from which the stats should be reported."
+  type        = string
+}
+
+variable "end_time" {
+  description = "The end time (RFC-3339) until which the stats should be reported."
+  type        = string
+}
+
+variable "sampling_interval" {
+  description = "The sampling interval in seconds at which the stats should be reported."
+  type        = number
+  default     = 30
+}
+
+variable "stat_type" {
+  description = "The down-sampling operator. One of SUM, MIN, MAX, AVG, COUNT, LAST."
+  type        = string
+  default     = "AVG"
+}

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -324,6 +324,7 @@ func Provider() *schema.Provider {
 			"nutanix_volume_group_v2":                         volumesv2.DatasourceNutanixVolumeGroupV2(),
 			"nutanix_volume_group_disks_v2":                   volumesv2.DatasourceNutanixVolumeDisksV2(),
 			"nutanix_volume_group_disk_v2":                    volumesv2.DatasourceNutanixVolumeDiskV2(),
+			"nutanix_volume_disk_stats_v2":                    volumesv2.DatasourceNutanixVolumeDiskStatsV2(),
 			"nutanix_volume_iscsi_clients_v2":                 volumesv2.DatasourceNutanixVolumeIscsiClientsV2(),
 			"nutanix_volume_iscsi_client_v2":                  volumesv2.DatasourceNutanixVolumeIscsiClientV2(),
 			"nutanix_recovery_point_v2":                       dataprotectionv2.DatasourceNutanixRecoveryPointV2(),

--- a/nutanix/services/volumesv2/data_source_nutanix_volume_disk_stats_v2.go
+++ b/nutanix/services/volumesv2/data_source_nutanix_volume_disk_stats_v2.go
@@ -1,0 +1,248 @@
+package volumesv2
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	volumesCommonStats "github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4/models/common/v1/stats"
+	volumesStats "github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4/models/volumes/v4/stats"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+// DatasourceNutanixVolumeDiskStatsV2 queries the Volume Disk stats identified by {extId}
+// in the Volume Group identified by {volumeGroupExtId}.
+func DatasourceNutanixVolumeDiskStatsV2() *schema.Resource {
+	return &schema.Resource{
+		Description: "Query the Volume Disk stats identified by {diskExtId}.",
+		ReadContext: DatasourceNutanixVolumeDiskStatsV2Read,
+		Schema: map[string]*schema.Schema{
+			"volume_group_ext_id": {
+				Description: "The external identifier of a Volume Group.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"ext_id": {
+				Description: "The external identifier of a Volume Disk.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"start_time": {
+				Description: "The start time in RFC-3339 format from which the stats should be reported.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"end_time": {
+				Description: "The end time in RFC-3339 format until which the stats should be reported.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"sampling_interval": {
+				Description: "The sampling interval in seconds at which the stats should be reported.",
+				Type:        schema.TypeInt,
+				Optional:    true,
+			},
+			"stat_type": {
+				Description:  "The operator to use while performing down-sampling on stats data. Allowed values are SUM, MIN, MAX, AVG, COUNT and LAST.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"SUM", "MIN", "MAX", "AVG", "COUNT", "LAST"}, false),
+			},
+			"select": {
+				Description: "A URL query parameter that allows clients to request a specific set of properties for each entity or complex type.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"tenant_id": {
+				Description: "A globally unique identifier that represents the tenant that owns this entity. The system automatically assigns it, and it and is immutable from an API consumer perspective (some use cases may cause this ID to change - For instance, a use case may require the transfer of ownership of the entity, but these cases are handled automatically on the server).",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"links": {
+				Description: "A HATEOAS style link for the response. Each link contains a user-friendly name identifying the link and an address for retrieving the particular resource.",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"href": {
+							Description: "The URL at which the entity described by the link can be accessed.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"rel": {
+							Description: "A name that identifies the relationship of the link to the object that is returned by the URL. The unique value of \"self\" identifies the URL for the object.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+					},
+				},
+			},
+			"volume_disk_ext_id": {
+				Description: "Uuid of the Volume Disk.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"controller_avg_io_latency_usecs":       schemaForVolumeDiskStatsTimeValuePair("Controller average I/O latency measured in microseconds."),
+			"controller_avg_read_io_latency_usecs":  schemaForVolumeDiskStatsTimeValuePair("Controller average read I/O latency measured in microseconds."),
+			"controller_avg_write_io_latency_usecs": schemaForVolumeDiskStatsTimeValuePair("Controller average write I/O latency measured in microseconds."),
+			"controller_io_bandwidth_kbps":          schemaForVolumeDiskStatsTimeValuePair("Controller I/O bandwidth measured in Kbps."),
+			"controller_num_iops":                   schemaForVolumeDiskStatsTimeValuePair("Controller I/O rate measured in iops."),
+			"controller_num_read_iops":              schemaForVolumeDiskStatsTimeValuePair("Controller read I/O measured in iops."),
+			"controller_num_write_iops":             schemaForVolumeDiskStatsTimeValuePair("Controller write I/O measured in iops."),
+			"controller_read_io_bandwidth_kbps":     schemaForVolumeDiskStatsTimeValuePair("Controller read I/O bandwidth measured in Kbps."),
+			"controller_user_bytes":                 schemaForVolumeDiskStatsTimeValuePair("Controller user bytes."),
+			"controller_write_io_bandwidth_kbps":    schemaForVolumeDiskStatsTimeValuePair("Controller write I/O bandwidth measured in Kbps."),
+		},
+	}
+}
+
+// schemaForVolumeDiskStatsTimeValuePair returns the shared schema for a list of
+// timestamp/value stat pairs used across all Volume Disk stat attributes.
+func schemaForVolumeDiskStatsTimeValuePair(description string) *schema.Schema {
+	return &schema.Schema{
+		Description: description,
+		Type:        schema.TypeList,
+		Computed:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"timestamp": {
+					Description: "Timestamp is returned in Epoch format.",
+					Type:        schema.TypeString,
+					Computed:    true,
+				},
+				"value": {
+					Description: "Value of the stat at the corresponding timestamp value represented in Int64 format.",
+					Type:        schema.TypeInt,
+					Computed:    true,
+				},
+			},
+		},
+	}
+}
+
+func DatasourceNutanixVolumeDiskStatsV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).VolumeAPI
+
+	volumeGroupExtID := d.Get("volume_group_ext_id").(string)
+	volumeDiskExtID := d.Get("ext_id").(string)
+
+	startTimeVal, err := time.Parse(time.RFC3339, d.Get("start_time").(string))
+	if err != nil {
+		return diag.Errorf("error while parsing start_time : %v", err)
+	}
+	endTimeVal, err := time.Parse(time.RFC3339, d.Get("end_time").(string))
+	if err != nil {
+		return diag.Errorf("error while parsing end_time : %v", err)
+	}
+
+	var samplingInterval *int
+	if si, ok := d.GetOk("sampling_interval"); ok {
+		if si.(int) <= 0 {
+			return diag.Errorf("sampling_interval should be greater than 0")
+		}
+		samplingInterval = utils.IntPtr(si.(int))
+	}
+
+	// Default value is LAST, aggregation containing only the last recorded value.
+	statType := volumesCommonStats.DOWNSAMPLINGOPERATOR_LAST
+	statTypeMap := map[string]volumesCommonStats.DownSamplingOperator{
+		"SUM":   volumesCommonStats.DOWNSAMPLINGOPERATOR_SUM,
+		"MIN":   volumesCommonStats.DOWNSAMPLINGOPERATOR_MIN,
+		"MAX":   volumesCommonStats.DOWNSAMPLINGOPERATOR_MAX,
+		"AVG":   volumesCommonStats.DOWNSAMPLINGOPERATOR_AVG,
+		"COUNT": volumesCommonStats.DOWNSAMPLINGOPERATOR_COUNT,
+		"LAST":  volumesCommonStats.DOWNSAMPLINGOPERATOR_LAST,
+	}
+	if st, ok := d.GetOk("stat_type"); ok {
+		statType = statTypeMap[st.(string)]
+	}
+
+	var selectQuery *string
+	if sel, ok := d.GetOk("select"); ok {
+		selectQuery = utils.StringPtr(sel.(string))
+	}
+
+	resp, err := conn.VolumeAPIInstance.GetVolumeDiskStats(
+		utils.StringPtr(volumeGroupExtID),
+		utils.StringPtr(volumeDiskExtID),
+		&startTimeVal,
+		&endTimeVal,
+		samplingInterval,
+		&statType,
+		selectQuery,
+	)
+	if err != nil {
+		return diag.Errorf("error while fetching Volume Disk stats : %v", err)
+	}
+
+	getResp := resp.Data.GetValue().(volumesStats.VolumeDiskStats)
+
+	if err := d.Set("tenant_id", getResp.TenantId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("ext_id", getResp.ExtId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("links", flattenLinks(getResp.Links)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("volume_disk_ext_id", getResp.VolumeDiskExtId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("controller_avg_io_latency_usecs", flattenVolumeStatsTimeValuePair(getResp.ControllerAvgIOLatencyUsecs)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("controller_avg_read_io_latency_usecs", flattenVolumeStatsTimeValuePair(getResp.ControllerAvgReadIOLatencyUsecs)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("controller_avg_write_io_latency_usecs", flattenVolumeStatsTimeValuePair(getResp.ControllerAvgWriteIOLatencyUsecs)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("controller_io_bandwidth_kbps", flattenVolumeStatsTimeValuePair(getResp.ControllerIOBandwidthKBps)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("controller_num_iops", flattenVolumeStatsTimeValuePair(getResp.ControllerNumIOPS)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("controller_num_read_iops", flattenVolumeStatsTimeValuePair(getResp.ControllerNumReadIOPS)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("controller_num_write_iops", flattenVolumeStatsTimeValuePair(getResp.ControllerNumWriteIOPS)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("controller_read_io_bandwidth_kbps", flattenVolumeStatsTimeValuePair(getResp.ControllerReadIOBandwidthKBps)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("controller_user_bytes", flattenVolumeStatsTimeValuePair(getResp.ControllerUserBytes)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("controller_write_io_bandwidth_kbps", flattenVolumeStatsTimeValuePair(getResp.ControllerWriteIOBandwidthKBps)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(utils.StringValue(getResp.ExtId))
+	return nil
+}
+
+// flattenVolumeStatsTimeValuePair converts a slice of Volume stats TimeValuePair
+// into the Terraform state representation.
+func flattenVolumeStatsTimeValuePair(timeValuePairs []volumesStats.TimeValuePair) []map[string]interface{} {
+	if len(timeValuePairs) == 0 {
+		return nil
+	}
+	timeValueList := make([]map[string]interface{}, len(timeValuePairs))
+	for k, v := range timeValuePairs {
+		pair := map[string]interface{}{}
+		if v.Timestamp != nil {
+			pair["timestamp"] = v.Timestamp.Format(time.RFC3339)
+		}
+		if v.Value != nil {
+			pair["value"] = int(utils.Int64Value(v.Value))
+		}
+		timeValueList[k] = pair
+	}
+	return timeValueList
+}

--- a/nutanix/services/volumesv2/data_source_nutanix_volume_disk_stats_v2_test.go
+++ b/nutanix/services/volumesv2/data_source_nutanix_volume_disk_stats_v2_test.go
@@ -1,0 +1,223 @@
+package volumesv2_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+// Test Plan — nutanix_volume_disk_stats_v2 (GetVolumeDiskStats)
+//
+// The GetVolumeDiskStats API queries time-series performance stats for a single
+// Volume Disk (identified by {extId}) that belongs to a Volume Group (identified
+// by {volumeGroupExtId}) over a [start_time, end_time] window. It is a read-only
+// datasource — there is no resource, so no CheckDestroy of a stats entity is
+// needed (Import not supported for this datasource).
+//
+// All prerequisites (Volume Group + Volume Disk) are created via resource blocks
+// so the test is self-contained and reproducible. Scenarios covered:
+//
+//  1. Basic: create a VG + disk, then query the disk stats with the required
+//     start_time/end_time window. Assert that the datasource resolves the disk
+//     identity (ext_id matches the created disk, volume_disk_ext_id is set) and
+//     the stats collections are present in state.
+//  2. WithStatType: same as basic but exercise the stat_type down-sampling
+//     operator (AVG) and an explicit sampling_interval to verify the query
+//     parameters are wired through to the API.
+//  3. InvalidStatType (negative): supply an invalid stat_type enum value and
+//     verify the ValidateFunc rejects it before any API call.
+//  4. InvalidStartTime (negative): supply a non-RFC3339 start_time and verify
+//     the datasource returns a descriptive parse error.
+//  5. InvalidExtId (negative): supply a random (non-existent) disk ext_id and
+//     verify the API returns an error.
+
+const datasourceVolumeDiskStats = "data.nutanix_volume_disk_stats_v2.test"
+
+func TestAccV2NutanixVolumeDiskStatsDataSource_Basic(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("terraform-test-volume-disk-stats-%d", r)
+	desc := "terraform test volume disk stats description"
+
+	startTime := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	endTime := time.Now().UTC().Format(time.RFC3339)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVolumeDiskStatsDataSourceConfig(name, desc, int(diskSizeBytes), startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceVolumeDiskStats, "ext_id",
+						"nutanix_volume_group_disk_v2.test", "id"),
+					resource.TestCheckResourceAttrSet(datasourceVolumeDiskStats, "volume_disk_ext_id"),
+					resource.TestCheckResourceAttr(datasourceVolumeDiskStats, "start_time", startTime),
+					resource.TestCheckResourceAttr(datasourceVolumeDiskStats, "end_time", endTime),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixVolumeDiskStatsDataSource_WithStatType(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("terraform-test-volume-disk-stats-%d", r)
+	desc := "terraform test volume disk stats description"
+
+	startTime := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	endTime := time.Now().UTC().Format(time.RFC3339)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVolumeDiskStatsDataSourceConfigWithStatType(name, desc, int(diskSizeBytes), startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceVolumeDiskStats, "ext_id",
+						"nutanix_volume_group_disk_v2.test", "id"),
+					resource.TestCheckResourceAttrSet(datasourceVolumeDiskStats, "volume_disk_ext_id"),
+					resource.TestCheckResourceAttr(datasourceVolumeDiskStats, "stat_type", "AVG"),
+					resource.TestCheckResourceAttr(datasourceVolumeDiskStats, "sampling_interval", "30"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixVolumeDiskStatsDataSource_InvalidStatType(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("terraform-test-volume-disk-stats-%d", r)
+	desc := "terraform test volume disk stats description"
+
+	startTime := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	endTime := time.Now().UTC().Format(time.RFC3339)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccVolumeDiskStatsDataSourceConfigInvalidStatType(name, desc, int(diskSizeBytes), startTime, endTime),
+				ExpectError: regexp.MustCompile(`expected stat_type to be one of`),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixVolumeDiskStatsDataSource_InvalidStartTime(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("terraform-test-volume-disk-stats-%d", r)
+	desc := "terraform test volume disk stats description"
+
+	endTime := time.Now().UTC().Format(time.RFC3339)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccVolumeDiskStatsDataSourceConfigInvalidStartTime(name, desc, int(diskSizeBytes), endTime),
+				ExpectError: regexp.MustCompile(`error while parsing start_time`),
+			},
+		},
+	})
+}
+
+func TestAccV2NutanixVolumeDiskStatsDataSource_InvalidExtId(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("terraform-test-volume-disk-stats-%d", r)
+	desc := "terraform test volume disk stats description"
+
+	startTime := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	endTime := time.Now().UTC().Format(time.RFC3339)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccVolumeDiskStatsDataSourceConfigInvalidExtID(name, desc, int(diskSizeBytes), startTime, endTime),
+				ExpectError: regexp.MustCompile(`error while fetching Volume Disk stats`),
+			},
+		},
+	})
+}
+
+func testAccVolumeDiskStatsDataSourceConfig(name, desc string, diskSizeBytes int, startTime, endTime string) string {
+	return testAccVolumeGroupResourceConfig(name, desc) +
+		testAccVolumeGroupDiskResourceConfig(name, desc, diskSizeBytes) +
+		fmt.Sprintf(`
+		data "nutanix_volume_disk_stats_v2" "test" {
+			volume_group_ext_id = nutanix_volume_group_v2.test.id
+			ext_id              = nutanix_volume_group_disk_v2.test.id
+			start_time          = "%[1]s"
+			end_time            = "%[2]s"
+			depends_on          = [nutanix_volume_group_disk_v2.test]
+		}
+	`, startTime, endTime)
+}
+
+func testAccVolumeDiskStatsDataSourceConfigWithStatType(name, desc string, diskSizeBytes int, startTime, endTime string) string {
+	return testAccVolumeGroupResourceConfig(name, desc) +
+		testAccVolumeGroupDiskResourceConfig(name, desc, diskSizeBytes) +
+		fmt.Sprintf(`
+		data "nutanix_volume_disk_stats_v2" "test" {
+			volume_group_ext_id = nutanix_volume_group_v2.test.id
+			ext_id              = nutanix_volume_group_disk_v2.test.id
+			start_time          = "%[1]s"
+			end_time            = "%[2]s"
+			sampling_interval   = 30
+			stat_type           = "AVG"
+			depends_on          = [nutanix_volume_group_disk_v2.test]
+		}
+	`, startTime, endTime)
+}
+
+func testAccVolumeDiskStatsDataSourceConfigInvalidStatType(name, desc string, diskSizeBytes int, startTime, endTime string) string {
+	return testAccVolumeGroupResourceConfig(name, desc) +
+		testAccVolumeGroupDiskResourceConfig(name, desc, diskSizeBytes) +
+		fmt.Sprintf(`
+		data "nutanix_volume_disk_stats_v2" "test" {
+			volume_group_ext_id = nutanix_volume_group_v2.test.id
+			ext_id              = nutanix_volume_group_disk_v2.test.id
+			start_time          = "%[1]s"
+			end_time            = "%[2]s"
+			stat_type           = "INVALID"
+			depends_on          = [nutanix_volume_group_disk_v2.test]
+		}
+	`, startTime, endTime)
+}
+
+func testAccVolumeDiskStatsDataSourceConfigInvalidStartTime(name, desc string, diskSizeBytes int, endTime string) string {
+	return testAccVolumeGroupResourceConfig(name, desc) +
+		testAccVolumeGroupDiskResourceConfig(name, desc, diskSizeBytes) +
+		fmt.Sprintf(`
+		data "nutanix_volume_disk_stats_v2" "test" {
+			volume_group_ext_id = nutanix_volume_group_v2.test.id
+			ext_id              = nutanix_volume_group_disk_v2.test.id
+			start_time          = "not-a-valid-timestamp"
+			end_time            = "%[1]s"
+			depends_on          = [nutanix_volume_group_disk_v2.test]
+		}
+	`, endTime)
+}
+
+func testAccVolumeDiskStatsDataSourceConfigInvalidExtID(name, desc string, diskSizeBytes int, startTime, endTime string) string {
+	return testAccVolumeGroupResourceConfig(name, desc) +
+		testAccVolumeGroupDiskResourceConfig(name, desc, diskSizeBytes) +
+		fmt.Sprintf(`
+		data "nutanix_volume_disk_stats_v2" "test" {
+			volume_group_ext_id = nutanix_volume_group_v2.test.id
+			ext_id              = "00000000-0000-0000-0000-000000000000"
+			start_time          = "%[1]s"
+			end_time            = "%[2]s"
+			depends_on          = [nutanix_volume_group_disk_v2.test]
+		}
+	`, startTime, endTime)
+}

--- a/website/docs/d/volume_disk_stats_v2.html.markdown
+++ b/website/docs/d/volume_disk_stats_v2.html.markdown
@@ -1,0 +1,72 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_volume_disk_stats_v2"
+sidebar_current: "docs-nutanix-datasource-volume-disk-stats-v2"
+description: |-
+  Query the Volume Disk stats identified by {diskExtId}.
+---
+
+# nutanix_volume_disk_stats_v2
+
+Query the Volume Disk stats identified by {diskExtId}.
+
+## Example Usage
+
+```hcl
+# Query the stats of a Volume Disk over a time window.
+data "nutanix_volume_disk_stats_v2" "example" {
+  volume_group_ext_id = "3770be9d-06be-4e25-b85d-3457d9b0ceb1"
+  ext_id              = "1d92110d-26b5-46c0-8c93-20b8171373e0"
+  start_time          = "2024-01-01T00:00:00Z"
+  end_time            = "2024-01-01T01:00:00Z"
+  sampling_interval   = 30
+  stat_type           = "AVG"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `volume_group_ext_id`: -(Required) The external identifier of a Volume Group.
+* `ext_id`: -(Required) The external identifier of a Volume Disk.
+* `start_time`: -(Required) The start time in RFC-3339 format from which the stats should be reported.
+* `end_time`: -(Required) The end time in RFC-3339 format until which the stats should be reported.
+* `sampling_interval`: -(Optional) The sampling interval in seconds at which the stats should be reported.
+* `stat_type`: -(Optional) The operator to use while performing down-sampling on stats data. Allowed values are `SUM`, `MIN`, `MAX`, `AVG`, `COUNT` and `LAST`.
+* `select`: -(Optional) A URL query parameter that allows clients to request a specific set of properties for each entity or complex type.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `tenant_id`: - A globally unique identifier that represents the tenant that owns this entity. The system automatically assigns it, and it and is immutable from an API consumer perspective (some use cases may cause this ID to change - For instance, a use case may require the transfer of ownership of the entity, but these cases are handled automatically on the server).
+* `ext_id`: - A globally unique identifier of an instance that is suitable for external consumption.
+* `links`: - A HATEOAS style link for the response. Each link contains a user-friendly name identifying the link and an address for retrieving the particular resource.
+* `volume_disk_ext_id`: - Uuid of the Volume Disk.
+* `controller_avg_io_latency_usecs`: - Controller average I/O latency measured in microseconds.
+* `controller_avg_read_io_latency_usecs`: - Controller average read I/O latency measured in microseconds.
+* `controller_avg_write_io_latency_usecs`: - Controller average write I/O latency measured in microseconds.
+* `controller_io_bandwidth_kbps`: - Controller I/O bandwidth measured in Kbps.
+* `controller_num_iops`: - Controller I/O rate measured in iops.
+* `controller_num_read_iops`: - Controller read I/O measured in iops.
+* `controller_num_write_iops`: - Controller write I/O measured in iops.
+* `controller_read_io_bandwidth_kbps`: - Controller read I/O bandwidth measured in Kbps.
+* `controller_user_bytes`: - Controller user bytes.
+* `controller_write_io_bandwidth_kbps`: - Controller write I/O bandwidth measured in Kbps.
+
+### Links
+
+The links attribute supports the following:
+
+* `href`: - The URL at which the entity described by the link can be accessed.
+* `rel`: - A name that identifies the relationship of the link to the object that is returned by the URL. The unique value of "self" identifies the URL for the object.
+
+### Stat Time Value Pairs
+
+Each of the `controller_*` attributes is a list where each element supports the following:
+
+* `timestamp`: - Timestamp is returned in Epoch format.
+* `value`: - Value of the stat at the corresponding timestamp value represented in Int64 format.
+
+See detailed information in [Nutanix Get Volume Disk Stats V4](https://developers.nutanix.com/api-reference?namespace=volumes&version=v4.2#tag/VolumeGroups/operation/getVolumeDiskStats).


### PR DESCRIPTION
## Summary

Auto-generated Terraform provider code for the **volumes** namespace, entity
**GetVolumeDiskStats**, based on the inline `sdk_info.json` (see prompt). One PR per code-gen run.

- SDK module: `github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4@v4.2.2`  (read from `go.mod`)
- API methods covered: `1` (GetVolumeDiskStats)
- Datasources generated: `1` — `nutanix_volume_disk_stats_v2`
- Resources generated:   `0` (N/A — the SDK method is a read-only stats query)

## Files changed

- `nutanix/services/volumesv2/`
  - `data_source_nutanix_volume_disk_stats_v2.go` — new singular stats datasource (schema + read + flatten helpers)
  - `data_source_nutanix_volume_disk_stats_v2_test.go` — acceptance tests (basic, stat_type, negative cases)
- `examples/volume_disk_stats_v2/`
  - `main.tf`, `variables.tf`, `terraform.tfvars`
- `website/docs/d/`
  - `volume_disk_stats_v2.html.markdown` — datasource documentation
- `nutanix/provider/provider.go` — registered `nutanix_volume_disk_stats_v2` in DataSourcesMap

Note: `nutanix/sdks/v4/volumes/volumes.go` and `nutanix/config.go` already expose the
`VolumeGroupsApi` instance (`VolumeAPI.VolumeAPIInstance`) on which `GetVolumeDiskStats`
is defined, so no SDK-client or config changes were required.

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `TF_ACC=1 go test ./nutanix/services/volumesv2 -v -run=TestAccV2NutanixVolumeDiskStatsDataSource -timeout 120m -coverprofile c.out -covermode=count` |
| Total testcases     | `5`                                          |
| Passed              | `0`                                          |
| Failed              | `1` (harness bootstrap — see analysis)       |
| Skipped             | `0`                                          |
| Wall-clock duration | `0:00:04`                                    |
| Cluster (PC)        | `10.102.194.88`                              |

### Analysis

The acceptance tests could not execute in the code-gen sandbox. The Terraform SDK
test harness (`hashicorp/hc-install`) attempts to download a Terraform CLI binary at
runtime and the sandbox network intercepts the HashiCorp releases API, returning:

```
cannot run Terraform provider tests: unexpected Content-Type: "application/vnd+hashicorp.releases-api.v0+json"
```

No Terraform binary is present on the runner and it cannot be fetched, so this failure
occurs before any provider/API logic runs. It affects **every** acceptance test in this
repository, not this datasource specifically. Retrying is deterministic (same network
result), so retries were not repeated.

Static verification that DID pass locally:
- `go build ./nutanix/services/volumesv2/... ./nutanix/provider/...` — success
- `go vet ./nutanix/services/volumesv2/...` — success
- `gofmt` / `goimports` — clean
- `make website-lint` (misspell) — clean

**Known issue:** acceptance tests unverified against a live cluster in this environment
due to the missing Terraform CLI / restricted egress. The tests are ready to run in a CI
environment with Terraform available.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
2026/07/16 08:46:24 Do some crazy stuff before tests!
=== RUN   TestAccV2NutanixVolumeDiskStatsDataSource_Basic
cannot run Terraform provider tests: unexpected Content-Type: "application/vnd+hashicorp.releases-api.v0+json"
FAIL	github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/volumesv2	0.424s
FAIL
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` are stored only in the agent transcript;
  no `sdk_info.json` is committed to this branch.
