### PR TITLE
 NGT ISO INSERT eject should be a no-op if iso eject is already done as part of NGT installation, custom eject.

### DIFF
--- a/nutanix/services/vmmv2/resource_nutanix_ngt_insert_iso_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_ngt_insert_iso_v2.go
@@ -299,7 +299,7 @@ func ResourceNutanixNGTInsertIsoV2Update(ctx context.Context, d *schema.Resource
 func ResourceNutanixNGTInsertIsoV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] ResourceNutanixNGTInsertIsoV2Delete : Ejecting NGT ISO from the CD-ROM %s of the VM %s", d.Get("cdrom_ext_id").(string), d.Get("vm_ext_id").(string))
 
-	if cdromExtID, cdromExists := d.GetOk("cdrom_ext_id")
+	cdromExtID, cdromExists := d.GetOk("cdrom_ext_id")
 	if action, ok := d.GetOk("action"); ok && action.(string) == "eject" || !cdromExists || cdromExtID.(string) == ""  {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,

--- a/nutanix/services/vmmv2/resource_nutanix_ngt_insert_iso_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_ngt_insert_iso_v2.go
@@ -298,7 +298,9 @@ func ResourceNutanixNGTInsertIsoV2Update(ctx context.Context, d *schema.Resource
 // ResourceNutanixNGTInsertIsoV2Delete eject the ngt iso from the cd-rom of the vm
 func ResourceNutanixNGTInsertIsoV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] ResourceNutanixNGTInsertIsoV2Delete : Ejecting NGT ISO from the CD-ROM %s of the VM %s", d.Get("cdrom_ext_id").(string), d.Get("vm_ext_id").(string))
-	if action, ok := d.GetOk("action"); ok && action.(string) == "eject" {
+
+	if cdromExtID, cdromExists := d.GetOk("cdrom_ext_id")
+	if action, ok := d.GetOk("action"); ok && action.(string) == "eject" || !cdromExists || cdromExtID.(string) == ""  {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "NGT ISO is not inserted on the CD-ROM of the VM or ejected earlier using an action, Ignoring the request to eject the NGT ISO",
@@ -308,10 +310,18 @@ func ResourceNutanixNGTInsertIsoV2Delete(ctx context.Context, d *schema.Resource
 }
 
 func ejectCdromISO(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	log.Printf("[DEBUG] Ejecting ISO from the CD-ROM %s of the VM %s", d.Get("cdrom_ext_id").(string), d.Get("vm_ext_id").(string))
 	conn := meta.(*conns.Client).VmmAPI
 	vmExtID := d.Get("vm_ext_id").(string)
-	extID := d.Get("cdrom_ext_id").(string)
+	cdromVal, cdromExists := d.GetOk("cdrom_ext_id")
+	if !cdromExists || cdromVal == nil || cdromVal.(string) == "" {
+		log.Printf("[DEBUG] ejectCdromISO: cdrom_ext_id is empty or not set, ISO was already ejected. Skipping.")
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "NGT ISO was already ejected (cdrom_ext_id is empty), skipping eject operation",
+		}}
+	}
+	extID := cdromVal.(string)
+	log.Printf("[DEBUG] Ejecting ISO from the CD-ROM %s of the VM %s", extID, vmExtID)
 
 	ejectCdRomByIdRequest := import3.EjectCdRomByIdRequest{
 		VmExtId: utils.StringPtr(vmExtID),

--- a/nutanix/services/vmmv2/resource_nutanix_ngt_insert_iso_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_ngt_insert_iso_v2.go
@@ -300,7 +300,7 @@ func ResourceNutanixNGTInsertIsoV2Delete(ctx context.Context, d *schema.Resource
 	log.Printf("[DEBUG] ResourceNutanixNGTInsertIsoV2Delete : Ejecting NGT ISO from the CD-ROM %s of the VM %s", d.Get("cdrom_ext_id").(string), d.Get("vm_ext_id").(string))
 
 	cdromExtID, cdromExists := d.GetOk("cdrom_ext_id")
-	if action, ok := d.GetOk("action"); ok && action.(string) == "eject" || !cdromExists || cdromExtID.(string) == ""  {
+	if action, ok := d.GetOk("action"); ok && action.(string) == "eject" || !cdromExists || cdromExtID.(string) == "" {
 		return diag.Diagnostics{{
 			Severity: diag.Warning,
 			Summary:  "NGT ISO is not inserted on the CD-ROM of the VM or ejected earlier using an action, Ignoring the request to eject the NGT ISO",


### PR DESCRIPTION
Fix:
   NGT ISO INSERT eject should be a no-op if iso eject is already done as part of NGT installation, custom eject.
   
 
 Tests:
Upgrade scenario — Insert + NGT Installed → Destroy

User inserted NGT ISO, NGT got installed (which auto-ejects the ISO from the CD-ROM), then upgraded to the latest provider version, then runs terraform destroy.
cdrom_ext_id becomes empty after Read (no GuestTools CD-ROM found on the VM).
Expected: Delete returns a warning and skips the eject gracefully.
Upgrade scenario — Insert + No Installation → Destroy

User inserted NGT ISO but never installed NGT (ISO is still mounted in the CD-ROM), then upgraded to the latest provider version, then runs terraform destroy.
cdrom_ext_id gets populated from the VM's CD-ROM with iso_type == GUEST_TOOLS.
Expected: Delete calls ejectCdromISO successfully and ejects the ISO.
Greenfield — Insert + NGT Installed → Destroy

Fresh setup with latest provider. User inserts ISO, NGT installs (auto-ejects ISO), then runs terraform destroy.
cdrom_ext_id is in state from Create (stale, but still valid CD-ROM device).
Expected: EjectCdRomById API handles this as a no-op since the CD-ROM is already empty.
Greenfield — Insert + No Installation → Destroy

Fresh setup with latest provider. User inserts ISO, does NOT install NGT, then runs terraform destroy.
cdrom_ext_id is valid and ISO is still mounted.
Expected: Delete calls ejectCdromISO and the API ejects the ISO successfully.
