### PR TITLE
fix(clustersv2): change management_server.type to TypeString and flatten properly

### DIFF
--- a/nutanix/services/clustersv2/data_source_nutanix_cluster_entity_v2.go
+++ b/nutanix/services/clustersv2/data_source_nutanix_cluster_entity_v2.go
@@ -171,7 +171,7 @@ func DatasourceNutanixClusterEntityV2() *schema.Resource {
 										Elem:     common.SchemaForIPList(false),
 									},
 									"type": {
-										Type:     schema.TypeBool,
+										Type:     schema.TypeString,
 										Computed: true,
 									},
 									"is_drs_enabled": {
@@ -816,7 +816,7 @@ func flattenManagementServerRef(pr *import1.ManagementServerRef) []map[string]in
 		mgm := make(map[string]interface{})
 
 		mgm["ip"] = flattenIPAddress(pr.Ip)
-		mgm["type"] = pr.Type
+		mgm["type"] = common.FlattenPtrEnum(pr.Type)
 		mgm["is_drs_enabled"] = pr.IsDrsEnabled
 		mgm["is_registered"] = pr.IsRegistered
 		mgm["is_in_use"] = pr.IsInUse


### PR DESCRIPTION
## Problem
In `nutanix_clusters_v2` and `nutanix_cluster_v2` data sources, reading clusters with a management server (e.g. ESX clusters with vCenter) fails with:
```
Error: cluster_entities.2.network.0.management_server.0.type: '' expected type 'bool', got unconvertible type 'config.ManagementServerType'
```

## Solution
1. Changed `management_server.type` schema definition from `schema.TypeBool` to `schema.TypeString`.
2. Flattened `pr.Type` using `common.FlattenPtrEnum(pr.Type)` consistent with enum handling throughout the v2 providers.

Fixes #1229

## Testing
- Verified with `go test -v ./nutanix/services/clustersv2/...` and full package compilation.
- Clean diff and full type compatibility.