### PR TITLE
fix(vmmv2): restore temporary If-Match/eTag for VM ops that still require it

### DIFF
--- a/nutanix/services/iamv2/resource_nutanix_authorization_policies_v2.go
+++ b/nutanix/services/iamv2/resource_nutanix_authorization_policies_v2.go
@@ -17,6 +17,7 @@ import (
 	import1 "github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4/models/iam/v4/authz"
 	import2 "github.com/nutanix/ntnx-api-golang-clients/iam-go-client/v4/models/iam/v4/request/authorizationpolicies"
 	conns "github.com/terraform-providers/terraform-provider-nutanix/nutanix"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/common"
 	"github.com/terraform-providers/terraform-provider-nutanix/utils"
 )
 
@@ -103,6 +104,11 @@ func ResourceNutanixAuthPoliciesV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"is_global": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 			"created_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -173,25 +179,22 @@ func ResourceNutanixAuthPoliciesV2Create(ctx context.Context, d *schema.Resource
 		input.Role = utils.StringPtr(role.(string))
 	}
 	if authPolicyType, ok := d.GetOk("authorization_policy_type"); ok {
-		const two, three, four, five, six = 2, 3, 4, 5, 6
-		subMap := map[string]interface{}{
-			"USER_DEFINED":                    two,
-			"SERVICE_DEFINED":                 three,
-			"PREDEFINED_READ_ONLY":            four,
-			"PREDEFINED_UPDATE_IDENTITY_ONLY": five,
-			"SERVICE_DEFINED_READ_ONLY":       six,
-		}
-		pInt := subMap[authPolicyType.(string)]
-		p := import1.AuthorizationPolicyType(pInt.(int))
-		input.AuthorizationPolicyType = &p
+		input.AuthorizationPolicyType = common.ExpandEnum[import1.AuthorizationPolicyType](authPolicyType.(string))
 	}
 	if projectExtID, ok := d.GetOk("project_ext_id"); ok {
 		input.ProjectExtId = utils.StringPtr(projectExtID.(string))
+	}
+	if common.IsExplicitlySet(d, "is_global") {
+		input.IsGlobal = utils.BoolPtr(d.Get("is_global").(bool))
 	}
 
 	createAuthorizationPolicyRequest := import2.CreateAuthorizationPolicyRequest{
 		Body: input,
 	}
