### PR TITLE
resource/nutanix_virtual_machine_v2: wait for a routable IP after power-on (#871)

### DIFF
--- a/examples/virtual_machine_v2/main.tf
+++ b/examples/virtual_machine_v2/main.tf
@@ -444,6 +444,52 @@ resource "nutanix_virtual_machine_v2" "example-13" {
   power_state = "OFF"
 }
 
+# create a virtual machine that waits for the guest to report a routable IPv4 address.
+#
+# Nutanix guest tools report the APIPA/link-local address (169.254.0.0/16) transiently
+# before DHCP completes. wait_for_ip_routable makes the create-time wait skip those and
+# keep polling, so provisioners and downstream resources get the real address.
+resource "nutanix_virtual_machine_v2" "example-14" {
+  name                 = "example-14"
+  description          = "vm example that waits for a routable ip"
+  num_cores_per_socket = 1
+  num_sockets          = 1
+  cluster {
+    ext_id = local.cluster_ext_id
+  }
+  disks {
+    disk_address {
+      bus_type = "SCSI"
+      index    = 0
+    }
+    backing_info {
+      vm_disk {
+        disk_size_bytes = "1073741824"
+        storage_container {
+          ext_id = data.nutanix_storage_containers_v2.sc.storage_containers[0].ext_id
+        }
+      }
+    }
+  }
+  nics {
+    nic_network_info {
+      virtual_ethernet_nic_network_info {
+        nic_type = "NORMAL_NIC"
+        subnet {
+          ext_id = data.nutanix_subnets_v2.vm-subnet.subnets[0].ext_id
+        }
+        vlan_mode = "ACCESS"
+      }
+    }
+  }
+  power_state = "ON"
+
+  # Defaults shown explicitly. Set wait_for_ip_timeout = 0 to disable the wait, or
+  # wait_for_ip_routable = false to accept the first learned address including APIPA.
+  wait_for_ip_timeout  = 5
+  wait_for_ip_routable = true
+}
+
 
 # list all virtual machines
 data "nutanix_virtual_machines_v2" "vms" {}

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"reflect"
 	"strconv"
 	"time"
@@ -614,6 +615,18 @@ func ResourceNutanixVirtualMachineV2() *schema.Resource {
 				Optional:     true,
 				Default:      "ON",
 				ValidateFunc: validation.StringInSlice([]string{"ON", "OFF", "PAUSED", "UNDETERMINED"}, false),
+			},
+			"wait_for_ip_timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     5,
+				Description: "Minutes to wait after power-on for the VM to report a usable IPv4 address. A value less than 1 disables the wait. Modeled on the vSphere provider's wait_for_guest_net_timeout.",
+			},
+			"wait_for_ip_routable": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "When waiting for an IP (see wait_for_ip_timeout), require a routable address, ignoring APIPA/link-local (169.254.0.0/16) addresses reported transiently before DHCP completes. Set false to accept the first learned address, including APIPA.",
 			},
 			"vtpm_config": {
 				Type:     schema.TypeList,
@@ -1409,13 +1422,14 @@ func ResourceNutanixVirtualMachineV2Create(ctx context.Context, d *schema.Resour
 	nics := d.Get("nics")
 	hasNics := nics != nil && len(common.InterfaceToSlice(nics)) > 0
 
-	if d.Get("power_state") == "ON" && hasNics {
+	waitForIPTimeout := d.Get("wait_for_ip_timeout").(int)
+	if d.Get("power_state") == "ON" && hasNics && waitForIPTimeout >= 1 {
 		// Wait for the VM to be available
 		waitIPConf := &resource.StateChangeConf{
 			Pending:    []string{"WAITING"},
 			Target:     []string{"AVAILABLE"},
-			Refresh:    waitForIPRefreshFunc(ctx, conn, utils.StringValue(uuid)),
-			Timeout:    timeout,
+			Refresh:    waitForIPRefreshFunc(ctx, conn, utils.StringValue(uuid), d.Get("wait_for_ip_routable").(bool)),
+			Timeout:    time.Duration(waitForIPTimeout) * time.Minute,
 			Delay:      delay,
 			MinTimeout: delay,
 		}
@@ -1427,7 +1441,7 @@ func ResourceNutanixVirtualMachineV2Create(ctx context.Context, d *schema.Resour
 			vmResp := vm.Data.GetValue().(config.Vm)
 
 			if len(vmResp.Nics) > 0 && vmResp.Nics[0].NetworkInfo != nil {
-				ipAddr := getFirstIPAddress(vmResp.Nics[0])
+				ipAddr := getFirstIPAddress(vmResp.Nics[0], d.Get("wait_for_ip_routable").(bool))
 				if ipAddr != "" {
 					d.SetConnInfo(map[string]string{
 						"type": "ssh",
@@ -3346,16 +3360,26 @@ func resourceNutanixVirtualMachineV2StateUpgradeV0(ctx context.Context, rawState
 	return rawState, nil
 }
 
+// isAPIPA reports whether s is an IPv4 link-local / APIPA address (169.254.0.0/16).
+// Nutanix guest tools report these transiently before DHCP assigns a real lease, so a
+// caller waiting for a usable address must skip them and keep polling (issue #871).
+func isAPIPA(s string) bool {
+	ip := net.ParseIP(s)
+	return ip != nil && ip.To4() != nil && ip.IsLinkLocalUnicast()
+}
+
 // getFirstIPAddress returns the first available IP address from a NIC.
 // It checks both DHCP learned IPs and statically configured IPs.
-func getFirstIPAddress(nic config.Nic) string {
+func getFirstIPAddress(nic config.Nic, routable bool) string {
 	if nic.NetworkInfo == nil {
 		return ""
 	}
 	// Check for DHCP learned IPs first
-	if nic.NetworkInfo.Ipv4Info != nil && len(nic.NetworkInfo.Ipv4Info.LearnedIpAddresses) > 0 {
-		if nic.NetworkInfo.Ipv4Info.LearnedIpAddresses[0].Value != nil {
-			return *nic.NetworkInfo.Ipv4Info.LearnedIpAddresses[0].Value
+	if nic.NetworkInfo.Ipv4Info != nil {
+		for _, ip := range nic.NetworkInfo.Ipv4Info.LearnedIpAddresses {
+			if ip.Value != nil && (!routable || !isAPIPA(*ip.Value)) {
+				return *ip.Value
+			}
 		}
 	}
 	// Check for statically configured IP
@@ -3365,7 +3389,7 @@ func getFirstIPAddress(nic config.Nic) string {
 	return ""
 }
 
-func waitForIPRefreshFunc(ctx context.Context, client *vmm.Client, vmUUID string) resource.StateRefreshFunc {
+func waitForIPRefreshFunc(ctx context.Context, client *vmm.Client, vmUUID string, routable bool) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		getVmByIdRequest := import3.GetVmByIdRequest{
 			ExtId: utils.StringPtr(vmUUID),
@@ -3383,8 +3407,11 @@ func waitForIPRefreshFunc(ctx context.Context, client *vmm.Client, vmUUID string
 					// Check for DHCP learned IPs
 					if nic.NetworkInfo.Ipv4Info != nil {
 						for _, ip := range nic.NetworkInfo.Ipv4Info.LearnedIpAddresses {
-							if ip.Value != nil {
+							if ip.Value != nil && (!routable || !isAPIPA(*ip.Value)) {
 								return resp, "AVAILABLE", nil
+							}
+							if ip.Value != nil && routable && isAPIPA(*ip.Value) {
+								log.Printf("[DEBUG] VM %s: ignoring APIPA/link-local %q; waiting for a routable IP", vmUUID, *ip.Value)
 							}
 						}
 					}

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -28,6 +28,15 @@ import (
 const (
 	timeout = 5 * time.Minute
 	delay   = 5 * time.Second
+
+	// defaultWaitForIPTimeoutMinutes is the default for the wait_for_ip_timeout argument,
+	// in minutes. It preserves the 5 minute IP wait this resource has always used (see
+	// timeout above), and matches the vSphere provider's wait_for_guest_net_timeout.
+	defaultWaitForIPTimeoutMinutes = 5
+
+	// defaultWaitForIPRoutable is the default for the wait_for_ip_routable argument:
+	// skip APIPA/link-local addresses while waiting for the guest to report an IP.
+	defaultWaitForIPRoutable = true
 )
 
 func ResourceNutanixVirtualMachineV2() *schema.Resource {
@@ -619,13 +628,13 @@ func ResourceNutanixVirtualMachineV2() *schema.Resource {
 			"wait_for_ip_timeout": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     5,
+				Default:     defaultWaitForIPTimeoutMinutes,
 				Description: "Minutes to wait after power-on for the VM to report a usable IPv4 address. A value less than 1 disables the wait. Modeled on the vSphere provider's wait_for_guest_net_timeout.",
 			},
 			"wait_for_ip_routable": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
+				Default:     defaultWaitForIPRoutable,
 				Description: "When waiting for an IP (see wait_for_ip_timeout), require a routable address, ignoring APIPA/link-local (169.254.0.0/16) addresses reported transiently before DHCP completes. Set false to accept the first learned address, including APIPA.",
 			},
 			"vtpm_config": {
@@ -3407,12 +3416,14 @@ func waitForIPRefreshFunc(ctx context.Context, client *vmm.Client, vmUUID string
 					// Check for DHCP learned IPs
 					if nic.NetworkInfo.Ipv4Info != nil {
 						for _, ip := range nic.NetworkInfo.Ipv4Info.LearnedIpAddresses {
-							if ip.Value != nil && (!routable || !isAPIPA(*ip.Value)) {
-								return resp, "AVAILABLE", nil
+							if ip.Value == nil {
+								continue
 							}
-							if ip.Value != nil && routable && isAPIPA(*ip.Value) {
+							if routable && isAPIPA(*ip.Value) {
 								log.Printf("[DEBUG] VM %s: ignoring APIPA/link-local %q; waiting for a routable IP", vmUUID, *ip.Value)
+								continue
 							}
+							return resp, "AVAILABLE", nil
 						}
 					}
 					// Check for statically configured IPs

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_apipa_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_apipa_test.go
@@ -1,0 +1,60 @@
+package vmmv2
+
+import (
+	"testing"
+
+	commonconfig "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/common/v1/config"
+	"github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/ahv/config"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+func TestIsAPIPA(t *testing.T) {
+	cases := map[string]bool{
+		"169.254.0.1":    true,  // APIPA
+		"169.254.99.200": true,  // APIPA
+		"10.0.0.5":       false, // routable
+		"192.168.1.10":   false,
+		"172.30.130.229": false, // a real corp desktop
+		"127.0.0.1":      false, // loopback, not link-local
+		"0.0.0.0":        false, // unspecified
+		"":               false,
+		"not-an-ip":      false,
+		"fe80::1":        false, // IPv6 link-local — we only skip IPv4 APIPA here
+	}
+	for in, want := range cases {
+		if got := isAPIPA(in); got != want {
+			t.Errorf("isAPIPA(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestGetFirstIPAddress(t *testing.T) {
+	learned := func(ips ...string) config.Nic {
+		la := make([]commonconfig.IPv4Address, 0, len(ips))
+		for _, ip := range ips {
+			la = append(la, commonconfig.IPv4Address{Value: utils.StringPtr(ip)})
+		}
+		return config.Nic{NetworkInfo: &config.NicNetworkInfo{Ipv4Info: &config.Ipv4Info{LearnedIpAddresses: la}}}
+	}
+	static := config.Nic{NetworkInfo: &config.NicNetworkInfo{
+		Ipv4Config: &config.Ipv4Config{IpAddress: &commonconfig.IPv4Address{Value: utils.StringPtr("192.168.5.5")}},
+	}}
+	tests := []struct {
+		name     string
+		nic      config.Nic
+		routable bool
+		want     string
+	}{
+		{"routable: apipa then real -> real", learned("169.254.1.5", "10.0.0.5"), true, "10.0.0.5"},
+		{"routable: only apipa -> empty (skipped)", learned("169.254.1.5"), true, ""},
+		{"routable: real only -> real", learned("10.1.2.3"), true, "10.1.2.3"},
+		{"not routable: only apipa -> apipa (accepted)", learned("169.254.1.5"), false, "169.254.1.5"},
+		{"no network info -> empty", config.Nic{}, true, ""},
+		{"static config fallback", static, true, "192.168.5.5"},
+	}
+	for _, tc := range tests {
+		if got := getFirstIPAddress(tc.nic, tc.routable); got != tc.want {
+			t.Errorf("%s: getFirstIPAddress(routable=%v) = %q, want %q", tc.name, tc.routable, got, tc.want)
+		}
+	}
+}

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
@@ -2,11 +2,14 @@ package vmmv2_test
 
 import (
 	"fmt"
+	"net"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	acc "github.com/terraform-providers/terraform-provider-nutanix/nutanix/acctest"
 )
 
@@ -1186,6 +1189,132 @@ func TestAccV2NutanixVmsResource_ClusterAutomaticSelection(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAccV2NutanixVmsResource_WaitForRoutableIP covers issue #871: on create the resource
+// must not report the APIPA/link-local address (169.254.0.0/16) that guest tools surface
+// transiently before DHCP completes.
+//
+// Step 1 uses the defaults (wait_for_ip_timeout = 5, wait_for_ip_routable = true) and
+// asserts that any IPv4 address learned on the NIC is routable. Step 2 sets
+// wait_for_ip_timeout = 0 to assert the wait can be disabled without failing the apply.
+//
+// Note: this is a timing-dependent guest behaviour, so the check only fails when an APIPA
+// address is actually reported - it does not require the guest to obtain a lease (a VM
+// with no guest tools simply reports no learned address and waits out the timeout, which
+// is non-fatal by design).
+func TestAccV2NutanixVmsResource_WaitForRoutableIP(t *testing.T) {
+	r := acctest.RandInt()
+	desc := "test vm waiting for a routable ip"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testVmsV2ConfigWaitForIP(r, desc, 5, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "name", fmt.Sprintf("tf-test-vm-%d", r)),
+					resource.TestCheckResourceAttr(resourceNameVms, "power_state", "ON"),
+					resource.TestCheckResourceAttr(resourceNameVms, "wait_for_ip_timeout", "5"),
+					resource.TestCheckResourceAttr(resourceNameVms, "wait_for_ip_routable", "true"),
+					resource.TestCheckResourceAttrSet(resourceNameVms, "nics.#"),
+					testCheckLearnedIPsAreRoutable(resourceNameVms),
+				),
+			},
+			{
+				// wait_for_ip_timeout < 1 disables the wait entirely.
+				Config: testVmsV2ConfigWaitForIP(r, desc, 0, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "wait_for_ip_timeout", "0"),
+					resource.TestCheckResourceAttr(resourceNameVms, "power_state", "ON"),
+				),
+			},
+		},
+	})
+}
+
+// testCheckLearnedIPsAreRoutable fails if any IPv4 address learned on the VM's NICs is an
+// APIPA/link-local address, which is what issue #871 reported being handed to provisioners.
+func testCheckLearnedIPsAreRoutable(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+		for key, value := range rs.Primary.Attributes {
+			if !strings.HasPrefix(key, "nics.") || !strings.HasSuffix(key, ".value") ||
+				!strings.Contains(key, ".ipv4_info.") || !strings.Contains(key, ".learned_ip_addresses.") {
+				continue
+			}
+			if ip := net.ParseIP(value); ip != nil && ip.To4() != nil && ip.IsLinkLocalUnicast() {
+				return fmt.Errorf("%s = %q is an APIPA/link-local address; expected a routable IPv4 address (issue #871)", key, value)
+			}
+		}
+		return nil
+	}
+}
+
+func testVmsV2ConfigWaitForIP(r int, desc string, waitTimeout int, routable bool) string {
+	return fmt.Sprintf(`
+		data "nutanix_clusters_v2" "clusters" {}
+
+		locals {
+			cluster0 = [
+			for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		  ][0]
+			config = jsondecode(file("%[3]s"))
+			vmm = local.config.vmm
+		}
+
+		data "nutanix_subnets_v2" "subnets" {
+			filter = "name eq '${local.vmm.subnet_name}'"
+		}
+
+		data "nutanix_storage_containers_v2" "sc" {
+		  filter = "clusterExtId eq '${local.cluster0}' and startswith(name,'default-container-')"
+		  limit = 1
+		}
+
+		resource "nutanix_virtual_machine_v2" "test"{
+			name= "tf-test-vm-%[1]d"
+			description =  "%[2]s"
+			num_cores_per_socket = 1
+			num_sockets = 1
+			cluster {
+				ext_id = local.cluster0
+			}
+			disks{
+				disk_address{
+					bus_type = "SCSI"
+					index = 0
+				}
+				backing_info{
+					vm_disk{
+						disk_size_bytes = "1073741824"
+						storage_container{
+							ext_id = data.nutanix_storage_containers_v2.sc.storage_containers[0].ext_id
+						}
+					}
+				}
+			}
+			nics{
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+						}
+						vlan_mode = "ACCESS"
+					}
+				}
+			}
+			power_state = "ON"
+
+			wait_for_ip_timeout  = %[4]d
+			wait_for_ip_routable = %[5]t
+		}
+`, r, desc, filepath, waitTimeout, routable)
 }
 
 func testVmsV4Config(name, desc string) string {

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_unit_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_unit_test.go
@@ -1,3 +1,10 @@
+// Unit tests for the routable-IP wait added for issue #871.
+//
+// These live in package vmmv2 (not vmmv2_test, like the acceptance tests in
+// resource_nutanix_virtual_machine_v2_test.go) because they exercise the unexported
+// isAPIPA/getFirstIPAddress helpers directly, which an external test package cannot reach.
+// The acceptance coverage for the same feature is
+// TestAccV2NutanixVmsResource_WaitForRoutableIP in resource_nutanix_virtual_machine_v2_test.go.
 package vmmv2
 
 import (
@@ -56,5 +63,18 @@ func TestGetFirstIPAddress(t *testing.T) {
 		if got := getFirstIPAddress(tc.nic, tc.routable); got != tc.want {
 			t.Errorf("%s: getFirstIPAddress(routable=%v) = %q, want %q", tc.name, tc.routable, got, tc.want)
 		}
+	}
+}
+
+// TestWaitForIPSchemaDefaults pins the schema defaults of the two new arguments to the
+// package constants, so a future change to either has to be deliberate.
+func TestWaitForIPSchemaDefaults(t *testing.T) {
+	s := ResourceNutanixVirtualMachineV2().Schema
+
+	if got := s["wait_for_ip_timeout"].Default; got != defaultWaitForIPTimeoutMinutes {
+		t.Errorf("wait_for_ip_timeout default = %v, want %v", got, defaultWaitForIPTimeoutMinutes)
+	}
+	if got := s["wait_for_ip_routable"].Default; got != defaultWaitForIPRoutable {
+		t.Errorf("wait_for_ip_routable default = %v, want %v", got, defaultWaitForIPRoutable)
 	}
 }

--- a/website/docs/r/virtual_machine_v2.html.markdown
+++ b/website/docs/r/virtual_machine_v2.html.markdown
@@ -210,6 +210,8 @@ The following arguments are supported:
 * `gpus`: (Optional) GPUs attached to the VM.
 * `serial_ports`: (Optional) Serial ports configured on the VM.
 * `protection_type`: (Optional) The type of protection applied on a VM. Valid values "PD_PROTECTED", "UNPROTECTED", "RULE_PROTECTED".
+* `wait_for_ip_timeout`: (Optional) Minutes to wait after power-on for the VM to report a usable IPv4 address on its first NIC. A value less than 1 disables the wait. Defaults to `5`. Modeled on the vSphere provider's `wait_for_guest_net_timeout`.
+* `wait_for_ip_routable`: (Optional) When waiting for an IP (see `wait_for_ip_timeout`), require a routable address, ignoring APIPA/link-local (`169.254.0.0/16`) addresses that guest tools report transiently before DHCP completes. Set to `false` to accept the first learned address, including APIPA. Defaults to `true`.
 
 
 ### Source

--- a/website/docs/r/virtual_machine_v2.html.markdown
+++ b/website/docs/r/virtual_machine_v2.html.markdown
@@ -150,6 +150,35 @@ resource "nutanix_virtual_machine_v2" "vm-3" {
   power_state = "ON"
 }
 
+# Wait for the guest to report a routable IPv4 address before the resource completes,
+# so provisioners and downstream resources do not receive the APIPA/link-local
+# (169.254.0.0/16) address guest tools report transiently before DHCP finishes.
+resource "nutanix_virtual_machine_v2" "vm-wait-for-ip" {
+  name                 = "example-vm-wait-for-ip"
+  num_cores_per_socket = 1
+  num_sockets          = 1
+  cluster {
+    ext_id = "1cefd0f5-6d38-4c9b-a07c-bdd2db004224"
+  }
+  nics {
+    nic_network_info {
+      virtual_ethernet_nic_network_info {
+        nic_type = "NORMAL_NIC"
+        subnet {
+          ext_id = "7f66e20f-67f4-473f-96bb-c4fcfd487f16"
+        }
+        vlan_mode = "ACCESS"
+      }
+    }
+  }
+  power_state = "ON"
+
+  # Defaults shown explicitly. Use wait_for_ip_timeout = 0 to disable the wait, or
+  # wait_for_ip_routable = false to accept the first learned address including APIPA.
+  wait_for_ip_timeout  = 5
+  wait_for_ip_routable = true
+}
+
 ```
 
 ## Lifecycle Behavior


### PR DESCRIPTION
Closes #871.

## Problem

In real deployments, `nutanix_virtual_machine_v2` **intermittently returns the wrong IP on create** —
an APIPA / link-local address (`169.254.0.0/16`) instead of the VM's actual DHCP address. Nutanix
guest tools surface the link-local address **transiently before DHCP completes**, and
`getFirstIPAddress` returned the first learned address unconditionally. As a result:

- `d.SetConnInfo` (and the IP used by provisioners) could be a `169.254.x` address, and
- the IP-wait state machine treated the APIPA as "available" and stopped waiting.

Consumers that need a routable address (provisioners, modules) then fail intermittently — it is a
race against DHCP latency, so it shows up sporadically on slow-lease networks.

## Fix

Make the post-power-on IP wait skip APIPA/link-local and keep polling for a routable address. Two
new arguments, modeled on the vSphere provider's guest-network waiter:

| Argument | Type | Default | Behavior |
|---|---|---|---|
| `wait_for_ip_timeout` | int (minutes) | `5` | How long to wait after power-on for a usable IPv4 address; `<1` disables. Mirrors vSphere `wait_for_guest_net_timeout`. |
| `wait_for_ip_routable` | bool | `true` | Ignore `169.254.0.0/16` while waiting. Set `false` to accept the first learned address (previous behavior). Mirrors vSphere `wait_for_guest_net_routable`. |

`isAPIPA()` (IPv4 link-local only) is used by both `getFirstIPAddress` and `waitForIPRefreshFunc`.

## Compatibility

- Defaults match the vSphere provider exactly (`5` min, routable `true`, `<1` disables).
- The IP wait timing out is non-fatal (logged; the resource still completes), so an intentionally
  APIPA-only VM simply waits out the timeout instead of failing.
- `wait_for_ip_routable = false` restores the prior "accept first learned address" behavior.

## Tests

**Unit** (`resource_nutanix_virtual_machine_v2_apipa_test.go`):

- `TestIsAPIPA` — `169.254.x` true; routable / loopback / IPv6 link-local / empty / malformed false.
- `TestGetFirstIPAddress` — apipa-then-routable → routable; apipa-only (routable) → skipped;
  apipa-only (not routable) → accepted; static fallback; no-network-info → empty.

**End-to-end** on an AHV cluster. The DHCP race was made deterministic from guest cloud-init (a
netplan bringing the NIC up on a link-local address with `dhcp4: false`, then a timer switching to
DHCP ~90 s later), reproducing the real timeline:

| Time | NIC learned IPs |
|---|---|
| t+24 s | `169.254.x` (link-local only) |
| t+136 s | routable address (link-local gone) |

Same VM configuration, only the provider version changed:

| | current release | this PR |
|---|---|---|
| waits for a routable IP | no | yes (≤ `wait_for_ip_timeout`, ignoring `169.254.x`) |
| IP reported | `169.254.x` | routable |
| consumer gating on a routable IP | fails | succeeds |

## Docs

`website/docs/r/virtual_machine_v2.html.markdown` documents both new arguments.
