### PR TITLE
Add nutanix_host resource to manage host categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+**New Features:**
+- **`nutanix_host` (Prism):** New resource to manage categories on an existing Nutanix host, consistent with how categories are already handled on `nutanix_subnet` and other resource types. Hosts are discovered rather than created/destroyed by the API, so this resource adopts an existing host by `host_id` and manages its category assignment only. [#1218](https://github.com/nutanix/terraform-provider-nutanix/issues/1218)
+
 ## 2.4.2(April 15, 2026) 
 [Full Changelog](https://github.com/nutanix/terraform-provider-nutanix/compare/v2.4.0...v2.4.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 **New Features:**
-- **`nutanix_host` (Prism):** New resource to manage categories on an existing Nutanix host, consistent with how categories are already handled on `nutanix_subnet` and other resource types. Hosts are discovered rather than created/destroyed by the API, so this resource adopts an existing host by `host_id` and manages its category assignment only. [#1218](https://github.com/nutanix/terraform-provider-nutanix/issues/1218)
+- **`nutanix_host` (Prism):** New resource to manage categories on an existing Nutanix host Hosts are discovered rather than created/destroyed by the API, so this resource adopts an existing host by `host_id` and manages its category assignment only. [#1218](https://github.com/nutanix/terraform-provider-nutanix/issues/1218)
 
 ## 2.4.2(April 15, 2026) 
 [Full Changelog](https://github.com/nutanix/terraform-provider-nutanix/compare/v2.4.0...v2.4.2)

--- a/nutanix/provider/provider.go
+++ b/nutanix/provider/provider.go
@@ -375,6 +375,7 @@ func Provider() *schema.Provider {
 			"nutanix_virtual_machine":                         vmm.ResourceNutanixVirtualMachine(),
 			"nutanix_image":                                   vmm.ResourceNutanixImage(),
 			"nutanix_subnet":                                  networking.ResourceNutanixSubnet(),
+			"nutanix_host":                                    clusters.ResourceNutanixHost(),
 			"nutanix_category_key":                            prism.ResourceNutanixCategoryKey(),
 			"nutanix_category_value":                          prism.ResourceNutanixCategoryValue(),
 			"nutanix_network_security_rule":                   networking.ResourceNutanixNetworkSecurityRule(),

--- a/nutanix/sdks/v3/prism/prism_service.go
+++ b/nutanix/sdks/v3/prism/prism_service.go
@@ -65,6 +65,7 @@ type Service interface {
 	GetHost(taskUUID string) (*HostResponse, error)
 	ListHost(getEntitiesRequest *DSMetadata) (*HostListResponse, error)
 	ListAllHost() (*HostListResponse, error)
+	UpdateHost(uuid string, body *HostIntentInput) (*HostResponse, error)
 	CreateProject(request *Project) (*Project, error)
 	GetProject(projectUUID string) (*Project, error)
 	ListProject(getEntitiesRequest *DSMetadata) (*ProjectListResponse, error)
@@ -1211,6 +1212,20 @@ func (op Operations) GetHost(hostUUID string) (*HostResponse, error) {
 	}
 
 	return host, op.client.Do(ctx, req, host)
+}
+
+func (op Operations) UpdateHost(uuid string, body *HostIntentInput) (*HostResponse, error) {
+	ctx := context.TODO()
+
+	path := fmt.Sprintf("/hosts/%s", uuid)
+	req, err := op.client.NewRequest(ctx, http.MethodPut, path, body)
+	hostResponse := new(HostResponse)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return hostResponse, op.client.Do(ctx, req, hostResponse)
 }
 
 // ListHost ...

--- a/nutanix/sdks/v3/prism/prism_service_test.go
+++ b/nutanix/sdks/v3/prism/prism_service_test.go
@@ -2879,6 +2879,104 @@ func TestOperations_GetHost(t *testing.T) {
 	}
 }
 
+func TestOperations_UpdateHost(t *testing.T) {
+	mux, c, server := setup()
+
+	defer server.Close()
+
+	mux.HandleFunc("/api/nutanix/v3/hosts/cfde831a-4e87-4a75-960f-89b0148aa2cc", func(w http.ResponseWriter, r *http.Request) {
+		testHTTPMethod(t, r, http.MethodPut)
+
+		expected := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"kind": "host",
+				"categories": map[string]interface{}{
+					"Environment": "Staging",
+				},
+			},
+		}
+
+		var v map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("decode json: %v", err)
+		}
+
+		if !reflect.DeepEqual(v, expected) {
+			t.Errorf("Request body\n got=%#v\nwant=%#v", v, expected)
+		}
+
+		fmt.Fprintf(w, `{
+			"metadata": {
+				"kind": "host",
+				"uuid": "cfde831a-4e87-4a75-960f-89b0148aa2cc",
+				"categories": {
+					"Environment": "Staging"
+				}
+			}
+		}`)
+	})
+
+	type fields struct {
+		client *client.Client
+	}
+
+	type args struct {
+		UUID string
+		body *HostIntentInput
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *HostResponse
+		wantErr bool
+	}{
+		{
+			"Test UpdateHost",
+			fields{
+				c,
+			},
+			args{
+				"cfde831a-4e87-4a75-960f-89b0148aa2cc",
+				&HostIntentInput{
+					Metadata: &Metadata{
+						Kind:       utils.StringPtr("host"),
+						Categories: map[string]string{"Environment": "Staging"},
+					},
+				},
+			},
+			&HostResponse{
+				Metadata: &Metadata{
+					Kind:       utils.StringPtr("host"),
+					UUID:       utils.StringPtr("cfde831a-4e87-4a75-960f-89b0148aa2cc"),
+					Categories: map[string]string{"Environment": "Staging"},
+				},
+			},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			op := Operations{
+				client: tt.fields.client,
+			}
+			got, err := op.UpdateHost(tt.args.UUID, tt.args.body)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Operations.UpdateHost() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Operations.UpdateHost() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestOperations_ListHost(t *testing.T) {
 	mux, c, server := setup()
 

--- a/nutanix/sdks/v3/prism/prism_structs.go
+++ b/nutanix/sdks/v3/prism/prism_structs.go
@@ -1930,6 +1930,7 @@ type HostStatus struct {
 	Name             string             `json:"name,omitempty"`
 	Resources        *HostResources     `json:"resources,omitempty"`
 	ClusterReference *ReferenceValues   `json:"cluster_reference,omitempty"`
+	ExecutionContext *ExecutionContext  `json:"execution_context,omitempty"`
 }
 
 // HostResponse Response object for intentful operations on a Host
@@ -1945,6 +1946,13 @@ type HostListResponse struct {
 	APIVersion string              `json:"api_version,omitempty"`
 	Entities   []*HostResponse     `json:"entities,omitempty"`
 	Metadata   *ListMetadataOutput `json:"metadata,omitempty"`
+}
+
+// HostIntentInput Request object for intentful operations on a Host
+type HostIntentInput struct {
+	APIVersion string    `json:"api_version,omitempty"`
+	Metadata   *Metadata `json:"metadata,omitempty"`
+	Spec       *HostSpec `json:"spec,omitempty"`
 }
 
 /* Project Resource */

--- a/nutanix/services/clusters/categories.go
+++ b/nutanix/services/clusters/categories.go
@@ -31,6 +31,18 @@ func categoriesSchema() *schema.Schema {
 	}
 }
 
+func expandCategories(categoriesSet interface{}) map[string]string {
+	categories := categoriesSet.(*schema.Set).List()
+	output := make(map[string]string)
+
+	for _, v := range categories {
+		category := v.(map[string]interface{})
+		output[category["name"].(string)] = category["value"].(string)
+	}
+
+	return output
+}
+
 func flattenCategories(categories map[string]string) []interface{} {
 	c := make([]interface{}, 0)
 

--- a/nutanix/services/clusters/helpers.go
+++ b/nutanix/services/clusters/helpers.go
@@ -1,16 +1,38 @@
 package clusters
 
 import (
+	"fmt"
 	"strconv"
+	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	v3 "github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v3/prism"
 	"github.com/terraform-providers/terraform-provider-nutanix/utils"
 )
 
 const (
 	// ERROR ..
-	ERROR = "ERROR"
+	ERROR              = "ERROR"
+	DEFAULTWAITTIMEOUT = 60
 )
+
+func taskStateRefreshFunc(client *v3.Client, taskUUID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		v, err := client.V3.GetTask(taskUUID)
+		if err != nil {
+			if strings.Contains(fmt.Sprint(err), "INVALID_UUID") {
+				return v, ERROR, nil
+			}
+			return nil, "", err
+		}
+
+		if *v.Status == "INVALID_UUID" || *v.Status == "FAILED" {
+			return v, *v.Status,
+				fmt.Errorf("error_detail: %s, progress_message: %s", utils.StringValue(v.ErrorDetail), utils.StringValue(v.ProgressMessage))
+		}
+		return v, *v.Status, nil
+	}
+}
 
 func setRSEntityMetadata(v *v3.Metadata) (map[string]interface{}, []interface{}) {
 	metadata := make(map[string]interface{})

--- a/nutanix/services/clusters/helpers.go
+++ b/nutanix/services/clusters/helpers.go
@@ -13,7 +13,6 @@ import (
 const (
 	// ERROR ..
 	ERROR              = "ERROR"
-	DEFAULTWAITTIMEOUT = 60
 )
 
 func taskStateRefreshFunc(client *v3.Client, taskUUID string) resource.StateRefreshFunc {

--- a/nutanix/services/clusters/helpers.go
+++ b/nutanix/services/clusters/helpers.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// ERROR ..
-	ERROR              = "ERROR"
+	ERROR = "ERROR"
 )
 
 func taskStateRefreshFunc(client *v3.Client, taskUUID string) resource.StateRefreshFunc {

--- a/nutanix/services/clusters/resource_nutanix_host.go
+++ b/nutanix/services/clusters/resource_nutanix_host.go
@@ -1,0 +1,483 @@
+package clusters
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/spf13/cast"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	v3 "github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v3/prism"
+)
+
+var (
+	hostDelay      = 10 * time.Second
+	hostMinTimeout = 3 * time.Second
+)
+
+func ResourceNutanixHost() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNutanixHostCreate,
+		ReadContext:   resourceNutanixHostRead,
+		UpdateContext: resourceNutanixHostUpdate,
+		DeleteContext: resourceNutanixHostDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(DEFAULTWAITTIMEOUT * time.Minute),
+			Update: schema.DefaultTimeout(DEFAULTWAITTIMEOUT * time.Minute),
+			Delete: schema.DefaultTimeout(DEFAULTWAITTIMEOUT * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"host_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The UUID of the existing Nutanix host to manage. Hosts cannot be created or deleted via Terraform; this resource adopts an existing host to manage its categories.",
+			},
+			"categories": categoriesSchema(),
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"gpu_driver_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"failover_cluster": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"ipmi": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"cpu_model": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"host_nics_id_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"num_cpu_sockets": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"windows_domain": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"gpu_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vendor": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"num_virtual_display_heads": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"assignable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"license_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"num_vgpus_allocated": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"pci_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"frame_buffer_size_mib": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"index": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"numa_node": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"max_resolution": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"consumer_reference": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fraction": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"guest_driver_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"device_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"serial_number": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cpu_capacity_hz": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"memory_capacity_mib": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"host_disks_reference_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"monitoring_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"hypervisor": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"host_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"num_cpu_cores": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"rackable_unit_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"controller_vm": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"block": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"cluster_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"api_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"metadata": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"project_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"owner_reference": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceNutanixHostCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).API
+
+	hostID := d.Get("host_id").(string)
+
+	host, err := conn.V3.GetHost(hostID)
+	if err != nil {
+		return diag.Errorf("error retrieving host with ID (%s): %s", hostID, err)
+	}
+
+	if v, ok := d.GetOk("categories"); ok {
+		if err := updateHostCategories(ctx, d, conn, host, expandCategories(v)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	d.SetId(hostID)
+
+	return resourceNutanixHostRead(ctx, d, meta)
+}
+
+func resourceNutanixHostRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).API
+
+	hostID := d.Id()
+
+	host, err := conn.V3.GetHost(hostID)
+	if err != nil {
+		if strings.Contains(fmt.Sprint(err), "ENTITY_NOT_FOUND") {
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("error retrieving host with ID (%s): %s", hostID, err)
+	}
+
+	if err := d.Set("host_id", hostID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("name", host.Status.Name); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("gpu_driver_version", host.Status.Resources.GPUDriverVersion); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("failover_cluster", flattenFailOverCluster(host.Status.Resources.FailoverCluster)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("ipmi", flattenIMPI(host.Status.Resources.IPMI)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("cpu_model", host.Status.Resources.CPUModel); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("host_nics_id_list", host.Status.Resources.HostNicsIDList); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("num_cpu_sockets", host.Status.Resources.NumCPUSockets); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("windows_domain", flattenWindowsDomain(host.Status.Resources.WindowsDomain)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("gpu_list", flattenGpuList(host.Status.Resources.GPUList)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("serial_number", host.Status.Resources.SerialNumber); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("cpu_capacity_hz", host.Status.Resources.CPUCapacityHZ); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("memory_capacity_mib", host.Status.Resources.MemoryVapacityMib); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("host_disks_reference_list", flattenReferenceList(host.Status.Resources.HostDisksReferenceList)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("monitoring_state", host.Status.Resources.MonitoringState); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("hypervisor", flattenHypervisor(host.Status.Resources.Hypervisor)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("host_type", host.Status.Resources.HostType); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("num_cpu_cores", host.Status.Resources.NumCPUCores); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("rackable_unit_reference", flattenReference(host.Status.Resources.RackableUnitReference)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("controller_vm", flattenControllerVM(host.Status.Resources.ControllerVM)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("block", flattenBlock(host.Status.Resources.Block)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("cluster_reference", flattenReference(host.Status.ClusterReference)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	m, c := setRSEntityMetadata(host.Metadata)
+
+	if err := d.Set("api_version", host.APIVersion); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("metadata", m); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("categories", c); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("project_reference", flattenReferenceValues(host.Metadata.ProjectReference)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("owner_reference", flattenReferenceValues(host.Metadata.OwnerReference)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceNutanixHostUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).API
+
+	hostID := d.Id()
+
+	if d.HasChange("categories") {
+		host, err := conn.V3.GetHost(hostID)
+		if err != nil {
+			return diag.Errorf("error retrieving host with ID (%s): %s", hostID, err)
+		}
+
+		if err := updateHostCategories(ctx, d, conn, host, expandCategories(d.Get("categories"))); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceNutanixHostRead(ctx, d, meta)
+}
+
+func resourceNutanixHostDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conn := meta.(*conns.Client).API
+
+	hostID := d.Id()
+
+	host, err := conn.V3.GetHost(hostID)
+	if err != nil {
+		if strings.Contains(fmt.Sprint(err), "ENTITY_NOT_FOUND") {
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("error retrieving host with ID (%s): %s", hostID, err)
+	}
+
+	if err := updateHostCategories(ctx, d, conn, host, map[string]string{}); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func updateHostCategories(ctx context.Context, d *schema.ResourceData, conn *v3.Client, host *v3.HostResponse, categories map[string]string) error {
+	metadata := &v3.Metadata{}
+	if host.Metadata != nil {
+		metadata = host.Metadata
+	}
+	metadata.Categories = categories
+
+	request := &v3.HostIntentInput{
+		APIVersion: host.APIVersion,
+		Metadata:   metadata,
+		Spec:       host.Spec,
+	}
+
+	resp, err := conn.V3.UpdateHost(*host.Metadata.UUID, request)
+	if err != nil {
+		return fmt.Errorf("error updating categories for host (%s): %w", *host.Metadata.UUID, err)
+	}
+
+	if resp.Status == nil || resp.Status.ExecutionContext == nil || resp.Status.ExecutionContext.TaskUUID == nil {
+		return nil
+	}
+
+	taskUUID := cast.ToString(resp.Status.ExecutionContext.TaskUUID)
+	if taskUUID == "" {
+		return nil
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"QUEUED", "RUNNING"},
+		Target:     []string{"SUCCEEDED"},
+		Refresh:    taskStateRefreshFunc(conn, taskUUID),
+		Timeout:    d.Timeout(schema.TimeoutUpdate),
+		Delay:      hostDelay,
+		MinTimeout: hostMinTimeout,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("error waiting for host (%s) categories update to finish: %w", *host.Metadata.UUID, err)
+	}
+
+	return nil
+}

--- a/nutanix/services/clusters/resource_nutanix_host_test.go
+++ b/nutanix/services/clusters/resource_nutanix_host_test.go
@@ -1,0 +1,190 @@
+package clusters_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
+)
+
+const resourceNameHost = "nutanix_host.acctest-managed"
+
+func TestAccNutanixHost_WithCategory(t *testing.T) {
+	imgName := fmt.Sprintf("test-acc-host-image-%s", acctest.RandString(3))
+	vmName := fmt.Sprintf("test-acc-host-vm-%s", acctest.RandString(3))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckNutanixHostStillExists,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNutanixHostConfigWithCategory(imgName, vmName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNutanixHostExists(resourceNameHost),
+					resource.TestCheckResourceAttrSet(resourceNameHost, "host_id"),
+					resource.TestCheckResourceAttrSet(resourceNameHost, "name"),
+					resource.TestCheckResourceAttr(resourceNameHost, "categories.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameHost, "categories.0.name", "Environment"),
+					resource.TestCheckResourceAttr(resourceNameHost, "categories.0.value", "Production"),
+				),
+			},
+			{
+				Config: testAccNutanixHostConfigWithCategoryUpdate(imgName, vmName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNutanixHostExists(resourceNameHost),
+					resource.TestCheckResourceAttr(resourceNameHost, "categories.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameHost, "categories.0.name", "Environment"),
+					resource.TestCheckResourceAttr(resourceNameHost, "categories.0.value", "Staging"),
+				),
+			},
+			{
+				ResourceName:      resourceNameHost,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckNutanixHostExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		conn := acc.TestAccProvider.Meta().(*conns.Client)
+		if _, err := conn.API.V3.GetHost(rs.Primary.ID); err != nil {
+			return fmt.Errorf("error fetching host (%s): %s", rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckNutanixHostStillExists(s *terraform.State) error {
+	conn := acc.TestAccProvider.Meta().(*conns.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "nutanix_host" {
+			continue
+		}
+
+		host, err := conn.API.V3.GetHost(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("host (%s) should still exist after destroying nutanix_host, but got: %s", rs.Primary.ID, err)
+		}
+		if len(host.Metadata.Categories) != 0 {
+			return fmt.Errorf("expected categories on host (%s) to be cleared after destroy, got: %v", rs.Primary.ID, host.Metadata.Categories)
+		}
+	}
+
+	return nil
+}
+
+func testAccNutanixHostConfigWithCategory(imgName, vmName string) string {
+	return fmt.Sprintf(`
+		data "nutanix_clusters" "clusters" {}
+
+		locals {
+			cluster1 = "${data.nutanix_clusters.clusters.entities.0.service_list.0 == "PRISM_CENTRAL"
+			? data.nutanix_clusters.clusters.entities.1.metadata.uuid : data.nutanix_clusters.clusters.entities.0.metadata.uuid}"
+		}
+
+		resource "nutanix_image" "acctest-host-image" {
+			name        = "%[1]s"
+			source_uri  = "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
+			description = "tiny image used to discover a host uuid for the nutanix_host acctest"
+		}
+
+		resource "nutanix_virtual_machine" "acctest-host-vm" {
+			name                  = "%[2]s"
+			cluster_uuid          = local.cluster1
+			num_vcpus_per_socket  = 1
+			num_sockets           = 1
+			memory_size_mib       = 186
+
+			disk_list {
+				data_source_reference = {
+					kind = "image"
+					uuid = nutanix_image.acctest-host-image.id
+				}
+
+				device_properties {
+					disk_address = {
+						device_index = 0
+						adapter_type = "IDE"
+					}
+					device_type = "CDROM"
+				}
+			}
+		}
+
+		resource "nutanix_host" "acctest-managed" {
+			host_id = nutanix_virtual_machine.acctest-host-vm.host_reference.uuid
+
+			categories {
+				name  = "Environment"
+				value = "Production"
+			}
+		}
+	`, imgName, vmName)
+}
+
+func testAccNutanixHostConfigWithCategoryUpdate(imgName, vmName string) string {
+	return fmt.Sprintf(`
+		data "nutanix_clusters" "clusters" {}
+
+		locals {
+			cluster1 = "${data.nutanix_clusters.clusters.entities.0.service_list.0 == "PRISM_CENTRAL"
+			? data.nutanix_clusters.clusters.entities.1.metadata.uuid : data.nutanix_clusters.clusters.entities.0.metadata.uuid}"
+		}
+
+		resource "nutanix_image" "acctest-host-image" {
+			name        = "%[1]s"
+			source_uri  = "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"
+			description = "tiny image used to discover a host uuid for the nutanix_host acctest"
+		}
+
+		resource "nutanix_virtual_machine" "acctest-host-vm" {
+			name                  = "%[2]s"
+			cluster_uuid          = local.cluster1
+			num_vcpus_per_socket  = 1
+			num_sockets           = 1
+			memory_size_mib       = 186
+
+			disk_list {
+				data_source_reference = {
+					kind = "image"
+					uuid = nutanix_image.acctest-host-image.id
+				}
+
+				device_properties {
+					disk_address = {
+						device_index = 0
+						adapter_type = "IDE"
+					}
+					device_type = "CDROM"
+				}
+			}
+		}
+
+		resource "nutanix_host" "acctest-managed" {
+			host_id = nutanix_virtual_machine.acctest-host-vm.host_reference.uuid
+
+			categories {
+				name  = "Environment"
+				value = "Staging"
+			}
+		}
+	`, imgName, vmName)
+}

--- a/website/docs/r/host.html.markdown
+++ b/website/docs/r/host.html.markdown
@@ -1,0 +1,102 @@
+---
+layout: "nutanix"
+page_title: "NUTANIX: nutanix_host"
+sidebar_current: "docs-nutanix-resource-nutanix-host"
+description: |-
+  This operation manages the categories assigned to an existing Nutanix host.
+---
+
+# nutanix_host
+
+Manages the categories assigned to an existing Nutanix host.
+
+Hosts are physical infrastructure that Prism Central discovers automatically - they are
+never created or destroyed through the Nutanix API. This resource therefore "adopts" an
+existing host, identified by `host_id`, and manages the category assignment on it, the
+same way `categories` is managed on [`nutanix_subnet`](subnet.html) and other resources.
+
+All other host attributes exposed by this resource are read-only and mirror the
+[`nutanix_host`](/docs/providers/nutanix/d/host.html) data source; they describe the
+adopted host but cannot be changed via Terraform.
+
+~> **NOTE** Destroying this resource does not delete the underlying host. It only clears
+the categories Terraform assigned to it and removes the resource from Terraform state.
+
+## Example Usage
+
+```hcl
+data "nutanix_hosts" "hosts" {}
+
+resource "nutanix_host" "managed-host" {
+  host_id = data.nutanix_hosts.hosts.entities.0.metadata.uuid
+
+  categories {
+    name  = "Environment"
+    value = "Production"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `host_id`: - (Required) The UUID of the existing host to adopt and manage. Changing this
+  forces a new resource (it re-targets a different host rather than mutating the current one).
+* `categories`: - (Optional) The categories to assign to the host. See below.
+
+### Categories
+
+The categories attribute supports the following:
+
+* `name`: - the key name.
+* `value`: - value of the key.
+
+## Attribute Reference
+
+The following attributes are exported (all read-only, mirroring the current state of the
+adopted host):
+
+* `name`: - The host's name.
+* `api_version` - The API version.
+* `metadata`: - The host kind metadata.
+* `project_reference`: - The reference to a project.
+* `owner_reference`: - The reference to a user.
+* `cluster_reference`: - Reference to the cluster the host belongs to.
+* `gpu_driver_version`: - Host GPU driver version.
+* `failover_cluster`: - Hyper-V failover cluster.
+* `ipmi`: - Host IPMI info.
+* `cpu_model`: - Host CPU model.
+* `host_nics_id_list`: - Host NICs.
+* `num_cpu_sockets`: - Number of CPU sockets.
+* `windows_domain`: - The name of the node to be renamed to during domain-join. If not given, a new name will be automatically assigned.
+* `gpu_list`: - List of GPUs on the host.
+* `serial_number`: - Node serial number.
+* `cpu_capacity_hz`: - Host CPU capacity.
+* `memory_capacity_mib`: - Host memory capacity in MiB.
+* `host_disks_reference_list`: - The reference to a disk.
+* `monitoring_state`: - Host monitoring status.
+* `hypervisor`: - Host Hypervisor information.
+* `host_type`: - Host type.
+* `num_cpu_cores`: - Number of CPU cores on the host.
+* `rackable_unit_reference`: - The reference to a rackable_unit.
+* `controller_vm`: - Host controller VM information.
+* `block`: - Host block config info.
+
+### Reference
+
+The `project_reference`, `owner_reference`, and `cluster_reference` attributes support the following:
+
+* `kind`: - The kind name.
+* `name`: - the name.
+* `uuid`: - the uuid.
+
+## Importing
+
+An existing `nutanix_host` resource can be imported using its host UUID:
+
+```shell
+terraform import nutanix_host.managed-host <HOST-UUID>
+```
+
+See detailed information in [Nutanix Host](https://www.nutanix.dev/api_references/prism-central-v3/#/5ef25d36e143a-get-a-existing-host).

--- a/website/nutanix.erb
+++ b/website/nutanix.erb
@@ -599,6 +599,9 @@
                 <li<%= sidebar_current("docs-nutanix-resource-nutanix-category-value") %>>
                     <a href="/docs/providers/nutanix/r/category_value.html">nutanix_category_value</a>
                 </li>
+                <li<%= sidebar_current("docs-nutanix-resource-nutanix-host") %>>
+                    <a href="/docs/providers/nutanix/r/host.html">nutanix_host</a>
+                </li>
                 <li<%= sidebar_current("docs-nutanix-resource-nutanix_image") %>>
                     <a href="/docs/providers/nutanix/r/image.html">nutanix_image</a>
                 </li>


### PR DESCRIPTION
Adds a new nutanix_host resource so categories can be assigned to existing Nutanix hosts via Terraform

- SDK: add HostIntentInput and Operations.UpdateHost (PUT /hosts/{uuid})
- clusters: new resource_nutanix_host.go (Create/Read/Update/Delete/Import)
- Register nutanix_host in the provider's ResourcesMap
- Docs page and sidebar entry

related to #1218