+
+	aJSON, _ := json.MarshalIndent(createAuthorizationPolicyRequest, "", "  ")
+	log.Printf("[DEBUG] Create Authorization Policy Request Body: %s", string(aJSON))
+
 	resp, err := conn.AuthAPIInstance.CreateAuthorizationPolicy(ctx, &createAuthorizationPolicyRequest)
 	if err != nil {
 		return diag.Errorf("error while creating authorization policies : %v", err)
@@ -313,26 +316,24 @@ func ResourceNutanixAuthPoliciesV2Update(ctx context.Context, d *schema.Resource
 		updatedSpec.Role = utils.StringPtr(d.Get("role").(string))
 	}
 	if d.HasChange("authorization_policy_type") {
-		const two, three, four, five, six = 2, 3, 4, 5, 6
-		subMap := map[string]interface{}{
-			"USER_DEFINED":                    two,
-			"SERVICE_DEFINED":                 three,
-			"PREDEFINED_READ_ONLY":            four,
-			"PREDEFINED_UPDATE_IDENTITY_ONLY": five,
-			"SERVICE_DEFINED_READ_ONLY":       six,
-		}
-		pInt := subMap[d.Get("authorization_policy_type").(string)]
-		p := import1.AuthorizationPolicyType(pInt.(int))
-		updatedSpec.AuthorizationPolicyType = &p
+		updatedSpec.AuthorizationPolicyType = common.ExpandEnum[import1.AuthorizationPolicyType](d.Get("authorization_policy_type").(string))
 	}
 	if d.HasChange("project_ext_id") {
 		return diag.Errorf("error while updating project_ext_id: Update of project_ext_id is not supported")
+	}
+	if d.HasChange("is_global") && common.IsExplicitlySet(d, "is_global") {
+		updatedSpec.IsGlobal = utils.BoolPtr(d.Get("is_global").(bool))
+	} else {
+		updatedSpec.IsGlobal = nil
 	}
 
 	updateAuthorizationPolicyByIdRequest := import2.UpdateAuthorizationPolicyByIdRequest{
 		ExtId: utils.StringPtr(d.Id()),
 		Body:  &updatedSpec,
 	}
+	aJSON, _ := json.MarshalIndent(updateAuthorizationPolicyByIdRequest, "", "  ")
+	log.Printf("[DEBUG] Update Authorization Policy Request Body: %s", string(aJSON))
+
 	updatedResp, err := conn.AuthAPIInstance.UpdateAuthorizationPolicyById(ctx, &updateAuthorizationPolicyByIdRequest, headers)
 	if err != nil {
 		return diag.Errorf("error while updating  Authorization Policy: %v", err)

--- a/nutanix/services/prismv2/resource_nutanix_pc_registration_v2.go
+++ b/nutanix/services/prismv2/resource_nutanix_pc_registration_v2.go
@@ -300,7 +300,7 @@ func ResourceNutanixClusterPCRegistrationV2Create(ctx context.Context, d *schema
 
 	body.RemoteCluster = remoteClusterBodySpec
 
-	aJSON, _ := json.Marshal(body)
+	aJSON, _ := json.MarshalIndent(body, "", "  ")
 	log.Printf("[DEBUG] PC Registration Request Body: %s", string(aJSON))
 
 	registerRequest := import3.RegisterRequest{

--- a/nutanix/services/vmmv2/helper.go
+++ b/nutanix/services/vmmv2/helper.go
@@ -99,7 +99,11 @@ func ApplyDiskDeletions(ctx context.Context, d *schema.ResourceData, meta interf
 			VmExtId: utils.StringPtr(vmID),
 			ExtId:   diskExtID,
 		}
-		resp, err := conn.VMAPIInstance.DeleteDiskById(ctx, &deleteDiskByIdRequest)
+		args, err := vmEtagArgs(ctx, conn, vmID)
+		if err != nil {
+			return diag.Errorf("error while fetching VM eTag for disk delete: %v", err)
+		}
+		resp, err := conn.VMAPIInstance.DeleteDiskById(ctx, &deleteDiskByIdRequest, args)
 		if err != nil {
 			return diag.Errorf("error while deleting Disk : %v", err)
 		}
@@ -169,7 +173,11 @@ func ApplyDiskAdditions(ctx context.Context, d *schema.ResourceData, meta interf
 			VmExtId: utils.StringPtr(vmID),
 			Body:    &diskInput,
 		}
-		resp, err := conn.VMAPIInstance.CreateDisk(ctx, &createDiskRequest)
+		args, err := vmEtagArgs(ctx, conn, vmID)
+		if err != nil {
+			return diag.Errorf("error while fetching VM eTag for disk create: %v", err)
+		}
+		resp, err := conn.VMAPIInstance.CreateDisk(ctx, &createDiskRequest, args)
 		if err != nil {
 			return diag.Errorf("error while creating Disk : %v", err)
 		}

--- a/nutanix/services/vmmv2/resource_nutanix_ngt_insert_iso_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_ngt_insert_iso_v2.go
@@ -327,7 +327,11 @@ func ejectCdromISO(ctx context.Context, d *schema.ResourceData, meta interface{}
 		VmExtId: utils.StringPtr(vmExtID),
 		ExtId:   utils.StringPtr(extID),
 	}
-	resp, err := conn.VMAPIInstance.EjectCdRomById(ctx, &ejectCdRomByIdRequest)
+	args, err := vmEtagArgs(ctx, conn, vmExtID)
+	if err != nil {
+		return diag.Errorf("error while fetching VM eTag for cd-rom eject: %v", err)
+	}
+	resp, err := conn.VMAPIInstance.EjectCdRomById(ctx, &ejectCdRomByIdRequest, args)
 	if err != nil {
 		return diag.Errorf("error while ejecting cd-rom : %v", err)
 	}

--- a/nutanix/services/vmmv2/resource_nutanix_ova_vm_deploy_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_ova_vm_deploy_v2.go
@@ -567,7 +567,11 @@ func ResourceNutanixOvaVMDeploymentCreate(ctx context.Context, d *schema.Resourc
 							VmExtId: utils.StringPtr(d.Id()),
 							Body:    &diskInput,
 						}
-						resp, err := conn.VMAPIInstance.CreateDisk(ctx, &createDiskRequest)
+						args, err := vmEtagArgs(ctx, conn, d.Id())
+						if err != nil {
+							return diag.Errorf("error while fetching VM eTag for disk create: %v", err)
+						}
+						resp, err := conn.VMAPIInstance.CreateDisk(ctx, &createDiskRequest, args)
 						if err != nil {
 							return diag.Errorf("error creating disk: %v", err)
 						}
@@ -731,7 +735,11 @@ func ResourceNutanixOvaVMDeploymentDelete(ctx context.Context, d *schema.Resourc
 	deleteVmByIdRequest := import7.DeleteVmByIdRequest{
 		ExtId: utils.StringPtr(d.Id()),
 	}
-	resp, err := conn.VMAPIInstance.DeleteVmById(ctx, &deleteVmByIdRequest)
+	args, err := vmEtagArgs(ctx, conn, d.Id())
+	if err != nil {
+		return diag.Errorf("error while fetching VM eTag for delete: %v", err)
+	}
+	resp, err := conn.VMAPIInstance.DeleteVmById(ctx, &deleteVmByIdRequest, args)
 	if err != nil {
 		return diag.Errorf("error while deleting vm : %v", err)
 	}
@@ -870,24 +878,16 @@ func handlePowerStateChanges(ctx context.Context, d *schema.ResourceData, meta i
 
 		switch newPowerState {
 		case "ON":
-			powerOnVmRequest := import7.PowerOnVmRequest{
-				ExtId: utils.StringPtr(d.Id()),
-			}
-			powerResp, err := vmmConn.VMAPIInstance.PowerOnVm(ctx, &powerOnVmRequest)
+			TaskRef, err := powerOnVMWithEtag(ctx, vmmConn, utils.StringPtr(d.Id()))
 			if err != nil {
 				return diag.Errorf("error powering on VM: %v", err)
 			}
-			TaskRef := powerResp.Data.GetValue().(import3.TaskReference)
 			taskUUID = TaskRef.ExtId
 		case "OFF":
-			powerOffVmRequest := import7.PowerOffVmRequest{
-				ExtId: utils.StringPtr(d.Id()),
-			}
-			powerResp, err := vmmConn.VMAPIInstance.PowerOffVm(ctx, &powerOffVmRequest)
+			TaskRef, err := powerOffVMWithEtag(ctx, vmmConn, utils.StringPtr(d.Id()))
 			if err != nil {
 				return diag.Errorf("error powering off VM: %v", err)
 			}
-			TaskRef := powerResp.Data.GetValue().(import3.TaskReference)
 			taskUUID = TaskRef.ExtId
 		default:
 			return diag.Errorf("unsupported power state: %s", newPowerState)

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -1693,7 +1693,11 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 					VmExtId: utils.StringPtr(d.Id()),
 					ExtId:   nicExtID,
 				}
-				resp, err := conn.VMAPIInstance.DeleteNicById(ctx, &deleteNicByIdRequest)
+				args, err := vmEtagArgs(ctx, conn, d.Id())
+				if err != nil {
+					return diag.Errorf("error while fetching VM eTag for nic delete: %v", err)
+				}
+				resp, err := conn.VMAPIInstance.DeleteNicById(ctx, &deleteNicByIdRequest, args)
 				if err != nil {
 					return diag.Errorf("error while deleting nic : %v", err)
 				}
@@ -1784,7 +1788,11 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 					VmExtId: utils.StringPtr(d.Id()),
 					Body:    &nicInput,
 				}
-				resp, err := conn.VMAPIInstance.CreateNic(ctx, &createNicRequest)
+				args, err := vmEtagArgs(ctx, conn, d.Id())
+				if err != nil {
+					return diag.Errorf("error while fetching VM eTag for nic create: %v", err)
+				}
+				resp, err := conn.VMAPIInstance.CreateNic(ctx, &createNicRequest, args)
 				if err != nil {
 					return diag.Errorf("error while creating NIC : %v", err)
 				}
@@ -1818,7 +1826,11 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 					VmExtId: utils.StringPtr(d.Id()),
 					Body:    &cdromInput,
 				}
-				resp, err := conn.VMAPIInstance.CreateCdRom(ctx, &createCdRomRequest)
+				args, err := vmEtagArgs(ctx, conn, d.Id())
+				if err != nil {
+					return diag.Errorf("error while fetching VM eTag for CdRom create: %v", err)
+				}
+				resp, err := conn.VMAPIInstance.CreateCdRom(ctx, &createCdRomRequest, args)
 				if err != nil {
 					return diag.Errorf("error while creating CdRom : %v", err)
 				}
@@ -1850,7 +1862,11 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 					VmExtId: utils.StringPtr(d.Id()),
 					ExtId:   cdromExtID,
 				}
-				resp, err := conn.VMAPIInstance.DeleteCdRomById(ctx, &deleteCdRomByIdRequest)
+				args, err := vmEtagArgs(ctx, conn, d.Id())
+				if err != nil {
+					return diag.Errorf("error while fetching VM eTag for CdRom delete: %v", err)
+				}
+				resp, err := conn.VMAPIInstance.DeleteCdRomById(ctx, &deleteCdRomByIdRequest, args)
 				if err != nil {
 					return diag.Errorf("error while deleting cdrom : %v", err)
 				}
@@ -1887,7 +1903,11 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 					VmExtId: utils.StringPtr(d.Id()),
 					ExtId:   serialPortExtID,
 				}
-				resp, err := conn.VMAPIInstance.DeleteSerialPortById(ctx, &deleteSerialPortByIdRequest)
+				args, err := vmEtagArgs(ctx, conn, d.Id())
+				if err != nil {
+					return diag.Errorf("error while fetching VM eTag for serial port delete: %v", err)
+				}
+				resp, err := conn.VMAPIInstance.DeleteSerialPortById(ctx, &deleteSerialPortByIdRequest, args)
 				if err != nil {
 					return diag.Errorf("error while deleting serial port : %v", err)
 				}
@@ -1958,7 +1978,11 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 					VmExtId: utils.StringPtr(d.Id()),
 					Body:    &serialPortInput,
 				}
-				resp, err := conn.VMAPIInstance.CreateSerialPort(ctx, &createSerialPortRequest)
+				args, err := vmEtagArgs(ctx, conn, d.Id())
+				if err != nil {
+					return diag.Errorf("error while fetching VM eTag for serial port create: %v", err)
+				}
+				resp, err := conn.VMAPIInstance.CreateSerialPort(ctx, &createSerialPortRequest, args)
 				if err != nil {
 					return diag.Errorf("error while creating SerialPort : %v", err)
 				}
@@ -1993,7 +2017,11 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 					VmExtId: utils.StringPtr(d.Id()),
 					Body:    &gpuInput,
 				}
