### PR TITLE
code-gen(iam/GetWelcomeBanner): terraform v2 provider code

### DIFF
--- a/examples/welcome_banner_v2/main.tf
+++ b/examples/welcome_banner_v2/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    nutanix = {
+      source  = "nutanix/nutanix"
+      version = "2.0.0"
+    }
+  }
+}
+
+#defining nutanix configuration
+provider "nutanix" {
+  username = var.nutanix_username
+  password = var.nutanix_password
+  endpoint = var.nutanix_endpoint
+  port     = 9440
+  insecure = true
+}
+
+# Fetch the configured welcome banner (singleton datasource — no input required).
+data "nutanix_welcome_banner_v2" "welcome-banner" {}
+
+output "welcome_banner" {
+  value = data.nutanix_welcome_banner_v2.welcome-banner
+}

--- a/examples/welcome_banner_v2/terraform.tfvars
+++ b/examples/welcome_banner_v2/terraform.tfvars
@@ -1,0 +1,4 @@
+#define values to the variables to be used in terraform file
+nutanix_username = "admin"
+nutanix_password = "password"
+nutanix_endpoint = "10.xx.xx.xx"

--- a/examples/welcome_banner_v2/variables.tf
+++ b/examples/welcome_banner_v2/variables.tf
@@ -1,0 +1,16 @@
+#define the type of variables to be used in terraform file
+variable "nutanix_username" {
+  description = "Username for the Nutanix Prism Central account."
+  type        = string
+}
+
+variable "nutanix_password" {
+  description = "Password for the Nutanix Prism Central account."
+  type        = string
+  sensitive   = true
+}
+
+variable "nutanix_endpoint" {
+  description = "Prism Central endpoint (IP or FQDN)."
+  type        = string
+}

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -307,6 +307,7 @@ func Provider() *schema.Provider {
 			"nutanix_authorization_policies_v2":               iamv2.DatasourceNutanixAuthorizationPoliciesV2(),
 			"nutanix_user_keys_v2":                            iamv2.DatasourceNutanixUserKeysV2(),
 			"nutanix_user_key_v2":                             iamv2.DatasourceNutanixUserKeyV2(),
+			"nutanix_welcome_banner_v2":                       iamv2.DatasourceNutanixWelcomeBannerV2(),
 			"nutanix_storage_container_v2":                    storagecontainersv2.DatasourceNutanixStorageContainerV2(),
 			"nutanix_storage_containers_v2":                   storagecontainersv2.DatasourceNutanixStorageContainersV2(),
 			"nutanix_storage_container_stats_info_v2":         storagecontainersv2.DatasourceNutanixStorageStatsInfoV2(),

--- a/nutanix/sdks/v4/iam/iam.go
+++ b/nutanix/sdks/v4/iam/iam.go
@@ -17,6 +17,7 @@ type Client struct {
 	OperationsAPIInstance       *api.OperationsApi
 	AuthAPIInstance             *api.AuthorizationPoliciesApi
 	EntityAPIInstance           *api.EntitiesApi
+	WelcomeBannerAPIInstance    *api.WelcomeBannerApi
 }
 
 func NewIamClient(credentials client.Credentials) (*Client, error) {
@@ -42,6 +43,7 @@ func NewIamClient(credentials client.Credentials) (*Client, error) {
 		UsersAPIInstance:            api.NewUsersApi(baseClient),
 		AuthAPIInstance:             api.NewAuthorizationPoliciesApi(baseClient),
 		EntityAPIInstance:           api.NewEntitiesApi(baseClient),
+		WelcomeBannerAPIInstance:    api.NewWelcomeBannerApi(baseClient),
 		APIClientInstance:           baseClient,
 	}
 

--- a/nutanix/services/iamv2/data_source_nutanix_welcome_banner_v2.go
+++ b/nutanix/services/iamv2/data_source_nutanix_welcome_banner_v2.go
@@ -1,0 +1,79 @@
+package iamv2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	iamAuthn "github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4/models/iam/v4/authn"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+)
+
+// DatasourceNutanixWelcomeBannerV2 fetches the configured welcome banner.
+func DatasourceNutanixWelcomeBannerV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: DatasourceNutanixWelcomeBannerV2Read,
+		Schema: map[string]*schema.Schema{
+			"content": {
+				Description: "Content of the welcome banner.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"created_time": {
+				Description: "Creation time of the welcome banner.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"is_enabled": {
+				Description: "Flag to denote whether the welcome banner is enabled or not.",
+				Type:        schema.TypeBool,
+				Computed:    true,
+			},
+			"last_updated_time": {
+				Description: "Last updated time of the welcome banner.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func DatasourceNutanixWelcomeBannerV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).IamAPI
+
+	resp, err := conn.WelcomeBannerAPIInstance.GetWelcomeBanner()
+	if err != nil {
+		return diag.Errorf("error while fetching welcome banner: %v", err)
+	}
+
+	if resp == nil || resp.GetData() == nil {
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "No data found.",
+			Detail:   "The API returned an empty welcome banner.",
+		}}
+	}
+
+	getResp := resp.GetData().(iamAuthn.WelcomeBanner)
+
+	if err := d.Set("content", getResp.Content); err != nil {
+		return diag.FromErr(err)
+	}
+	if getResp.CreatedTime != nil {
+		if err := d.Set("created_time", getResp.CreatedTime.String()); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err := d.Set("is_enabled", getResp.IsEnabled); err != nil {
+		return diag.FromErr(err)
+	}
+	if getResp.LastUpdatedTime != nil {
+		if err := d.Set("last_updated_time", getResp.LastUpdatedTime.String()); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	d.SetId(resource.UniqueId())
+	return nil
+}

--- a/nutanix/services/iamv2/data_source_nutanix_welcome_banner_v2_test.go
+++ b/nutanix/services/iamv2/data_source_nutanix_welcome_banner_v2_test.go
@@ -1,0 +1,47 @@
+package iamv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+// Test plan for nutanix_welcome_banner_v2 (singleton datasource):
+//
+// GetWelcomeBanner fetches the cluster-wide configured welcome banner. It is a
+// read-only singleton config endpoint (no ext_id input, no Create/Update/Delete
+// resource in this code-gen scope). Coverage:
+//
+//  1. Basic read: query the singleton datasource with no arguments and verify
+//     the datasource is populated (id + is_enabled are always present in state).
+//     content / created_time / last_updated_time are optional on the wire (only
+//     returned once a banner is configured), so they are asserted with
+//     TestCheckResourceAttrSet only when the banner is enabled — here we assert
+//     the always-present attributes so the test is stable across clusters.
+//  2. No-argument config: verify the singleton datasource accepts zero inputs
+//     (no ext_id) and still resolves — this validates the singleton wiring.
+
+const datasourceNameWelcomeBanner = "data.nutanix_welcome_banner_v2.test"
+
+func TestAccV2NutanixWelcomeBannerDatasource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testWelcomeBannerDatasourceV2Config(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceNameWelcomeBanner, "id"),
+					resource.TestCheckResourceAttrSet(datasourceNameWelcomeBanner, "is_enabled"),
+				),
+			},
+		},
+	})
+}
+
+func testWelcomeBannerDatasourceV2Config() string {
+	return `
+		data "nutanix_welcome_banner_v2" "test" {}
+	`
+}

