### PR TITLE
Fix issue 1107: Fix VM v2 NIC should_assign_ip state handling

### DIFF
--- a/nutanix/services/vmmv2/data_source_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/data_source_nutanix_virtual_machine_v2.go
@@ -2460,6 +2460,10 @@ func flattenCdRomBusType(pr *config.CdRomBusType) string {
 }
 
 func flattenNic(nic []config.Nic) []interface{} {
+	return flattenNicWithResourceData(nic, nil)
+}
+
+func flattenNicWithResourceData(nic []config.Nic, d *schema.ResourceData) []interface{} {
 	if len(nic) > 0 {
 		nicList := make([]interface{}, len(nic))
 
@@ -2518,11 +2522,123 @@ func flattenNic(nic []config.Nic) []interface{} {
 				}
 			}
 
+			if shouldAssignIP, ok := configuredShouldAssignIP(d, k); ok {
+				setShouldAssignIPInFlattenedNetworkInfo(nics["network_info"], shouldAssignIP)
+				setShouldAssignIPInFlattenedNicNetworkInfo(nics["nic_network_info"], shouldAssignIP)
+			}
+
 			nicList[k] = nics
 		}
 		return nicList
 	}
 	return nil
+}
+
+func configuredShouldAssignIP(d *schema.ResourceData, nicIndex int) (bool, bool) {
+	if d == nil {
+		return false, false
+	}
+
+	rawConfig := d.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.IsKnown() || rawConfig.Type() == cty.NilType {
+		return false, false
+	}
+
+	nics, ok := rawConfigAttribute(rawConfig, "nics")
+	if !ok {
+		return false, false
+	}
+
+	nicConfigs := rawConfigCollection(nics)
+	if nicIndex < 0 || nicIndex >= len(nicConfigs) {
+		return false, false
+	}
+
+	if value, ok := configuredShouldAssignIPFromLegacyNetworkInfo(nicConfigs[nicIndex]); ok {
+		return value, true
+	}
+	return configuredShouldAssignIPFromNicNetworkInfo(nicConfigs[nicIndex])
+}
+
+func configuredShouldAssignIPFromLegacyNetworkInfo(nicConfig cty.Value) (bool, bool) {
+	networkInfo, ok := rawConfigAttribute(nicConfig, "network_info")
+	if !ok {
+		return false, false
+	}
+	return configuredShouldAssignIPFromNetworkInfoList(networkInfo)
+}
+
+func configuredShouldAssignIPFromNicNetworkInfo(nicConfig cty.Value) (bool, bool) {
+	nicNetworkInfo, ok := rawConfigAttribute(nicConfig, "nic_network_info")
+	if !ok {
+		return false, false
+	}
+
+	for _, nicNetworkInfoItem := range rawConfigCollection(nicNetworkInfo) {
+		for _, networkInfoKey := range []string{"virtual_ethernet_nic_network_info", "dp_offload_nic_network_info"} {
+			networkInfo, ok := rawConfigAttribute(nicNetworkInfoItem, networkInfoKey)
+			if !ok {
+				continue
+			}
+			if value, ok := configuredShouldAssignIPFromNetworkInfoList(networkInfo); ok {
+				return value, true
+			}
+		}
+	}
+
+	return false, false
+}
+
+func configuredShouldAssignIPFromNetworkInfoList(networkInfo cty.Value) (bool, bool) {
+	for _, networkInfoItem := range rawConfigCollection(networkInfo) {
+		ipv4Config, ok := rawConfigAttribute(networkInfoItem, "ipv4_config")
+		if !ok {
+			continue
+		}
+		for _, ipv4ConfigItem := range rawConfigCollection(ipv4Config) {
+			shouldAssignIP, ok := rawConfigAttribute(ipv4ConfigItem, "should_assign_ip")
+			if !ok || shouldAssignIP.Type() != cty.Bool {
+				continue
+			}
+			return shouldAssignIP.True(), true
+		}
+	}
+
+	return false, false
+}
+
+func setShouldAssignIPInFlattenedNicNetworkInfo(nicNetworkInfo interface{}, value bool) {
+	forEachFlattenedMap(nicNetworkInfo, func(nicNetworkInfoItem map[string]interface{}) {
+		setShouldAssignIPInFlattenedNetworkInfo(nicNetworkInfoItem["virtual_ethernet_nic_network_info"], value)
+		setShouldAssignIPInFlattenedNetworkInfo(nicNetworkInfoItem["dp_offload_nic_network_info"], value)
+	})
+}
+
+func setShouldAssignIPInFlattenedNetworkInfo(networkInfo interface{}, value bool) {
+	forEachFlattenedMap(networkInfo, func(networkInfoItem map[string]interface{}) {
+		setShouldAssignIPInFlattenedIPv4Config(networkInfoItem["ipv4_config"], value)
+	})
+}
+
+func setShouldAssignIPInFlattenedIPv4Config(ipv4Config interface{}, value bool) {
+	forEachFlattenedMap(ipv4Config, func(ipv4ConfigItem map[string]interface{}) {
+		ipv4ConfigItem["should_assign_ip"] = value
+	})
+}
+
+func forEachFlattenedMap(value interface{}, fn func(map[string]interface{})) {
+	switch items := value.(type) {
+	case []interface{}:
+		for _, item := range items {
+			if itemMap, ok := item.(map[string]interface{}); ok {
+				fn(itemMap)
+			}
+		}
+	case []map[string]interface{}:
+		for _, itemMap := range items {
+			fn(itemMap)
+		}
+	}
 }
 
 func flattenEmulatedNic(pr *config.EmulatedNic) []map[string]interface{} {

--- a/nutanix/services/vmmv2/data_source_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/data_source_nutanix_virtual_machine_v2.go
@@ -2523,7 +2523,6 @@ func flattenNicWithResourceData(nic []config.Nic, d *schema.ResourceData) []inte
 			}
 
 			if shouldAssignIP, ok := configuredShouldAssignIP(d, k); ok {
-				setShouldAssignIPInFlattenedNetworkInfo(nics["network_info"], shouldAssignIP)
 				setShouldAssignIPInFlattenedNicNetworkInfo(nics["nic_network_info"], shouldAssignIP)
 			}
 