-				resp, err := conn.VMAPIInstance.CreateGpu(ctx, &createGpuRequest)
+				args, err := vmEtagArgs(ctx, conn, d.Id())
+				if err != nil {
+					return diag.Errorf("error while fetching VM eTag for Gpu create: %v", err)
+				}
+				resp, err := conn.VMAPIInstance.CreateGpu(ctx, &createGpuRequest, args)
 				if err != nil {
 					return diag.Errorf("error while creating Gpu : %v", err)
 				}
@@ -2025,7 +2053,11 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 					VmExtId: utils.StringPtr(d.Id()),
 					ExtId:   gpuExtID,
 				}
-				resp, err := conn.VMAPIInstance.DeleteGpuById(ctx, &deleteGpuByIdRequest)
+				args, err := vmEtagArgs(ctx, conn, d.Id())
+				if err != nil {
+					return diag.Errorf("error while fetching VM eTag for Gpu delete: %v", err)
+				}
+				resp, err := conn.VMAPIInstance.DeleteGpuById(ctx, &deleteGpuByIdRequest, args)
 				if err != nil {
 					return diag.Errorf("error while deleting gpu : %v", err)
 				}
@@ -2063,7 +2095,11 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 				ExtId: utils.StringPtr(d.Id()),
 				Body:  &body,
 			}
-			resp, err := conn.VMAPIInstance.DisassociateCategories(ctx, &disassociateCategoriesRequest)
+			args, err := vmEtagArgs(ctx, conn, d.Id())
+			if err != nil {
+				return diag.Errorf("error while fetching VM eTag for categories disassociate: %v", err)
+			}
+			resp, err := conn.VMAPIInstance.DisassociateCategories(ctx, &disassociateCategoriesRequest, args)
 			if err != nil {
 				return diag.Errorf("error while diassociate categories : %v", err)
 			}
