### PR TITLE
fix(lcm): format release_date as a string in available_versions

### DIFF
--- a/nutanix/services/lcmv2/data_source_lcm_entitiy_v2.go
+++ b/nutanix/services/lcmv2/data_source_lcm_entitiy_v2.go
@@ -428,7 +428,7 @@ func flattenAvailableVersions(availableVersions []lcmEntityPkg.AvailableVersion)
 			"order":                  availableVersion.Order,
 			"disablement_reason":     availableVersion.DisablementReason,
 			"release_notes":          availableVersion.ReleaseNotes,
-			"release_date":           availableVersion.ReleaseDate,
+			"release_date":           flattenTime(availableVersion.ReleaseDate),
 			"custom_message":         availableVersion.CustomMessage,
 			"child_entities":         availableVersion.ChildEntities,
 			"group_uuid":             availableVersion.GroupUuid,


### PR DESCRIPTION
Hi :wave:,

I hit an interesting edge case when reading an LCM entity that has an available version with a release date fails with;

```
Error: entities.18.available_versions.0.release_date: '' expected type 'string', got unconvertible type 'time.Time'

  with data.nutanix_lcm_entities_v2.example,
  on main.tf line 27, in data "nutanix_lcm_entities_v2" "example":
  27: data "nutanix_lcm_entities_v2" "example" {
```

The `available_versions` schema declares `release_date` as `TypeString`, but the
flatten assigns the SDK value directly.

Looks to be that `AvailableVersion.ReleaseDate` is a `*time.Time`, so the SDK cannot convert it.

Both `nutanix_lcm_entity_v2` and `nutanix_lcm_entities_v2` are affected; they share the `flattenAvailableVersions`.

### Fix

Use `flattenTime`, which already exists in the same file and is already used for
`last_updated_time` in both data sources.

The `release_date` was the only time field I saw that missed it.

### What had to line up

Four things had to line up at once, and missing any one of them means the field
is never flattened:

1. **An inventory has run.** Before that the entity list is empty, so there is
   nothing to flatten. A freshly built cluster returns no entities at all.
2. **At least one entity has an available update.** Entities that are already at
   the latest version have an empty `available_versions`.
3. **That update carries a release date.** This is the narrow one. On the cluster
   where I hit it, 20 entities returned, 3 had available updates, and exactly 1 of
   those had a `releaseDate` populated.
4. **LCM is being driven through the Terraform data sources.** Anyone using Prism
   for LCM never obviously touches this code path.