@@ -2554,9 +2553,6 @@ func configuredShouldAssignIP(d *schema.ResourceData, nicIndex int) (bool, bool)
 		return false, false
 	}
 
-	if value, ok := configuredShouldAssignIPFromLegacyNetworkInfo(nicConfigs[nicIndex]); ok {
-		return value, true
-	}
 	return configuredShouldAssignIPFromNicNetworkInfo(nicConfigs[nicIndex])
 }
 
@@ -2584,9 +2580,6 @@ func configuredShouldAssignIPFromState(nics interface{}, nicIndex int) (bool, bo
 }
 
 func configuredShouldAssignIPFromFlattenedNic(nic map[string]interface{}) (bool, bool) {
-	if value, ok := configuredShouldAssignIPFromFlattenedNetworkInfo(nic["network_info"]); ok {
-		return value, true
-	}
 	return configuredShouldAssignIPFromFlattenedNicNetworkInfo(nic["nic_network_info"])
 }
 
@@ -2627,14 +2620,6 @@ func configuredShouldAssignIPFromFlattenedNetworkInfo(networkInfo interface{}) (
 		})
 	})
 	return result, found
-}
-
-func configuredShouldAssignIPFromLegacyNetworkInfo(nicConfig cty.Value) (bool, bool) {
-	networkInfo, ok := rawConfigAttribute(nicConfig, "network_info")
-	if !ok {
-		return false, false
-	}
-	return configuredShouldAssignIPFromNetworkInfoList(networkInfo)
 }
 
 func configuredShouldAssignIPFromNicNetworkInfo(nicConfig cty.Value) (bool, bool) {

--- a/nutanix/services/vmmv2/data_source_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/data_source_nutanix_virtual_machine_v2.go
@@ -2541,7 +2541,7 @@ func configuredShouldAssignIP(d *schema.ResourceData, nicIndex int) (bool, bool)
 
 	rawConfig := d.GetRawConfig()
 	if rawConfig.IsNull() || !rawConfig.IsKnown() || rawConfig.Type() == cty.NilType {
-		return false, false
+		return configuredShouldAssignIPFromState(d.Get("nics"), nicIndex)
 	}
 
 	nics, ok := rawConfigAttribute(rawConfig, "nics")
@@ -2558,6 +2558,75 @@ func configuredShouldAssignIP(d *schema.ResourceData, nicIndex int) (bool, bool)
 		return value, true
 	}
 	return configuredShouldAssignIPFromNicNetworkInfo(nicConfigs[nicIndex])