--- a/website/docs/d/welcome_banner_v2.html.markdown
+++ b/website/docs/d/welcome_banner_v2.html.markdown
@@ -1,0 +1,32 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_welcome_banner_v2"
+sidebar_current: "docs-nutanix-datasource-welcome-banner-v2"
+description: |-
+  Fetches the configured welcome banner.
+---
+
+# nutanix_welcome_banner_v2
+
+Fetches the configured welcome banner.
+
+## Example Usage
+
+```hcl
+data "nutanix_welcome_banner_v2" "welcome-banner" {}
+```
+
+## Argument Reference
+
+This is a singleton data source and does not take any arguments.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `content`: - Content of the welcome banner.
+- `created_time`: - Creation time of the welcome banner.
+- `is_enabled`: - Flag to denote whether the welcome banner is enabled or not.
+- `last_updated_time`: - Last updated time of the welcome banner.
+
+See detailed information in [Nutanix Get Welcome Banner v4](https://developers.nutanix.com/api-reference?namespace=iam&version=v4.1#tag/WelcomeBanner/operation/getWelcomeBanner).


### PR DESCRIPTION
## Summary

Auto-generated Terraform provider code for the **iam** namespace, entity
**GetWelcomeBanner**, based on the inline `sdk_info.json` (see prompt). One PR per code-gen run.

- SDK module: `github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4@v4.1.2-beta.2` (read from `go.mod`)
- API methods covered: `1` (GetWelcomeBanner)
- Datasources generated: `1` — `nutanix_welcome_banner_v2` (singleton)
- Resources generated:   `0` (SDK exposes no Create for this entity in scope; Step 4 = N/A)

## Files changed

**nutanix/sdks/v4/iam/**
- `iam.go` — added `WelcomeBannerAPIInstance *api.WelcomeBannerApi` to the Client struct and initialized it in `NewIamClient`.

**nutanix/services/iamv2/**
- `data_source_nutanix_welcome_banner_v2.go` — singleton datasource (`GetWelcomeBanner`, no ext_id input).
- `data_source_nutanix_welcome_banner_v2_test.go` — acceptance test.

**examples/welcome_banner_v2/**
- `main.tf`, `variables.tf`, `terraform.tfvars`

**website/docs/d/**
- `welcome_banner_v2.html.markdown`

**registration**
- `nutanix/provider/provider.go` — registered `nutanix_welcome_banner_v2` in DataSourcesMap.

## Test execution

| Metric              | Value                                                                                   |
|---------------------|-----------------------------------------------------------------------------------------|
| Command             | `TF_ACC=1 go test ./nutanix/services/iamv2 -v -run=TestAccV2NutanixWelcomeBannerDatasource_Basic -timeout 60m -coverprofile c.out -covermode=count` |
| Total testcases     | `1`                                                                                     |
| Passed              | `0`                                                                                     |
| Failed              | `1` (environmental — see analysis)                                                      |
| Skipped             | `0`                                                                                     |
| Wall-clock duration | `0:00:06`                                                                               |
| Cluster (PC)        | `10.44.76.91`                                                                           |

### Analysis

- **TestAccV2NutanixWelcomeBannerDatasource_Basic** — failed during provider
  plugin bootstrap, **before any test body ran**, with:
  `cannot run Terraform provider tests: unexpected Content-Type: "application/vnd+hashicorp.releases-api.v0+json"`.
  This is the terraform-plugin-sdk acceptance harness being unable to reach the
  HashiCorp releases API from the sandbox (no outbound network to
  `releases.hashicorp.com`). It affects **all** acceptance tests in the repo,
  not just this one, and is **not** a defect in the generated code.

  Evidence the code is correct:
  - `go build ./nutanix/services/iamv2/...` — passes.
  - `go vet ./nutanix/services/iamv2/...` — passes.
  - `go test ./nutanix/services/iamv2 -run TestAccV2NutanixWelcomeBannerDatasource_Basic`
    (without `TF_ACC=1`) — **ok** (test compiles and is correctly gated).

  **Known issue:** acceptance run cannot be executed in this environment due to
  the network restriction above. The test is expected to pass on CI / a live PC
  with registry access.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
2026/07/16 09:32:37 Do some crazy stuff before tests!
=== RUN   TestAccV2NutanixWelcomeBannerDatasource_Basic
cannot run Terraform provider tests: unexpected Content-Type: "application/vnd+hashicorp.releases-api.v0+json"
FAIL	github.com/terraform-providers/terraform-provider-nutanix/nutanix/services/iamv2	0.402s
FAIL
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` are stored only in the agent transcript;
  no `sdk_info.json` is committed to this branch.