@@ -2094,7 +2130,11 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 				ExtId: utils.StringPtr(d.Id()),
 				Body:  &body,
 			}
-			resp, err := conn.VMAPIInstance.AssociateCategories(ctx, &associateCategoriesRequest)
+			args, err := vmEtagArgs(ctx, conn, d.Id())
+			if err != nil {
+				return diag.Errorf("error while fetching VM eTag for categories associate: %v", err)
+			}
+			resp, err := conn.VMAPIInstance.AssociateCategories(ctx, &associateCategoriesRequest, args)
 			if err != nil {
 				return diag.Errorf("error while associating categories : %v", err)
 			}
@@ -2154,7 +2194,11 @@ func ResourceNutanixVirtualMachineV2Delete(ctx context.Context, d *schema.Resour
 	deleteVmByIdRequest := import3.DeleteVmByIdRequest{
 		ExtId: utils.StringPtr(d.Id()),
 	}
-	resp, err := conn.VMAPIInstance.DeleteVmById(ctx, &deleteVmByIdRequest)
+	args, err := vmEtagArgs(ctx, conn, d.Id())
+	if err != nil {
+		return diag.Errorf("error while fetching VM eTag for delete: %v", err)
+	}
+	resp, err := conn.VMAPIInstance.DeleteVmById(ctx, &deleteVmByIdRequest, args)
 	if err != nil {
 		return diag.Errorf("error while deleting vm : %v", err)
 	}
@@ -3059,40 +3103,18 @@ func extractTaskReferenceFromResponse(resp interface{}) (import1.TaskReference, 
 	return taskRef, nil
 }
 
-// powerOnVM performs a single power-on API call. Retries are handled at the task layer in callForPowerOnVM.
+// powerOnVM performs a single power-on API call with If-Match eTag.
+// Retries (API + task) are handled in callForPowerOnVM.
+// REMOVE_AFTER: v2.6.0 — drop eTag via powerOnVMWithEtag (see vm_etag_compat.go).
 func powerOnVM(ctx context.Context, conn *vmm.Client, vmID *string) (import1.TaskReference, error) {
-	powerOnVmRequest := import3.PowerOnVmRequest{
-		ExtId: vmID,
-	}
-	resp, err := conn.VMAPIInstance.PowerOnVm(ctx, &powerOnVmRequest)
-	if err != nil {
-		return import1.TaskReference{}, fmt.Errorf("error powering on VM: %v", err)
-	}
-
-	taskRef, err := extractTaskReferenceFromResponse(resp)
-	if err != nil {
-		return import1.TaskReference{}, fmt.Errorf("error extracting task reference from power on response: %v", err)
-	}
-	log.Printf("[DEBUG] PowerOn Response: TaskReference ExtId: %s", utils.StringValue(taskRef.ExtId))
-	return taskRef, nil
+	return powerOnVMWithEtag(ctx, conn, vmID)
 }
 
-// powerOffVM performs a single power-off API call. Retries are handled at the task layer in callForPowerOffVM.
+// powerOffVM performs a single power-off API call with If-Match eTag.
+// Retries (API + task) are handled in callForPowerOffVM.
+// REMOVE_AFTER: v2.6.0 — drop eTag via powerOffVMWithEtag (see vm_etag_compat.go).
 func powerOffVM(ctx context.Context, conn *vmm.Client, vmID *string) (import1.TaskReference, error) {
-	powerOffVmRequest := import3.PowerOffVmRequest{
-		ExtId: vmID,
-	}
-	resp, err := conn.VMAPIInstance.PowerOffVm(ctx, &powerOffVmRequest)
-	if err != nil {
-		return import1.TaskReference{}, fmt.Errorf("error powering off VM: %v", err)
-	}
-
-	taskRef, err := extractTaskReferenceFromResponse(resp)
-	if err != nil {
-		return import1.TaskReference{}, fmt.Errorf("error extracting task reference from power off response: %v", err)
-	}
-	log.Printf("[DEBUG] PowerOff Response: TaskReference ExtId: %s", utils.StringValue(taskRef.ExtId))
-	return taskRef, nil
+	return powerOffVMWithEtag(ctx, conn, vmID)
 }
 
 func flattenPowerState(pr *config.PowerState) string {
@@ -3114,51 +3136,167 @@ func flattenPowerState(pr *config.PowerState) string {
 	return "UNKNOWN"
 }
 
+// callForPowerOffVM retries power-off API + task wait, refreshing eTag each attempt.
+// REMOVE_AFTER: v2.6.0 — collapse to single-shot (see vm_etag_compat.go removal recipe).
 func callForPowerOffVM(ctx context.Context, conn *vmm.Client, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	prismConn := meta.(*conns.Client).PrismAPI
+	var lastErr error
+	var taskUUID *string
 
-	TaskRef, err := powerOffVM(ctx, conn, utils.StringPtr(d.Id()))
-	if err != nil {
-		return diag.Errorf("error while powering off Virtual Machine: %v", err)
-	}
-	taskUUID := TaskRef.ExtId
+	for taskAttempt := 0; taskAttempt < maxPowerRetries; taskAttempt++ {
+		getVmByIdRequest := import3.GetVmByIdRequest{
+			ExtId: utils.StringPtr(d.Id()),
+		}
+		readResp, errR := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+		if errR != nil {
+			return diag.Errorf("error while reading vm : %v", errR)
+		}
+		vmResp := readResp.Data.GetValue().(config.Vm)
+		currentPower := vmResp.PowerState.GetName()
+		log.Printf("[DEBUG] Power-off task attempt %d/%d: VM current power_state=%s", taskAttempt+1, maxPowerRetries, currentPower)
+		if currentPower == "OFF" {
+			log.Printf("[DEBUG] VM is already in OFF state")
+			return nil
+		}
 
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"PENDING", "RUNNING", "QUEUED"},
-		Target:  []string{"SUCCEEDED"},
-		Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, prismConn, utils.StringValue(taskUUID)),
-		Timeout: d.Timeout(schema.TimeoutCreate),
-	}
+		TaskRef, err := powerOffVM(ctx, conn, utils.StringPtr(d.Id()))
+		if err != nil {
+			lastErr = err
+			if taskAttempt < maxPowerRetries-1 {
+				log.Printf("[DEBUG] Power-off API failed (attempt %d/%d), retrying in %v: %v",
+					taskAttempt+1, maxPowerRetries, powerTaskRetryDelay, err)
+				select {
+				case <-ctx.Done():
+					return diag.FromErr(ctx.Err())
+				case <-time.After(powerTaskRetryDelay):
+					continue
+				}
+			}
+			return diag.Errorf("error while powering off Virtual Machine after %d attempts: %v", maxPowerRetries, err)
+		}
+		taskUUID = TaskRef.ExtId
 
-	if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
-		return diag.Errorf("error waiting for virtual machine (%s) to power off: %s",
-			utils.StringValue(taskUUID), errWaitTask)
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{"PENDING", "RUNNING", "QUEUED"},
+			Target:  []string{"SUCCEEDED"},
+			Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, prismConn, utils.StringValue(taskUUID)),
+			Timeout: d.Timeout(schema.TimeoutCreate),
+		}
+
+		_, errWaitTask := stateConf.WaitForStateContext(ctx)
+		if errWaitTask == nil {
+			log.Printf("[DEBUG] Power-off task reported SUCCEEDED for task %s; verifying VM power_state", utils.StringValue(taskUUID))
+			verifyReq := import3.GetVmByIdRequest{ExtId: utils.StringPtr(d.Id())}
+			verifyResp, errV := conn.VMAPIInstance.GetVmById(ctx, &verifyReq)
+			if errV != nil {
+				log.Printf("[DEBUG] Could not re-read VM after task success: %v", errV)
+				return nil
+			}
+			verifyVM := verifyResp.Data.GetValue().(config.Vm)
+			actualPower := verifyVM.PowerState.GetName()
+			log.Printf("[DEBUG] VM power_state after task: %s (expected OFF)", actualPower)
+			if actualPower != "OFF" {
+				log.Printf("[DEBUG] WARNING: Task reported SUCCEEDED but VM power_state is %s (expected OFF) - possible backend inconsistency or race", actualPower)
+			}
+			return nil
+		}
+		lastErr = errWaitTask
+		if taskAttempt < maxPowerRetries-1 {
+			log.Printf("[DEBUG] Power-off task failed or timed out (attempt %d/%d), retrying API call and task in %v: %v",
+				taskAttempt+1, maxPowerRetries, powerTaskRetryDelay, errWaitTask)
+			select {
+			case <-ctx.Done():
+				return diag.FromErr(ctx.Err())
+			case <-time.After(powerTaskRetryDelay):
+				// continue to next task retry
+			}
+		}
 	}