+}
+
+func configuredShouldAssignIPFromState(nics interface{}, nicIndex int) (bool, bool) {
+	if nicIndex < 0 {
+		return false, false
+	}
+
+	switch nicList := nics.(type) {
+	case []interface{}:
+		if nicIndex >= len(nicList) {
+			return false, false
+		}
+		if nic, ok := nicList[nicIndex].(map[string]interface{}); ok {
+			return configuredShouldAssignIPFromFlattenedNic(nic)
+		}
+	case []map[string]interface{}:
+		if nicIndex >= len(nicList) {
+			return false, false
+		}
+		return configuredShouldAssignIPFromFlattenedNic(nicList[nicIndex])
+	}
+
+	return false, false
+}
+
+func configuredShouldAssignIPFromFlattenedNic(nic map[string]interface{}) (bool, bool) {
+	if value, ok := configuredShouldAssignIPFromFlattenedNetworkInfo(nic["network_info"]); ok {
+		return value, true
+	}
+	return configuredShouldAssignIPFromFlattenedNicNetworkInfo(nic["nic_network_info"])
+}
+
+func configuredShouldAssignIPFromFlattenedNicNetworkInfo(nicNetworkInfo interface{}) (bool, bool) {
+	var result bool
+	found := false
+	forEachFlattenedMap(nicNetworkInfo, func(nicNetworkInfoItem map[string]interface{}) {
+		if found {
+			return
+		}
+		for _, networkInfoKey := range []string{"virtual_ethernet_nic_network_info", "dp_offload_nic_network_info"} {
+			value, ok := configuredShouldAssignIPFromFlattenedNetworkInfo(nicNetworkInfoItem[networkInfoKey])
+			if ok {
+				result = value
+				found = true
+				return
+			}
+		}
+	})
+	return result, found
+}
+
+func configuredShouldAssignIPFromFlattenedNetworkInfo(networkInfo interface{}) (bool, bool) {
+	var result bool
+	found := false
+	forEachFlattenedMap(networkInfo, func(networkInfoItem map[string]interface{}) {
+		if found {
+			return
+		}
+		forEachFlattenedMap(networkInfoItem["ipv4_config"], func(ipv4ConfigItem map[string]interface{}) {
+			if found {
+				return
+			}
+			if shouldAssignIP, ok := ipv4ConfigItem["should_assign_ip"].(bool); ok {
+				result = shouldAssignIP
+				found = true
+			}
+		})
+	})
+	return result, found
 }
 
 func configuredShouldAssignIPFromLegacyNetworkInfo(nicConfig cty.Value) (bool, bool) {
@@ -2616,14 +2685,23 @@ func setShouldAssignIPInFlattenedNicNetworkInfo(nicNetworkInfo interface{}, valu
 
 func setShouldAssignIPInFlattenedNetworkInfo(networkInfo interface{}, value bool) {
 	forEachFlattenedMap(networkInfo, func(networkInfoItem map[string]interface{}) {
-		setShouldAssignIPInFlattenedIPv4Config(networkInfoItem["ipv4_config"], value)
+		if !setShouldAssignIPInFlattenedIPv4Config(networkInfoItem["ipv4_config"], value) {
+			networkInfoItem["ipv4_config"] = []interface{}{
+				map[string]interface{}{
+					"should_assign_ip": value,
+				},
+			}
+		}
 	})
 }
 
-func setShouldAssignIPInFlattenedIPv4Config(ipv4Config interface{}, value bool) {
+func setShouldAssignIPInFlattenedIPv4Config(ipv4Config interface{}, value bool) bool {
+	updated := false
 	forEachFlattenedMap(ipv4Config, func(ipv4ConfigItem map[string]interface{}) {
 		ipv4ConfigItem["should_assign_ip"] = value
+		updated = true
 	})
+	return updated
 }
 
 func forEachFlattenedMap(value interface{}, fn func(map[string]interface{})) {

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -3638,7 +3638,7 @@ func setVMConfig(d *schema.ResourceData, getResp config.Vm) diag.Diagnostics {
 		return diags
 	}
 	for k, v := range fields {
-		if k == "disks" {
+		if k == "disks" || k == "nics" {
 			continue
 		}
 		if err := d.Set(k, v); err != nil {
@@ -3751,7 +3751,7 @@ func setVMConfig(d *schema.ResourceData, getResp config.Vm) diag.Diagnostics {
 	if err := d.Set("cd_roms", flattenCdRom(getResp.CdRoms)); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("nics", flattenNic(getResp.Nics)); err != nil {
+	if err := d.Set("nics", flattenNicWithResourceData(getResp.Nics, d)); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("gpus", flattenGpu(getResp.Gpus)); err != nil {

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2_test.go
@@ -184,6 +184,31 @@ func TestAccV2NutanixVmsResource_WithNic(t *testing.T) {
 	})
 }
 
+func TestAccV2NutanixVmsResource_WithNicShouldAssignIP(t *testing.T) {
+	r := acctest.RandInt()
+	desc := "test vm description"
+	config := testVmsV4ConfigWithNicShouldAssignIP(r, desc, false)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckNutanixVmsResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameVms, "name", fmt.Sprintf("tf-test-vm-%d", r)),
+					resource.TestCheckResourceAttr(resourceNameVms, "nics.0.nic_network_info.0.virtual_ethernet_nic_network_info.0.ipv4_config.0.should_assign_ip", "false"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccV2NutanixVmsResource_WithNicTrunk(t *testing.T) {
 	r := acctest.RandInt()
 	desc := "test vm description"
@@ -1399,6 +1424,69 @@ func testVmsV4ConfigWithNic(r int, desc string, isConnected bool) string {
 			power_state = "ON"
 		}
 `, r, desc, filepath, isConnected)
+}
+
+func testVmsV4ConfigWithNicShouldAssignIP(r int, desc string, shouldAssignIP bool) string {
+	return fmt.Sprintf(`
+		data "nutanix_clusters_v2" "clusters" {}
+
+		locals {
+			cluster0 = [
+			for cluster in data.nutanix_clusters_v2.clusters.cluster_entities :
+			cluster.ext_id if cluster.config[0].cluster_function[0] != "PRISM_CENTRAL"
+		  ][0]
+			config = jsondecode(file("%[3]s"))
+			vmm = local.config.vmm
+		}
+
+		data "nutanix_subnets_v2" "subnets" {
+			filter = "name eq '${local.vmm.subnet_name}'"
+		}
+
+		data "nutanix_storage_containers_v2" "ngt-sc" {
+		  filter = "clusterExtId eq '${local.cluster0}' and startswith(name,'default-container-')"
+		  limit = 1
+		}
+
+		resource "nutanix_virtual_machine_v2" "test"{
+			name= "tf-test-vm-%[1]d"
+			description =  "%[2]s"
+			num_cores_per_socket = 1
+			num_sockets = 1
+			cluster {
+				ext_id = local.cluster0
+			}
+			disks{
+				disk_address{
+					bus_type = "SCSI"
+					index = 0
+				}
+				backing_info{
+					vm_disk{
+						disk_size_bytes = "1073741824"
+						storage_container{
+							ext_id = data.nutanix_storage_containers_v2.ngt-sc.storage_containers[0].ext_id
+						}
+					}
+				}
+			}
+			nics{
+				nic_network_info{
+					virtual_ethernet_nic_network_info{
+						nic_type = "NORMAL_NIC"
+						subnet{
+							ext_id = data.nutanix_subnets_v2.subnets.subnets[0].ext_id
+						}
+						vlan_mode = "ACCESS"
+						ipv4_config {
+							should_assign_ip = %[4]t
+						}
+					}
+				}
+			}
+			power_state = "OFF"
+		}
+`, r, desc, filepath, shouldAssignIP)
 }
 
 func testVmsV4ConfigWithNicWithTrunkVlan(r int, desc string) string {


### PR DESCRIPTION
## Summary
- Preserve configured `should_assign_ip` values when flattening VM v2 NIC state.
- Skip the generic `nics` field update in `setVMConfig` and set it explicitly using resource data-aware flattening.
- Support both legacy `network_info` and newer `nic_network_info` shapes when restoring `should_assign_ip`.