### PR TITLE
Fix issue 1217 : legacy boot order changes in VMs

### DIFF
--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -332,31 +332,26 @@ func ResourceNutanixVirtualMachineV2() *schema.Resource {
 									"boot_device": {
 										Type:     schema.TypeList,
 										Optional: true,
-										Computed: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"boot_device_disk": {
 													Type:     schema.TypeList,
 													Optional: true,
-													Computed: true,
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
 															"disk_address": {
 																Type:     schema.TypeList,
 																Optional: true,
-																Computed: true,
 																Elem: &schema.Resource{
 																	Schema: map[string]*schema.Schema{
 																		"bus_type": {
 																			Type:         schema.TypeString,
 																			Optional:     true,
-																			Computed:     true,
 																			ValidateFunc: validation.StringInSlice([]string{"SCSI", "SPAPR", "PCI", "IDE", "SATA"}, false),
 																		},
 																		"index": {
 																			Type:     schema.TypeInt,
 																			Optional: true,
-																			Computed: true,
 																		},
 																	},
 																},
@@ -367,13 +362,11 @@ func ResourceNutanixVirtualMachineV2() *schema.Resource {
 												"boot_device_nic": {
 													Type:     schema.TypeList,
 													Optional: true,
-													Computed: true,
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
 															"mac_address": {
 																Type:     schema.TypeString,
 																Optional: true,
-																Computed: true,
 															},
 														},
 													},
@@ -548,31 +541,26 @@ func ResourceNutanixVirtualMachineV2() *schema.Resource {
 									"boot_device": {
 										Type:     schema.TypeList,
 										Optional: true,
-										Computed: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"boot_device_disk": {
 													Type:     schema.TypeList,
 													Optional: true,
-													Computed: true,
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
 															"disk_address": {
 																Type:     schema.TypeList,
 																Optional: true,
-																Computed: true,
 																Elem: &schema.Resource{
 																	Schema: map[string]*schema.Schema{
 																		"bus_type": {
 																			Type:         schema.TypeString,
 																			Optional:     true,
-																			Computed:     true,
 																			ValidateFunc: validation.StringInSlice([]string{"SCSI", "SPAPR", "PCI", "IDE", "SATA"}, false),
 																		},
 																		"index": {
 																			Type:     schema.TypeInt,
 																			Optional: true,
-																			Computed: true,
 																		},
 																	},
 																},
@@ -583,13 +571,11 @@ func ResourceNutanixVirtualMachineV2() *schema.Resource {
 												"boot_device_nic": {
 													Type:     schema.TypeList,
 													Optional: true,
-													Computed: true,
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
 															"mac_address": {
 																Type:     schema.TypeString,
 																Optional: true,
-																Computed: true,
 															},
 														},
 													},
@@ -1596,15 +1582,7 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 		checkForUpdateParams = true
 	}
 	if d.HasChange("machine_type") {
-		const two, three, four = 2, 3, 4
-		subMap := map[string]interface{}{
-			"PC":      two,
-			"PSERIES": three,
-			"Q35":     four,
-		}
-		pVal := subMap[d.Get("machine_type").(string)]
-		p := config.MachineType(pVal.(int))
-		updateSpec.MachineType = &p
+		updateSpec.MachineType = common.ExpandEnum[config.MachineType](d.Get("machine_type").(string))
 		checkForUpdateParams = true
 	}
 	if d.HasChange("vtpm_config") {
@@ -1624,15 +1602,7 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 		checkForUpdateParams = true
 	}
 	if d.HasChange("protection_type") {
-		const two, three, four = 2, 3, 4
-		subMap := map[string]interface{}{
-			"UNPROTECTED":    two,
-			"PD_PROTECTED":   three,
-			"RULE_PROTECTED": four,
-		}
-		pVal := subMap[d.Get("protection_type").(string)]
-		p := config.ProtectionType(pVal.(int))
-		updateSpec.ProtectionType = &p
+		updateSpec.ProtectionType = common.ExpandEnum[config.ProtectionType](d.Get("protection_type").(string))
 		checkForUpdateParams = true
 	}
 	if d.HasChange("protection_policy_state") {
@@ -1645,11 +1615,17 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 	}
 
 	if checkForUpdateParams {
+		args := make(map[string]interface{})
+		args["If-Match"] = getEtagHeader(updatedVMResp, conn)
+
+		aJSON, _ := json.MarshalIndent(updateSpec, "", "  ")
+		log.Printf("[DEBUG] vm update spec: %s", string(aJSON))
+
 		updateVmByIdRequest := import3.UpdateVmByIdRequest{
 			ExtId: utils.StringPtr(d.Id()),
 			Body:  &updateSpec,
 		}
-		updateResp, err := conn.VMAPIInstance.UpdateVmById(ctx, &updateVmByIdRequest)
+		updateResp, err := conn.VMAPIInstance.UpdateVmById(ctx, &updateVmByIdRequest, args)
 		if err != nil {
 			return diag.Errorf("error while updating Virtual Machines : %v", err)
 		}

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -1615,9 +1615,6 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 	}
 
 	if checkForUpdateParams {
-		args := make(map[string]interface{})
-		args["If-Match"] = getEtagHeader(updatedVMResp, conn)
-
 		aJSON, _ := json.MarshalIndent(updateSpec, "", "  ")
 		log.Printf("[DEBUG] vm update spec: %s", string(aJSON))
 
@@ -1625,6 +1622,12 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 			ExtId: utils.StringPtr(d.Id()),
 			Body:  &updateSpec,
 		}
+		readResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+		if err != nil {
+			return diag.Errorf("error while reading vm for update: %v", err)
+		}
+		args := make(map[string]interface{})
+		args["If-Match"] = getEtagHeader(readResp, conn)
 		updateResp, err := conn.VMAPIInstance.UpdateVmById(ctx, &updateVmByIdRequest, args)
 		if err != nil {
 			return diag.Errorf("error while updating Virtual Machines : %v", err)

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
@@ -616,6 +616,73 @@ func TestAccV2NutanixVmsResource_WithLegacyBootOrder(t *testing.T) {
 	})
 }
 
+func TestAccV2NutanixVmsResource_LegacyBootOrderChangeWithBootDevice(t *testing.T) {
+	r := acctest.RandInt()
+	name := fmt.Sprintf("tf-test-vm-%d", r)
+	desc := "test vm description"
+	mac := fmt.Sprintf("50:6b:8d:%02x:%02x:%02x", r&0xff, (r>>8)&0xff, (r>>16)&0xff)
+	bootDeviceNic := fmt.Sprintf(`
+				  boot_device {
+					boot_device_nic {
+					  mac_address = "%s"
+					}
+				  }`, mac)
+	bootDeviceDisk := `
+				  boot_device {
+					boot_device_disk {
+					  disk_address {
+						bus_type = "SATA"
+						index    = 0
+					  }
+					}
+				  }`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testVmsV4ConfigWithLegacyBootOrderChange(name, desc, mac, "", `["CDROM", "DISK", "NETWORK"]`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "name", name),
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_order.0", "CDROM"),
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_order.1", "DISK"),
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_order.2", "NETWORK"),
+				),
+			},
+			{
+				Config: testVmsV4ConfigWithLegacyBootOrderChange(name, desc, mac, bootDeviceNic, `["NETWORK", "DISK", "CDROM"]`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_device.0.boot_device_nic.0.mac_address", mac),
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_order.0", "NETWORK"),
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_order.1", "DISK"),
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_order.2", "CDROM"),
+				),
+			},
+			{
+				Config: testVmsV4ConfigWithLegacyBootOrderChange(name, desc, mac, bootDeviceDisk, `["CDROM", "DISK", "NETWORK"]`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_device.0.boot_device_disk.0.disk_address.0.bus_type", "SATA"),
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_device.0.boot_device_disk.0.disk_address.0.index", "0"),
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_device.0.boot_device_nic.#", "0"),
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_order.0", "CDROM"),
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_order.1", "DISK"),
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_order.2", "NETWORK"),
+				),
+			},
+			{
+				Config: testVmsV4ConfigWithLegacyBootOrderChange(name, desc, mac, "", `["CDROM", "DISK", "NETWORK"]`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_device.#", "0"),
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_order.0", "CDROM"),
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_order.1", "DISK"),
+					resource.TestCheckResourceAttr(resourceNameVms, "boot_config.0.legacy_boot.0.boot_order.2", "NETWORK"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccV2NutanixVmsResource_WithUEFIBootOrder(t *testing.T) {
 	r := acctest.RandInt()
 	name := fmt.Sprintf("tf-test-vm-%d", r)
@@ -1147,7 +1214,7 @@ func testVmsV4Config(name, desc string) string {
 func testVmsV4ConfigWithDisk(r int, desc string) string {
 	return fmt.Sprintf(`
 		data "nutanix_clusters_v2" "clusters" {
-			filter = "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+			filter = "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"		
 		}
 
 		resource "nutanix_subnet_v2" "subnet" {
@@ -1194,7 +1261,7 @@ func testVmsV4ConfigWithDisk(r int, desc string) string {
 				ignore_changes = [placement_targets]
 			}
 		}
-
+		
 		data "nutanix_storage_containers_v2" "ngt-sc" {
 		  filter = "clusterExtId eq '${local.cluster0}' and startswith(name,'default-container-')"
 		  limit = 1
@@ -1716,6 +1783,64 @@ func testVmsV4ConfigWithLegacyBootWithUpdateOrder(name, desc string) string {
 			power_state = "ON"
 		}
 `, name, desc)
+}
+
+func testVmsV4ConfigWithLegacyBootOrderChange(name, desc, macAddress, bootDeviceBlock, bootOrder string) string {
+	return fmt.Sprintf(`
+		data "nutanix_clusters_v2" "clusters" {}
+
+		locals {
+			cluster0 = [
+				for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+				cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+			][0]
+			config = jsondecode(file("%[6]s"))
+			vmm = local.config.vmm
+		}
+
+		data "nutanix_subnets_v2" "subnets" {
+			filter = "name eq '${local.vmm.subnet_name}'"
+		}
+
+		resource "nutanix_virtual_machine_v2" "test"{
+			name                 = "%[1]s"
+			description          = "%[2]s"
+			num_cores_per_socket = 1
+			num_sockets          = 1
+			power_state          = "OFF"
+			cluster {
+				ext_id = local.cluster0
+			}
+			nics {
+				nic_backing_info {
+					virtual_ethernet_nic {
+						mac_address = "%[3]s"
+					}
+				}
+				nic_network_info {
+					virtual_ethernet_nic_network_info {
+						nic_type = "NORMAL_NIC"
+						subnet {
+							ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+						}
+						vlan_mode = "ACCESS"
+					}
+				}
+			}
+			cd_roms {
+				disk_address {
+					bus_type = "SATA"
+					index    = 0
+				}
+			}
+			boot_config {
+				legacy_boot {
+%[4]s
+					boot_order = %[5]s
+				}
+			}
+		}
+`, name, desc, macAddress, bootDeviceBlock, bootOrder, filepath)
 }
 
 func testVmsV4ConfigWithLegacyBootDevice(name, desc string) string {


### PR DESCRIPTION
Add test for legacy boot order changes in VMs

- Introduced a new test case to validate the behavior of legacy boot order changes when modifying boot devices for Nutanix virtual machines.
- Enhanced the configuration functions to support testing various boot device scenarios, including NIC and disk configurations.
- Updated the resource schema to remove unnecessary computed fields for boot devices, streamlining the resource definition.
- Added metadata fields to the subnet documentation to provide additional context for users.