-	return nil
+	log.Printf("[DEBUG] Power-off failed after %d attempts; last error: %v", maxPowerRetries, lastErr)
+	return diag.Errorf("error waiting for virtual machine (%s) to power off after %d attempts: %s",
+		utils.StringValue(taskUUID), maxPowerRetries, lastErr)
 }
 
+// callForPowerOnVM retries power-on API + task wait, refreshing eTag each attempt.
+// REMOVE_AFTER: v2.6.0 — collapse to single-shot (see vm_etag_compat.go removal recipe).
 func callForPowerOnVM(ctx context.Context, conn *vmm.Client, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	prismConn := meta.(*conns.Client).PrismAPI
+	var lastErr error
+	var taskUUID *string
 
-	TaskRef, err := powerOnVM(ctx, conn, utils.StringPtr(d.Id()))
-	if err != nil {
-		return diag.Errorf("error while powering on Virtual Machine: %v", err)
-	}
-	taskUUID := TaskRef.ExtId
-	log.Printf("[DEBUG] PowerOn Response: TaskReference ExtId: %s (waiting for task)", utils.StringValue(taskUUID))
+	for taskAttempt := 0; taskAttempt < maxPowerRetries; taskAttempt++ {
+		getVmByIdRequest := import3.GetVmByIdRequest{
+			ExtId: utils.StringPtr(d.Id()),
+		}
+		readResp, errR := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+		if errR != nil {
+			return diag.Errorf("error while reading vm : %v", errR)
+		}
+		vmResp := readResp.Data.GetValue().(config.Vm)
+		currentPower := vmResp.PowerState.GetName()
+		log.Printf("[DEBUG] Power-on task attempt %d/%d: VM current power_state=%s", taskAttempt+1, maxPowerRetries, currentPower)
+		if currentPower == "ON" {
+			log.Printf("[DEBUG] VM is already in ON state")
+			return nil
+		}
 
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"PENDING", "RUNNING", "QUEUED"},
-		Target:  []string{"SUCCEEDED"},
-		Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, prismConn, utils.StringValue(taskUUID)),
-		Timeout: d.Timeout(schema.TimeoutUpdate),
-	}
+		TaskRef, err := powerOnVM(ctx, conn, utils.StringPtr(d.Id()))
+		if err != nil {
+			lastErr = err
+			if taskAttempt < maxPowerRetries-1 {
+				log.Printf("[DEBUG] Power-on API failed (attempt %d/%d), retrying in %v: %v",
+					taskAttempt+1, maxPowerRetries, powerTaskRetryDelay, err)
+				select {
+				case <-ctx.Done():
+					return diag.FromErr(ctx.Err())
+				case <-time.After(powerTaskRetryDelay):
+					continue
+				}
+			}
+			return diag.Errorf("error while powering on Virtual Machine after %d attempts: %v", maxPowerRetries, err)
+		}
+		taskUUID = TaskRef.ExtId
+		log.Printf("[DEBUG] PowerOn Response: TaskReference ExtId: %s (waiting for task)", utils.StringValue(taskUUID))
 
-	if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
-		return diag.Errorf("error waiting for virtual machine (%s) to power on: %s",
-			utils.StringValue(taskUUID), errWaitTask)
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{"PENDING", "RUNNING", "QUEUED"},
+			Target:  []string{"SUCCEEDED"},
+			Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, prismConn, utils.StringValue(taskUUID)),
+			Timeout: d.Timeout(schema.TimeoutUpdate),
+		}
+
+		_, errWaitTask := stateConf.WaitForStateContext(ctx)
+		if errWaitTask == nil {
+			log.Printf("[DEBUG] Power-on task reported SUCCEEDED for task %s; verifying VM power_state", utils.StringValue(taskUUID))
+			verifyReq := import3.GetVmByIdRequest{ExtId: utils.StringPtr(d.Id())}
+			verifyResp, errV := conn.VMAPIInstance.GetVmById(ctx, &verifyReq)
+			if errV != nil {
+				log.Printf("[DEBUG] Could not re-read VM after task success: %v", errV)
+				return nil
+			}
+			verifyVM := verifyResp.Data.GetValue().(config.Vm)
+			actualPower := verifyVM.PowerState.GetName()
+			log.Printf("[DEBUG] VM power_state after task: %s (expected ON)", actualPower)
+			if actualPower != "ON" {
+				log.Printf("[DEBUG] WARNING: Task reported SUCCEEDED but VM power_state is %s (expected ON) - possible backend inconsistency or race", actualPower)
+			}
+			return nil
+		}
+		lastErr = errWaitTask
+		if taskAttempt < maxPowerRetries-1 {
+			log.Printf("[DEBUG] Power-on task failed or timed out (attempt %d/%d), retrying API call and task in %v: %v",
+				taskAttempt+1, maxPowerRetries, powerTaskRetryDelay, errWaitTask)
+			select {
+			case <-ctx.Done():
+				return diag.FromErr(ctx.Err())
+			case <-time.After(powerTaskRetryDelay):
+				// continue to next task retry
+			}
+		}
 	}
-	return nil
+	log.Printf("[DEBUG] Power-on failed after %d attempts; last error: %v", maxPowerRetries, lastErr)
+	return diag.Errorf("error waiting for virtual machine (%s) to power on after %d attempts: %s",
+		utils.StringValue(taskUUID), maxPowerRetries, lastErr)
 }
 
 func diffConfig(oldValue []interface{}, newValue []interface{}) ([]interface{}, []interface{}, []interface{}) {

--- a/nutanix/services/vmmv2/resource_nutanix_vm_cdrom_insert_eject_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vm_cdrom_insert_eject_v2.go
@@ -217,7 +217,11 @@ func ResourceNutanixVmsCdRomsInsertEjectV2Create(ctx context.Context, d *schema.
 			ExtId:   utils.StringPtr(extID.(string)),
 			Body:    &body,
 		}
-		resp, err := conn.VMAPIInstance.InsertCdRomById(ctx, &insertCdRomByIdRequest)
+		args, err := vmEtagArgs(ctx, conn, vmExtID.(string))
+		if err != nil {
+			return diag.Errorf("error while fetching VM eTag for cd-rom insert: %v", err)
+		}
+		resp, err := conn.VMAPIInstance.InsertCdRomById(ctx, &insertCdRomByIdRequest, args)
 		if err != nil {
 			return diag.Errorf("error while inserting cd-rom : %v", err)
 		}

--- a/nutanix/services/vmmv2/resource_nutanix_vms_clone_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vms_clone_v2.go
@@ -1266,7 +1266,11 @@ func ResourceNutanixVMCloneV2Create(ctx context.Context, d *schema.ResourceData,
 		ExtId: utils.StringPtr(vmExtID.(string)),
 		Body:  body,
 	}
-	resp, err := conn.VMAPIInstance.CloneVm(ctx, &cloneVmRequest)
+	args, err := vmEtagArgs(ctx, conn, vmExtID.(string))
+	if err != nil {
+		return diag.Errorf("error while fetching VM eTag for clone: %v", err)
+	}
+	resp, err := conn.VMAPIInstance.CloneVm(ctx, &cloneVmRequest, args)
 	if err != nil {
 		return diag.Errorf("error while Cloning Vm : %v", err)
 	}

--- a/nutanix/services/vmmv2/resource_nutanix_vms_gc_update_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vms_gc_update_v2.go
@@ -193,7 +193,11 @@ func ResourceNutanixVMGCUpdateV2Create(ctx context.Context, d *schema.ResourceDa
 		ExtId: utils.StringPtr(vmExtID.(string)),
 		Body:  body,
 	}
-	resp, err := conn.VMAPIInstance.CustomizeGuestVm(ctx, &customizeGuestVmRequest)
+	args, err := vmEtagArgs(ctx, conn, vmExtID.(string))
+	if err != nil {
+		return diag.Errorf("error while fetching VM eTag for guest customize: %v", err)
+	}
+	resp, err := conn.VMAPIInstance.CustomizeGuestVm(ctx, &customizeGuestVmRequest, args)
 	if err != nil {
 		return diag.Errorf("error while creating Vm's Customize Guest : %v", err)
 	}

--- a/nutanix/services/vmmv2/resource_nutanix_vms_network_device_assign_ip_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vms_network_device_assign_ip_v2.go
@@ -73,7 +73,11 @@ func ResourceNutanixVmsNetworkDeviceAssignIPV2Create(ctx context.Context, d *sch
 		ExtId:   utils.StringPtr(extID.(string)),
 		Body:    &body,
 	}
-	resp, err := conn.VMAPIInstance.AssignIpById(ctx, &assignIpByIdRequest)
+	args, err := vmEtagArgs(ctx, conn, vmExtID.(string))
+	if err != nil {
+		return diag.Errorf("error while fetching VM eTag for assign IP: %v", err)
+	}
+	resp, err := conn.VMAPIInstance.AssignIpById(ctx, &assignIpByIdRequest, args)
 	if err != nil {
 		return diag.Errorf("error while assigning IP : %v", err)
 	}

--- a/nutanix/services/vmmv2/resource_nutanix_vms_network_device_migrate_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vms_network_device_migrate_v2.go
@@ -102,7 +102,11 @@ func ResourceNutanixVmsNetworkDeviceMigrateV2Create(ctx context.Context, d *sche
 		ExtId:   utils.StringPtr(extID.(string)),
 		Body:    &body,
 	}
-	resp, err := conn.VMAPIInstance.MigrateNicById(ctx, &migrateNicByIdRequest)
+	args, err := vmEtagArgs(ctx, conn, vmExtID.(string))
+	if err != nil {
+		return diag.Errorf("error while fetching VM eTag for nic migrate: %v", err)
+	}
+	resp, err := conn.VMAPIInstance.MigrateNicById(ctx, &migrateNicByIdRequest, args)
 	if err != nil {
 		return diag.Errorf("error while migrate nic : %v", err)
 	}
@@ -171,7 +175,11 @@ func ResourceNutanixVmsNetworkDeviceMigrateV2Update(ctx context.Context, d *sche
 		ExtId:   utils.StringPtr(extID.(string)),
 		Body:    &body,
 	}
-	resp, err := conn.VMAPIInstance.MigrateNicById(ctx, &migrateNicByIdRequest)
+	args, err := vmEtagArgs(ctx, conn, vmExtID.(string))
+	if err != nil {
+		return diag.Errorf("error while fetching VM eTag for nic migrate: %v", err)
+	}
+	resp, err := conn.VMAPIInstance.MigrateNicById(ctx, &migrateNicByIdRequest, args)
 	if err != nil {
 		return diag.Errorf("error while migrate nic : %v", err)
 	}

--- a/nutanix/services/vmmv2/resource_nutanix_vms_shutdown_action_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vms_shutdown_action_v2.go
@@ -87,12 +87,16 @@ func ResourceNutanixVmsShutdownActionV2Create(ctx context.Context, d *schema.Res
 	}
 
 	var TaskRef import1.TaskReference
+	args, err := vmEtagArgs(ctx, conn, vmExtID.(string))
+	if err != nil {
+		return diag.Errorf("error while fetching VM eTag for power action: %v", err)
+	}
 	//nolint:gocritic // Keeping if-else for clarity in this specific case
 	if action == "shutdown" {
 		shutdownVmRequest := import3.ShutdownVmRequest{
 			ExtId: utils.StringPtr(vmExtID.(string)),
 		}
-		resp, err := conn.VMAPIInstance.ShutdownVm(ctx, &shutdownVmRequest)
+		resp, err := conn.VMAPIInstance.ShutdownVm(ctx, &shutdownVmRequest, args)
 		if err != nil {
 			return diag.Errorf("error while Shutdown VM : %v", err)
 		}
@@ -102,7 +106,7 @@ func ResourceNutanixVmsShutdownActionV2Create(ctx context.Context, d *schema.Res
 			ExtId: utils.StringPtr(vmExtID.(string)),
 			Body:  &body,
 		}
-		resp, err := conn.VMAPIInstance.ShutdownGuestVm(ctx, &shutdownGuestVmRequest)
+		resp, err := conn.VMAPIInstance.ShutdownGuestVm(ctx, &shutdownGuestVmRequest, args)
 		if err != nil {
 			return diag.Errorf("error while Shutdown Guest VM : %v", err)
 		}
@@ -111,7 +115,7 @@ func ResourceNutanixVmsShutdownActionV2Create(ctx context.Context, d *schema.Res
 		rebootVmRequest := import3.RebootVmRequest{
 			ExtId: utils.StringPtr(vmExtID.(string)),
 		}
-		resp, err := conn.VMAPIInstance.RebootVm(ctx, &rebootVmRequest)
+		resp, err := conn.VMAPIInstance.RebootVm(ctx, &rebootVmRequest, args)
 		if err != nil {
 			return diag.Errorf("error while performing Reboot VM  : %v", err)
 		}
@@ -121,7 +125,7 @@ func ResourceNutanixVmsShutdownActionV2Create(ctx context.Context, d *schema.Res
 			ExtId: utils.StringPtr(vmExtID.(string)),
 			Body:  &body,
 		}
-		resp, err := conn.VMAPIInstance.RebootGuestVm(ctx, &rebootGuestVmRequest)
+		resp, err := conn.VMAPIInstance.RebootGuestVm(ctx, &rebootGuestVmRequest, args)
 		if err != nil {
 			return diag.Errorf("error while performing Reboot Guest VM : %v", err)
 		}

--- a/nutanix/services/vmmv2/vm_etag_compat.go
+++ b/nutanix/services/vmmv2/vm_etag_compat.go
@@ -1,0 +1,91 @@
+package vmmv2
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	import1 "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/prism/v4/config"
+	import3 "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/request/vm"
+	"github.com/terraform-providers/terraform-provider-nutanix/nutanix/sdks/v4/vmm"
+	"github.com/terraform-providers/terraform-provider-nutanix/utils"
+)
+
+// TEMPORARY COMPAT — REMOVE_AFTER: provider v2.6.0 (two releases after reintroduction).
+//
+// PC still requires If-Match (eTag) on several VMM power / create / delete ops
+// (PLAT-104 / MISSING_ETAG_HEADER). Once the platform no longer requires eTag:
+//  1. Delete this file (vm_etag_compat.go).
+//  2. Strip vmEtagArgs(...) / powerOnVMWithEtag / powerOffVMWithEtag and ", args"
+//     from call sites in resource_nutanix_virtual_machine_v2.go, helper.go, and
+//     resource_nutanix_ova_vm_deploy_v2.go.
+//  3. Collapse callForPowerOnVM / callForPowerOffVM back to a single-shot API +
+//     task wait (no maxPowerRetries loop).
+//  4. Changelog: remove temporary VMM If-Match compatibility.
+
+const (
+	// maxPowerRetries is used for both API-layer retries (power-on/power-off call)
+	// and task-layer retries (wait for task).
+	maxPowerRetries     = 10
+	powerTaskRetryDelay = 5 * time.Second
+)
+
+// vmEtagArgs GETs the VM and returns SDK header args with a fresh If-Match eTag.
+// REMOVE_AFTER: v2.6.0 — delete with this file.
+func vmEtagArgs(ctx context.Context, conn *vmm.Client, vmID string) (map[string]interface{}, error) {
+	getVmByIdRequest := import3.GetVmByIdRequest{
+		ExtId: utils.StringPtr(vmID),
+	}
+	readResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+	if err != nil {
+		return nil, fmt.Errorf("error while fetching VM for eTag: %w", err)
+	}
+	args := make(map[string]interface{})
+	args["If-Match"] = getEtagHeader(readResp, conn)
+	return args, nil
+}
+
+// powerOnVMWithEtag performs a single PowerOnVm call with a fresh If-Match eTag.
+// REMOVE_AFTER: v2.6.0 — delete with this file; callers can call PowerOnVm without args.
+func powerOnVMWithEtag(ctx context.Context, conn *vmm.Client, vmID *string) (import1.TaskReference, error) {
+	args, err := vmEtagArgs(ctx, conn, utils.StringValue(vmID))
+	if err != nil {
+		return import1.TaskReference{}, err
+	}
+	powerOnVmRequest := import3.PowerOnVmRequest{
+		ExtId: vmID,
+	}
+	resp, err := conn.VMAPIInstance.PowerOnVm(ctx, &powerOnVmRequest, args)
+	if err != nil {
+		return import1.TaskReference{}, fmt.Errorf("error powering on VM: %v", err)
+	}
+	taskRef, err := extractTaskReferenceFromResponse(resp)
+	if err != nil {
+		return import1.TaskReference{}, fmt.Errorf("error extracting task reference from power on response: %v", err)
+	}
+	log.Printf("[DEBUG] PowerOn Response: TaskReference ExtId: %s", utils.StringValue(taskRef.ExtId))
+	return taskRef, nil
+}
+
+// powerOffVMWithEtag performs a single PowerOffVm call with a fresh If-Match eTag.
+// REMOVE_AFTER: v2.6.0 — delete with this file; callers can call PowerOffVm without args.
+func powerOffVMWithEtag(ctx context.Context, conn *vmm.Client, vmID *string) (import1.TaskReference, error) {
+	args, err := vmEtagArgs(ctx, conn, utils.StringValue(vmID))
+	if err != nil {
+		return import1.TaskReference{}, err
+	}
+	powerOffVmRequest := import3.PowerOffVmRequest{
+		ExtId: vmID,
+	}
+	resp, err := conn.VMAPIInstance.PowerOffVm(ctx, &powerOffVmRequest, args)
+	if err != nil {
+		return import1.TaskReference{}, fmt.Errorf("error powering off VM: %v", err)
+	}
+	taskRef, err := extractTaskReferenceFromResponse(resp)
+	if err != nil {
+		return import1.TaskReference{}, fmt.Errorf("error extracting task reference from power off response: %v", err)
+	}
+	log.Printf("[DEBUG] PowerOff Response: TaskReference ExtId: %s", utils.StringValue(taskRef.ExtId))
+	return taskRef, nil
+}


### PR DESCRIPTION
## Summary
- Restore temporary `If-Match` (eTag) support for VMM ops that still require it on current PC (`PLAT-10004` / `MISSING_ETAG_HEADER`), after it was dropped during the request-object migration.
- Centralize fetch/pass logic in `vm_etag_compat.go` (`vmEtagArgs`, power helpers) so this can be removed cleanly after ~2 releases (target: provider v2.6.0).
- Re-enable power-on/off multi-attempt retry with a fresh eTag each attempt, and wire eTag into create/delete/action call sites that were failing acceptance (NIC/CD-ROM/serial/GPU, categories, disks, clone, guest customize, assign IP, migrate NIC, shutdown/reboot, CD-ROM insert/eject, OVA deploy).

## Test plan
- [ ] `go build ./nutanix/services/vmmv2/`
- [ ] Acc: `TestAccV2NutanixVmsResource_Basic` (power_state ON)
- [ ] Acc: CD-ROM insert/eject (`nutanix_vm_cdrom_insert_eject_v2`)
- [ ] Acc: clone / GC update / assign IP / migrate NIC / shutdown action
- [ ] Acc: OVA VM deploy power path
- [ ] Confirm no `MISSING_ETAG_HEADER` / `PLAT-10004` on the above