### PR TITLE
Revert "Remove ETag dependency from VM $action endpoints in AHV V4 APIs" (revert PR #55)

### DIFF
--- a/nutanix/services/vmmv2/helper.go
+++ b/nutanix/services/vmmv2/helper.go
@@ -94,12 +94,21 @@ func ApplyDiskDeletions(ctx context.Context, d *schema.ResourceData, meta interf
 		}
 		diskInput := diskInputs[0]
 		diskExtID := diskInput.ExtId
+		getVmByIdRequest := import1.GetVmByIdRequest{
+			ExtId: utils.StringPtr(vmID),
+		}
+		readVMResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+		if err != nil {
+			return diag.Errorf("error while fetching vm : %v", err)
+		}
+		args := make(map[string]interface{})
+		args["If-Match"] = getEtagHeader(readVMResp, conn)
 
 		deleteDiskByIdRequest := import1.DeleteDiskByIdRequest{
 			VmExtId: utils.StringPtr(vmID),
 			ExtId:   diskExtID,
 		}
-		resp, err := conn.VMAPIInstance.DeleteDiskById(ctx, &deleteDiskByIdRequest)
+		resp, err := conn.VMAPIInstance.DeleteDiskById(ctx, &deleteDiskByIdRequest, args)
 		if err != nil {
 			return diag.Errorf("error while deleting Disk : %v", err)
 		}
@@ -129,12 +138,12 @@ func ApplyDiskUpdates(ctx context.Context, d *schema.ResourceData, meta interfac
 		getVmByIdRequest := import1.GetVmByIdRequest{
 			ExtId: utils.StringPtr(vmID),
 		}
-		readResp, errR := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
-		if errR != nil {
-			return diag.Errorf("error while reading vm for disk update: %v", errR)
+		readVMResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+		if err != nil {
+			return diag.Errorf("error while fetching vm : %v", err)
 		}
 		args := make(map[string]interface{})
-		args["If-Match"] = getEtagHeader(readResp, conn)
+		args["If-Match"] = getEtagHeader(readVMResp, conn)
 
 		updateDiskByIdRequest := import1.UpdateDiskByIdRequest{
 			VmExtId: utils.StringPtr(vmID),
@@ -164,12 +173,21 @@ func ApplyDiskAdditions(ctx context.Context, d *schema.ResourceData, meta interf
 			continue
 		}
 		diskInput := diskInputs[0]
+		getVmByIdRequest := import1.GetVmByIdRequest{
+			ExtId: utils.StringPtr(vmID),
+		}
+		readVMResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+		if err != nil {
+			return diag.Errorf("error while fetching vm : %v", err)
+		}
+		args := make(map[string]interface{})
+		args["If-Match"] = getEtagHeader(readVMResp, conn)
 
 		createDiskRequest := import1.CreateDiskRequest{
 			VmExtId: utils.StringPtr(vmID),
 			Body:    &diskInput,
 		}
-		resp, err := conn.VMAPIInstance.CreateDisk(ctx, &createDiskRequest)
+		resp, err := conn.VMAPIInstance.CreateDisk(ctx, &createDiskRequest, args)
 		if err != nil {
 			return diag.Errorf("error while creating Disk : %v", err)
 		}

--- a/nutanix/services/vmmv2/helper_test.go
+++ b/nutanix/services/vmmv2/helper_test.go
@@ -25,12 +25,15 @@ func testAccCheckNutanixVmsResourceDestroy(s *terraform.State) error {
 		getVmByIdRequest := import1.GetVmByIdRequest{
 			ExtId: utils.StringPtr(rs.Primary.ID),
 		}
-		_, err := vmClient.GetVmById(ctx, &getVmByIdRequest)
+		vmResponse, err := vmClient.GetVmById(ctx, &getVmByIdRequest)
 		if err == nil {
+			etag := vmClient.ApiClient.GetEtag(vmResponse)
+			args := make(map[string]interface{})
+			args["If-Match"] = utils.StringPtr(etag)
 			deleteVmByIdRequest := import1.DeleteVmByIdRequest{
 				ExtId: utils.StringPtr(rs.Primary.ID),
 			}
-			_, err = vmClient.DeleteVmById(ctx, &deleteVmByIdRequest)
+			_, err = vmClient.DeleteVmById(ctx, &deleteVmByIdRequest, args)
 			if err != nil {
 				return fmt.Errorf("error: VM still exists: %v", err)
 			}

--- a/nutanix/services/vmmv2/resource_nutanix_ngt_insert_iso_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_ngt_insert_iso_v2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -313,29 +314,58 @@ func ejectCdromISO(ctx context.Context, d *schema.ResourceData, meta interface{}
 	vmExtID := d.Get("vm_ext_id").(string)
 	extID := d.Get("cdrom_ext_id").(string)
 
-	ejectCdRomByIdRequest := import3.EjectCdRomByIdRequest{
-		VmExtId: utils.StringPtr(vmExtID),
-		ExtId:   utils.StringPtr(extID),
-	}
-	resp, err := conn.VMAPIInstance.EjectCdRomById(ctx, &ejectCdRomByIdRequest)
-	if err != nil {
-		return diag.Errorf("error while ejecting cd-rom : %v", err)
+	// This operation is async. Under cluster load, the task may sit in QUEUED state for a
+	// long time, and the VM ETag can change before the task actually starts, leading to a
+	// VM_ETAG_MISMATCH failure. In that case, re-fetch the latest ETag and retry.
+	const maxAttempts = 5
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		getVmByIdRequest := import3.GetVmByIdRequest{
+			ExtId: utils.StringPtr(vmExtID),
+		}
+		readResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+		if err != nil {
+			return diag.Errorf("error while reading vm : %v", err)
+		}
+		// Extract E-Tag Header
+		args := make(map[string]interface{})
+		args["If-Match"] = getEtagHeader(readResp, conn)
+
+		// Eject the ISO from the CD-ROM of the VM
+		ejectCdRomByIdRequest := import3.EjectCdRomByIdRequest{
+			VmExtId: utils.StringPtr(vmExtID),
+			ExtId:   utils.StringPtr(extID),
+		}
+		resp, err := conn.VMAPIInstance.EjectCdRomById(ctx, &ejectCdRomByIdRequest, args)
+		if err != nil {
+			return diag.Errorf("error while ejecting cd-rom : %v", err)
+		}
+
+		TaskRef := resp.Data.GetValue().(vmmPrism.TaskReference)
+		taskUUID := TaskRef.ExtId
+
+		taskconn := meta.(*conns.Client).PrismAPI
+
+		// Wait for the CD-ROM to be ejected
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{"PENDING", "RUNNING", "QUEUED"},
+			Target:  []string{"SUCCEEDED"},
+			Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, taskconn, utils.StringValue(taskUUID)),
+			Timeout: d.Timeout(schema.TimeoutDelete),
+		}
+
+		if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
+			// Retry only for the known ETag mismatch failure mode.
+			if attempt < maxAttempts && isVmmEtagMismatchErr(errWaitTask) {
+				log.Printf("[DEBUG] ISO EJECTION failed due to VM ETag mismatch (attempt %d/%d). Retrying with refreshed ETag. Task UUID: %s, error: %s",
+					attempt, maxAttempts, utils.StringValue(taskUUID), errWaitTask)
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			return diag.Errorf("ISO EJECTION FAILED: REASON: %s : Task UUID: %s", errWaitTask, utils.StringValue(taskUUID))
+		}
+		return nil
 	}
 
-	TaskRef := resp.Data.GetValue().(vmmPrism.TaskReference)
-	taskUUID := TaskRef.ExtId
-
-	taskconn := meta.(*conns.Client).PrismAPI
-
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"PENDING", "RUNNING", "QUEUED"},
-		Target:  []string{"SUCCEEDED"},
-		Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, taskconn, utils.StringValue(taskUUID)),
-		Timeout: d.Timeout(schema.TimeoutDelete),
-	}
-
-	if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
-		return diag.Errorf("ISO EJECTION FAILED: REASON: %s : Task UUID: %s", errWaitTask, utils.StringValue(taskUUID))
-	}
+	// Unreachable because the loop always returns on success or failure.
 	return nil
 }

--- a/nutanix/services/vmmv2/resource_nutanix_ova_vm_deploy_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_ova_vm_deploy_v2.go
@@ -562,12 +562,22 @@ func ResourceNutanixOvaVMDeploymentCreate(ctx context.Context, d *schema.Resourc
 					for _, diskInput := range diskInputs {
 						aJSON, _ := json.MarshalIndent(diskInput, "", "  ")
 						log.Printf("[DEBUG] disk input: %s", string(aJSON))
+						getVmByIdRequest := import7.GetVmByIdRequest{
+							ExtId: utils.StringPtr(d.Id()),
+						}
+						readVMResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+						if err != nil {
+							return diag.Errorf("error reading VM for disk creation: %v", err)
+						}
+
+						args := make(map[string]interface{})
+						args["If-Match"] = getEtagHeader(readVMResp, conn)
 
 						createDiskRequest := import7.CreateDiskRequest{
 							VmExtId: utils.StringPtr(d.Id()),
 							Body:    &diskInput,
 						}
-						resp, err := conn.VMAPIInstance.CreateDisk(ctx, &createDiskRequest)
+						resp, err := conn.VMAPIInstance.CreateDisk(ctx, &createDiskRequest, args)
 						if err != nil {
 							return diag.Errorf("error creating disk: %v", err)
 						}
@@ -728,10 +738,21 @@ func ResourceNutanixOvaVMDeploymentUpdate(ctx context.Context, d *schema.Resourc
 func ResourceNutanixOvaVMDeploymentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.Client).VmmAPI
 
+	getVmByIdRequest := import7.GetVmByIdRequest{
+		ExtId: utils.StringPtr(d.Id()),
+	}
+	readResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+	if err != nil {
+		return diag.Errorf("error while reading vm : %v", err)
+	}
+	// Extract E-Tag Header
+	args := make(map[string]interface{})
+	args["If-Match"] = getEtagHeader(readResp, conn)
+
 	deleteVmByIdRequest := import7.DeleteVmByIdRequest{
 		ExtId: utils.StringPtr(d.Id()),
 	}
-	resp, err := conn.VMAPIInstance.DeleteVmById(ctx, &deleteVmByIdRequest)
+	resp, err := conn.VMAPIInstance.DeleteVmById(ctx, &deleteVmByIdRequest, args)
 	if err != nil {
 		return diag.Errorf("error while deleting vm : %v", err)
 	}
@@ -865,6 +886,16 @@ func handlePowerStateChanges(ctx context.Context, d *schema.ResourceData, meta i
 		log.Printf("[DEBUG] Handling power state change from '%s' to '%s'", oldPowerState, newPowerState)
 
 		vmmConn := conn.(*conns.Client).VmmAPI
+		getVmByIdRequest := import7.GetVmByIdRequest{
+			ExtId: utils.StringPtr(d.Id()),
+		}
+		readResp, err := vmmConn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+		if err != nil {
+			return diag.Errorf("error reading VM for power state change: %v", err)
+		}
+
+		args := make(map[string]interface{})
+		args["If-Match"] = getEtagHeader(readResp, vmmConn)
 
 		var taskUUID *string
 
@@ -873,7 +904,7 @@ func handlePowerStateChanges(ctx context.Context, d *schema.ResourceData, meta i
 			powerOnVmRequest := import7.PowerOnVmRequest{
 				ExtId: utils.StringPtr(d.Id()),
 			}
-			powerResp, err := vmmConn.VMAPIInstance.PowerOnVm(ctx, &powerOnVmRequest)
+			powerResp, err := vmmConn.VMAPIInstance.PowerOnVm(ctx, &powerOnVmRequest, args)
 			if err != nil {
 				return diag.Errorf("error powering on VM: %v", err)
 			}
@@ -883,7 +914,7 @@ func handlePowerStateChanges(ctx context.Context, d *schema.ResourceData, meta i
 			powerOffVmRequest := import7.PowerOffVmRequest{
 				ExtId: utils.StringPtr(d.Id()),
 			}
-			powerResp, err := vmmConn.VMAPIInstance.PowerOffVm(ctx, &powerOffVmRequest)
+			powerResp, err := vmmConn.VMAPIInstance.PowerOffVm(ctx, &powerOffVmRequest, args)
 			if err != nil {
 				return diag.Errorf("error powering off VM: %v", err)
 			}

--- a/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go
@@ -1710,11 +1710,22 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 
 				nicExtID := nicInput.ExtId
 
+				getVmByIdRequest := import3.GetVmByIdRequest{
+					ExtId: utils.StringPtr(d.Id()),
+				}
+				ReadVMResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+				if err != nil {
+					return diag.Errorf("error while fetching vm : %v", err)
+				}
+
+				// // Extract E-Tag Header
+				args := make(map[string]interface{})
+				args["If-Match"] = getEtagHeader(ReadVMResp, conn)
 				deleteNicByIdRequest := import3.DeleteNicByIdRequest{
 					VmExtId: utils.StringPtr(d.Id()),
 					ExtId:   nicExtID,
 				}
-				resp, err := conn.VMAPIInstance.DeleteNicById(ctx, &deleteNicByIdRequest)
+				resp, err := conn.VMAPIInstance.DeleteNicById(ctx, &deleteNicByIdRequest, args)
 				if err != nil {
 					return diag.Errorf("error while deleting nic : %v", err)
 				}
@@ -1756,20 +1767,21 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 				nicInput := expandNic([]interface{}{nic}, d, basePath)[0]
 
 				nicExtID := nicInput.ExtId
+				getVmByIdRequest := import3.GetVmByIdRequest{
+					ExtId: utils.StringPtr(d.Id()),
+				}
+				ReadVMResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+				if err != nil {
+					return diag.Errorf("error while fetching vm : %v", err)
+				}
+
+				// // Extract E-Tag Header
+				args := make(map[string]interface{})
+				args["If-Match"] = getEtagHeader(ReadVMResp, conn)
 
 				log.Printf("[DEBUG] updating nic: %+v", *nicExtID)
 				aJSON, _ := json.MarshalIndent(nicInput, "", "  ")
 				log.Printf("[DEBUG] update nic payload: %s", string(aJSON))
-
-				getVmByIdRequest := import3.GetVmByIdRequest{
-					ExtId: utils.StringPtr(d.Id()),
-				}
-				readResp, errR := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
-				if errR != nil {
-					return diag.Errorf("error while reading vm for nic update: %v", errR)
-				}
-				args := make(map[string]interface{})
-				args["If-Match"] = getEtagHeader(readResp, conn)
 
 				updateNicByIdRequest := import3.UpdateNicByIdRequest{
 					VmExtId: utils.StringPtr(d.Id()),
@@ -1800,12 +1812,22 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 		if len(newAddedNic) > 0 {
 			for _, nic := range newAddedNic {
 				nicInput := expandNic([]interface{}{nic}, nil, "")[0]
+				getVmByIdRequest := import3.GetVmByIdRequest{
+					ExtId: utils.StringPtr(d.Id()),
+				}
+				ReadVMResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+				if err != nil {
+					return diag.Errorf("error while fetching vm : %v", err)
+				}
 
+				// // Extract E-Tag Header
+				args := make(map[string]interface{})
+				args["If-Match"] = getEtagHeader(ReadVMResp, conn)
 				createNicRequest := import3.CreateNicRequest{
 					VmExtId: utils.StringPtr(d.Id()),
 					Body:    &nicInput,
 				}
-				resp, err := conn.VMAPIInstance.CreateNic(ctx, &createNicRequest)
+				resp, err := conn.VMAPIInstance.CreateNic(ctx, &createNicRequest, args)
 				if err != nil {
 					return diag.Errorf("error while creating NIC : %v", err)
 				}
@@ -1835,11 +1857,22 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 			for _, cdrom := range newAddedCdRom {
 				cdromInput := expandCdRom([]interface{}{cdrom})[0]
 
+				getVmByIdRequest := import3.GetVmByIdRequest{
+					ExtId: utils.StringPtr(d.Id()),
+				}
+				ReadVMResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+				if err != nil {
+					return diag.Errorf("error while fetching vm : %v", err)
+				}
+
+				// // Extract E-Tag Header
+				args := make(map[string]interface{})
+				args["If-Match"] = getEtagHeader(ReadVMResp, conn)
 				createCdRomRequest := import3.CreateCdRomRequest{
 					VmExtId: utils.StringPtr(d.Id()),
 					Body:    &cdromInput,
 				}
-				resp, err := conn.VMAPIInstance.CreateCdRom(ctx, &createCdRomRequest)
+				resp, err := conn.VMAPIInstance.CreateCdRom(ctx, &createCdRomRequest, args)
 				if err != nil {
 					return diag.Errorf("error while creating CdRom : %v", err)
 				}
@@ -1867,11 +1900,22 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 
 				cdromExtID := cdromInput.ExtId
 
+				getVmByIdRequest := import3.GetVmByIdRequest{
+					ExtId: utils.StringPtr(d.Id()),
+				}
+				ReadVMResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+				if err != nil {
+					return diag.Errorf("error while fetching vm : %v", err)
+				}
+
+				// // Extract E-Tag Header
+				args := make(map[string]interface{})
+				args["If-Match"] = getEtagHeader(ReadVMResp, conn)
 				deleteCdRomByIdRequest := import3.DeleteCdRomByIdRequest{
 					VmExtId: utils.StringPtr(d.Id()),
 					ExtId:   cdromExtID,
 				}
-				resp, err := conn.VMAPIInstance.DeleteCdRomById(ctx, &deleteCdRomByIdRequest)
+				resp, err := conn.VMAPIInstance.DeleteCdRomById(ctx, &deleteCdRomByIdRequest, args)
 				if err != nil {
 					return diag.Errorf("error while deleting cdrom : %v", err)
 				}
@@ -1903,12 +1947,23 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 				serialPortInput := expandSerialPort([]interface{}{serialPort})[0]
 
 				serialPortExtID := serialPortInput.ExtId
+				getVmByIdRequest := import3.GetVmByIdRequest{
+					ExtId: utils.StringPtr(d.Id()),
+				}
+				ReadVMResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+				if err != nil {
+					return diag.Errorf("error while fetching vm : %v", err)
+				}
+
+				// // Extract E-Tag Header
+				args := make(map[string]interface{})
+				args["If-Match"] = getEtagHeader(ReadVMResp, conn)
 
 				deleteSerialPortByIdRequest := import3.DeleteSerialPortByIdRequest{
 					VmExtId: utils.StringPtr(d.Id()),
 					ExtId:   serialPortExtID,
 				}
-				resp, err := conn.VMAPIInstance.DeleteSerialPortById(ctx, &deleteSerialPortByIdRequest)
+				resp, err := conn.VMAPIInstance.DeleteSerialPortById(ctx, &deleteSerialPortByIdRequest, args)
 				if err != nil {
 					return diag.Errorf("error while deleting serial port : %v", err)
 				}
@@ -1934,16 +1989,17 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 				serialPortInput := expandSerialPort([]interface{}{serialPort})[0]
 
 				portExtTD := serialPortInput.ExtId
-
 				getVmByIdRequest := import3.GetVmByIdRequest{
 					ExtId: utils.StringPtr(d.Id()),
 				}
-				readResp, errR := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
-				if errR != nil {
-					return diag.Errorf("error while reading vm for serial port update: %v", errR)
+				ReadVMResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+				if err != nil {
+					return diag.Errorf("error while fetching vm : %v", err)
 				}
+
+				// // Extract E-Tag Header
 				args := make(map[string]interface{})
-				args["If-Match"] = getEtagHeader(readResp, conn)
+				args["If-Match"] = getEtagHeader(ReadVMResp, conn)
 
 				updateSerialPortByIdRequest := import3.UpdateSerialPortByIdRequest{
 					VmExtId: utils.StringPtr(d.Id()),
@@ -1975,11 +2031,23 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 			for _, serialPort := range newAddedSerialPorts {
 				serialPortInput := expandSerialPort([]interface{}{serialPort})[0]
 
+				getVmByIdRequest := import3.GetVmByIdRequest{
+					ExtId: utils.StringPtr(d.Id()),
+				}
+				ReadVMResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+				if err != nil {
+					return diag.Errorf("error while fetching vm : %v", err)
+				}
+
+				// // Extract E-Tag Header
+				args := make(map[string]interface{})
+				args["If-Match"] = getEtagHeader(ReadVMResp, conn)
+
 				createSerialPortRequest := import3.CreateSerialPortRequest{
 					VmExtId: utils.StringPtr(d.Id()),
 					Body:    &serialPortInput,
 				}
-				resp, err := conn.VMAPIInstance.CreateSerialPort(ctx, &createSerialPortRequest)
+				resp, err := conn.VMAPIInstance.CreateSerialPort(ctx, &createSerialPortRequest, args)
 				if err != nil {
 					return diag.Errorf("error while creating SerialPort : %v", err)
 				}
@@ -2009,12 +2077,23 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 		if len(newAddedGpus) > 0 {
 			for _, gpu := range newAddedGpus {
 				gpuInput := expandGpu([]interface{}{gpu})[0]
+				getVmByIdRequest := import3.GetVmByIdRequest{
+					ExtId: utils.StringPtr(d.Id()),
+				}
+				ReadVMResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+				if err != nil {
+					return diag.Errorf("error while fetching vm : %v", err)
+				}
+
+				// // Extract E-Tag Header
+				args := make(map[string]interface{})
+				args["If-Match"] = getEtagHeader(ReadVMResp, conn)
 
 				createGpuRequest := import3.CreateGpuRequest{
 					VmExtId: utils.StringPtr(d.Id()),
 					Body:    &gpuInput,
 				}
-				resp, err := conn.VMAPIInstance.CreateGpu(ctx, &createGpuRequest)
+				resp, err := conn.VMAPIInstance.CreateGpu(ctx, &createGpuRequest, args)
 				if err != nil {
 					return diag.Errorf("error while creating Gpu : %v", err)
 				}
@@ -2041,12 +2120,23 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 				gpuInput := expandGpu([]interface{}{gpu})[0]
 
 				gpuExtID := gpuInput.ExtId
+				getVmByIdRequest := import3.GetVmByIdRequest{
+					ExtId: utils.StringPtr(d.Id()),
+				}
+				ReadVMResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+				if err != nil {
+					return diag.Errorf("error while fetching vm : %v", err)
+				}
+
+				// // Extract E-Tag Header
+				args := make(map[string]interface{})
+				args["If-Match"] = getEtagHeader(ReadVMResp, conn)
 
 				deleteGpuByIdRequest := import3.DeleteGpuByIdRequest{
 					VmExtId: utils.StringPtr(d.Id()),
 					ExtId:   gpuExtID,
 				}
-				resp, err := conn.VMAPIInstance.DeleteGpuById(ctx, &deleteGpuByIdRequest)
+				resp, err := conn.VMAPIInstance.DeleteGpuById(ctx, &deleteGpuByIdRequest, args)
 				if err != nil {
 					return diag.Errorf("error while deleting gpu : %v", err)
 				}
@@ -2080,11 +2170,22 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 
 			body.Categories = expandCategoryReference(oldDeletedCategories)
 
+			getVmByIdRequest := import3.GetVmByIdRequest{
+				ExtId: utils.StringPtr(d.Id()),
+			}
+			readResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+			if err != nil {
+				return diag.Errorf("error while reading vm : %v", err)
+			}
+			// Extract E-Tag Header
+			args := make(map[string]interface{})
+			args["If-Match"] = getEtagHeader(readResp, conn)
+
 			disassociateCategoriesRequest := import3.DisassociateCategoriesRequest{
 				ExtId: utils.StringPtr(d.Id()),
 				Body:  &body,
 			}
-			resp, err := conn.VMAPIInstance.DisassociateCategories(ctx, &disassociateCategoriesRequest)
+			resp, err := conn.VMAPIInstance.DisassociateCategories(ctx, &disassociateCategoriesRequest, args)
 			if err != nil {
 				return diag.Errorf("error while diassociate categories : %v", err)
 			}
@@ -2111,11 +2212,21 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 
 			body.Categories = expandCategoryReference(newAddedCategories)
 
+			getVmByIdRequest := import3.GetVmByIdRequest{
+				ExtId: utils.StringPtr(d.Id()),
+			}
+			readResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+			if err != nil {
+				return diag.Errorf("error while reading vm : %v", err)
+			}
+			// Extract E-Tag Header
+			args := make(map[string]interface{})
+			args["If-Match"] = getEtagHeader(readResp, conn)
 			associateCategoriesRequest := import3.AssociateCategoriesRequest{
 				ExtId: utils.StringPtr(d.Id()),
 				Body:  &body,
 			}
-			resp, err := conn.VMAPIInstance.AssociateCategories(ctx, &associateCategoriesRequest)
+			resp, err := conn.VMAPIInstance.AssociateCategories(ctx, &associateCategoriesRequest, args)
 			if err != nil {
 				return diag.Errorf("error while associating categories : %v", err)
 			}
@@ -2172,10 +2283,21 @@ func ResourceNutanixVirtualMachineV2Update(ctx context.Context, d *schema.Resour
 func ResourceNutanixVirtualMachineV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conn := meta.(*conns.Client).VmmAPI
 
+	getVmByIdRequest := import3.GetVmByIdRequest{
+		ExtId: utils.StringPtr(d.Id()),
+	}
+	readResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+	if err != nil {
+		return diag.Errorf("error while reading vm : %v", err)
+	}
+	// Extract E-Tag Header
+	args := make(map[string]interface{})
+	args["If-Match"] = getEtagHeader(readResp, conn)
+
 	deleteVmByIdRequest := import3.DeleteVmByIdRequest{
 		ExtId: utils.StringPtr(d.Id()),
 	}
-	resp, err := conn.VMAPIInstance.DeleteVmById(ctx, &deleteVmByIdRequest)
+	resp, err := conn.VMAPIInstance.DeleteVmById(ctx, &deleteVmByIdRequest, args)
 	if err != nil {
 		return diag.Errorf("error while deleting vm : %v", err)
 	}
@@ -3082,10 +3204,22 @@ func extractTaskReferenceFromResponse(resp interface{}) (import1.TaskReference, 
 
 // powerOnVM performs a single power-on API call. Retries are handled at the task layer in callForPowerOnVM.
 func powerOnVM(ctx context.Context, conn *vmm.Client, vmID *string) (import1.TaskReference, error) {
+	getVmByIdRequest := import3.GetVmByIdRequest{
+		ExtId: vmID,
+	}
+	readResp, errR := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+	if errR != nil {
+		return import1.TaskReference{}, fmt.Errorf("error while fetching vm : %v", errR)
+	}
+
+	args := make(map[string]interface{})
+
+	args["If-Match"] = getEtagHeader(readResp, conn)
+
 	powerOnVmRequest := import3.PowerOnVmRequest{
 		ExtId: vmID,
 	}
-	resp, err := conn.VMAPIInstance.PowerOnVm(ctx, &powerOnVmRequest)
+	resp, err := conn.VMAPIInstance.PowerOnVm(ctx, &powerOnVmRequest, args)
 	if err != nil {
 		return import1.TaskReference{}, fmt.Errorf("error powering on VM: %v", err)
 	}
@@ -3100,10 +3234,22 @@ func powerOnVM(ctx context.Context, conn *vmm.Client, vmID *string) (import1.Tas
 
 // powerOffVM performs a single power-off API call. Retries are handled at the task layer in callForPowerOffVM.
 func powerOffVM(ctx context.Context, conn *vmm.Client, vmID *string) (import1.TaskReference, error) {
+	getVmByIdRequest := import3.GetVmByIdRequest{
+		ExtId: vmID,
+	}
+	readResp, errR := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+	if errR != nil {
+		return import1.TaskReference{}, fmt.Errorf("error while fetching vm : %v", errR)
+	}
+
+	args := make(map[string]interface{})
+
+	args["If-Match"] = getEtagHeader(readResp, conn)
+
 	powerOffVmRequest := import3.PowerOffVmRequest{
 		ExtId: vmID,
 	}
-	resp, err := conn.VMAPIInstance.PowerOffVm(ctx, &powerOffVmRequest)
+	resp, err := conn.VMAPIInstance.PowerOffVm(ctx, &powerOffVmRequest, args)
 	if err != nil {
 		return import1.TaskReference{}, fmt.Errorf("error powering off VM: %v", err)
 	}
@@ -3135,51 +3281,173 @@ func flattenPowerState(pr *config.PowerState) string {
 	return "UNKNOWN"
 }
 
+const (
+	// maxPowerRetries is used for both API-layer retries (power-on/power-off call) and task-layer retries (wait for task).
+	maxPowerRetries     = 10
+	powerTaskRetryDelay = 5 * time.Second
+)
+
 func callForPowerOffVM(ctx context.Context, conn *vmm.Client, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	prismConn := meta.(*conns.Client).PrismAPI
+	var lastErr error
+	var taskUUID *string
 
-	TaskRef, err := powerOffVM(ctx, conn, utils.StringPtr(d.Id()))
-	if err != nil {
-		return diag.Errorf("error while powering off Virtual Machine: %v", err)
-	}
-	taskUUID := TaskRef.ExtId
+	for taskAttempt := 0; taskAttempt < maxPowerRetries; taskAttempt++ {
+		getVmByIdRequest := import3.GetVmByIdRequest{
+			ExtId: utils.StringPtr(d.Id()),
+		}
+		readResp, errR := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+		if errR != nil {
+			return diag.Errorf("error while reading vm : %v", errR)
+		}
+		vmResp := readResp.Data.GetValue().(config.Vm)
+		currentPower := vmResp.PowerState.GetName()
+		log.Printf("[DEBUG] Power-off task attempt %d/%d: VM current power_state=%s", taskAttempt+1, maxPowerRetries, currentPower)
+		if currentPower == "OFF" {
+			log.Printf("[DEBUG] VM is already in OFF state")
+			return nil
+		}
 
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"PENDING", "RUNNING", "QUEUED"},
-		Target:  []string{"SUCCEEDED"},
-		Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, prismConn, utils.StringValue(taskUUID)),
-		Timeout: d.Timeout(schema.TimeoutCreate),
-	}
+		TaskRef, err := powerOffVM(ctx, conn, utils.StringPtr(d.Id()))
+		if err != nil {
+			lastErr = err
+			if taskAttempt < maxPowerRetries-1 {
+				log.Printf("[DEBUG] Power-off API failed (attempt %d/%d), retrying in %v: %v",
+					taskAttempt+1, maxPowerRetries, powerTaskRetryDelay, err)
+				select {
+				case <-ctx.Done():
+					return diag.FromErr(ctx.Err())
+				case <-time.After(powerTaskRetryDelay):
+					continue
+				}
+			}
+			return diag.Errorf("error while powering off Virtual Machine after %d attempts: %v", maxPowerRetries, err)
+		}
+		taskUUID = TaskRef.ExtId
 
-	if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
-		return diag.Errorf("error waiting for virtual machine (%s) to power off: %s",
-			utils.StringValue(taskUUID), errWaitTask)
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{"PENDING", "RUNNING", "QUEUED"},
+			Target:  []string{"SUCCEEDED"},
+			Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, prismConn, utils.StringValue(taskUUID)),
+			Timeout: d.Timeout(schema.TimeoutCreate),
+		}
+
+		_, errWaitTask := stateConf.WaitForStateContext(ctx)
+		if errWaitTask == nil {
+			log.Printf("[DEBUG] Power-off task reported SUCCEEDED for task %s; verifying VM power_state", utils.StringValue(taskUUID))
+			getVmByIdRequest := import3.GetVmByIdRequest{
+				ExtId: utils.StringPtr(d.Id()),
+			}
+			verifyResp, errV := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+			if errV != nil {
+				log.Printf("[DEBUG] Could not re-read VM after task success: %v", errV)
+				return nil
+			}
+			verifyVM := verifyResp.Data.GetValue().(config.Vm)
+			actualPower := verifyVM.PowerState.GetName()
+			log.Printf("[DEBUG] VM power_state after task: %s (expected OFF)", actualPower)
+			if actualPower != "OFF" {
+				log.Printf("[DEBUG] WARNING: Task reported SUCCEEDED but VM power_state is %s (expected OFF) - possible backend inconsistency or race", actualPower)
+			}
+			return nil
+		}
+		lastErr = errWaitTask
+		if taskAttempt < maxPowerRetries-1 {
+			log.Printf("[DEBUG] Power-off task failed or timed out (attempt %d/%d), retrying API call and task in %v: %v",
+				taskAttempt+1, maxPowerRetries, powerTaskRetryDelay, errWaitTask)
+			select {
+			case <-ctx.Done():
+				return diag.FromErr(ctx.Err())
+			case <-time.After(powerTaskRetryDelay):
+				// continue to next task retry
+			}
+		}
 	}
-	return nil
+	log.Printf("[DEBUG] Power-off failed after %d attempts; last error: %v", maxPowerRetries, lastErr)
+	return diag.Errorf("error waiting for virtual machine (%s) to power off after %d attempts: %s",
+		utils.StringValue(taskUUID), maxPowerRetries, lastErr)
 }
 
 func callForPowerOnVM(ctx context.Context, conn *vmm.Client, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	prismConn := meta.(*conns.Client).PrismAPI
+	var lastErr error
+	var taskUUID *string
 
-	TaskRef, err := powerOnVM(ctx, conn, utils.StringPtr(d.Id()))
-	if err != nil {
-		return diag.Errorf("error while powering on Virtual Machine: %v", err)
-	}
-	taskUUID := TaskRef.ExtId
-	log.Printf("[DEBUG] PowerOn Response: TaskReference ExtId: %s (waiting for task)", utils.StringValue(taskUUID))
+	for taskAttempt := 0; taskAttempt < maxPowerRetries; taskAttempt++ {
+		getVmByIdRequest := import3.GetVmByIdRequest{
+			ExtId: utils.StringPtr(d.Id()),
+		}
+		readResp, errR := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+		if errR != nil {
+			return diag.Errorf("error while reading vm : %v", errR)
+		}
+		vmResp := readResp.Data.GetValue().(config.Vm)
+		currentPower := vmResp.PowerState.GetName()
+		log.Printf("[DEBUG] Power-on task attempt %d/%d: VM current power_state=%s", taskAttempt+1, maxPowerRetries, currentPower)
+		if currentPower == "ON" {
+			log.Printf("[DEBUG] VM is already in ON state")
+			return nil
+		}
 
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{"PENDING", "RUNNING", "QUEUED"},
-		Target:  []string{"SUCCEEDED"},
-		Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, prismConn, utils.StringValue(taskUUID)),
-		Timeout: d.Timeout(schema.TimeoutUpdate),
-	}
+		TaskRef, err := powerOnVM(ctx, conn, utils.StringPtr(d.Id()))
+		if err != nil {
+			lastErr = err
+			if taskAttempt < maxPowerRetries-1 {
+				log.Printf("[DEBUG] Power-on API failed (attempt %d/%d), retrying in %v: %v",
+					taskAttempt+1, maxPowerRetries, powerTaskRetryDelay, err)
+				select {
+				case <-ctx.Done():
+					return diag.FromErr(ctx.Err())
+				case <-time.After(powerTaskRetryDelay):
+					continue
+				}
+			}
+			return diag.Errorf("error while powering on Virtual Machine after %d attempts: %v", maxPowerRetries, err)
+		}
+		taskUUID = TaskRef.ExtId
+		log.Printf("[DEBUG] PowerOn Response: TaskReference ExtId: %s (waiting for task)", utils.StringValue(taskUUID))
 
-	if _, errWaitTask := stateConf.WaitForStateContext(ctx); errWaitTask != nil {
-		return diag.Errorf("error waiting for virtual machine (%s) to power on: %s",
-			utils.StringValue(taskUUID), errWaitTask)
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{"PENDING", "RUNNING", "QUEUED"},
+			Target:  []string{"SUCCEEDED"},
+			Refresh: common.TaskStateRefreshPrismTaskGroupFunc(ctx, prismConn, utils.StringValue(taskUUID)),
+			Timeout: d.Timeout(schema.TimeoutUpdate),
+		}
+
+		_, errWaitTask := stateConf.WaitForStateContext(ctx)
+		if errWaitTask == nil {
+			log.Printf("[DEBUG] Power-on task reported SUCCEEDED for task %s; verifying VM power_state", utils.StringValue(taskUUID))
+			getVmByIdRequest := import3.GetVmByIdRequest{
+				ExtId: utils.StringPtr(d.Id()),
+			}
+			verifyResp, errV := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+			if errV != nil {
+				log.Printf("[DEBUG] Could not re-read VM after task success: %v", errV)
+				return nil
+			}
+			verifyVM := verifyResp.Data.GetValue().(config.Vm)
+			actualPower := verifyVM.PowerState.GetName()
+			log.Printf("[DEBUG] VM power_state after task: %s (expected ON)", actualPower)
+			if actualPower != "ON" {
+				log.Printf("[DEBUG] WARNING: Task reported SUCCEEDED but VM power_state is %s (expected ON) - possible backend inconsistency or race", actualPower)
+			}
+			return nil
+		}
+		lastErr = errWaitTask
+		if taskAttempt < maxPowerRetries-1 {
+			log.Printf("[DEBUG] Power-on task failed or timed out (attempt %d/%d), retrying API call and task in %v: %v",
+				taskAttempt+1, maxPowerRetries, powerTaskRetryDelay, errWaitTask)
+			select {
+			case <-ctx.Done():
+				return diag.FromErr(ctx.Err())
+			case <-time.After(powerTaskRetryDelay):
+				// continue to next task retry
+			}
+		}
 	}
-	return nil
+	log.Printf("[DEBUG] Power-on failed after %d attempts; last error: %v", maxPowerRetries, lastErr)
+	return diag.Errorf("error waiting for virtual machine (%s) to power on after %d attempts: %s",
+		utils.StringValue(taskUUID), maxPowerRetries, lastErr)
 }
 
 func diffConfig(oldValue []interface{}, newValue []interface{}) ([]interface{}, []interface{}, []interface{}) {

--- a/nutanix/services/vmmv2/resource_nutanix_vm_cdrom_insert_eject_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vm_cdrom_insert_eject_v2.go
@@ -212,12 +212,23 @@ func ResourceNutanixVmsCdRomsInsertEjectV2Create(ctx context.Context, d *schema.
 			body.BackingInfo = expandVMDisk(backInfo)
 		}
 
+		getVmByIdRequest := import3.GetVmByIdRequest{
+			ExtId: utils.StringPtr(vmExtID.(string)),
+		}
+		readResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+		if err != nil {
+			return diag.Errorf("error while reading vm : %v", err)
+		}
+		// Extract E-Tag Header
+		args := make(map[string]interface{})
+		args["If-Match"] = getEtagHeader(readResp, conn)
+
 		insertCdRomByIdRequest := import3.InsertCdRomByIdRequest{
 			VmExtId: utils.StringPtr(vmExtID.(string)),
 			ExtId:   utils.StringPtr(extID.(string)),
 			Body:    &body,
 		}
-		resp, err := conn.VMAPIInstance.InsertCdRomById(ctx, &insertCdRomByIdRequest)
+		resp, err := conn.VMAPIInstance.InsertCdRomById(ctx, &insertCdRomByIdRequest, args)
 		if err != nil {
 			return diag.Errorf("error while inserting cd-rom : %v", err)
 		}

--- a/nutanix/services/vmmv2/resource_nutanix_vm_revert_from_recovery_points_replicate_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vm_revert_from_recovery_points_replicate_v2.go
@@ -47,6 +47,18 @@ func ResourceNutanixRevertVMRecoveryPointV2Create(ctx context.Context, d *schema
 
 	conn := meta.(*conns.Client).VmmAPI
 
+	extID := d.Get("ext_id")
+
+	getVmByIdRequest := import3.GetVmByIdRequest{
+		ExtId: utils.StringPtr(extID.(string)),
+	}
+	readResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+	if err != nil {
+		return diag.Errorf("error while fetching Vm : %v", err)
+	}
+	args := make(map[string]interface{})
+	args["If-Match"] = getEtagHeader(readResp, conn)
+
 	body := config.RevertParams{}
 	rpExtID := d.Get("ext_id").(string)
 
@@ -58,7 +70,7 @@ func ResourceNutanixRevertVMRecoveryPointV2Create(ctx context.Context, d *schema
 		ExtId: utils.StringPtr(rpExtID),
 		Body:  &body,
 	}
-	resp, err := conn.VMAPIInstance.RevertVm(ctx, &revertVmRequest)
+	resp, err := conn.VMAPIInstance.RevertVm(ctx, &revertVmRequest, args)
 	if err != nil {
 		return diag.Errorf("error while reverting vm : %v", err)
 	}

--- a/nutanix/services/vmmv2/resource_nutanix_vms_clone_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vms_clone_v2.go
@@ -1232,6 +1232,17 @@ func ResourceNutanixVMCloneV2Create(ctx context.Context, d *schema.ResourceData,
 	conn := meta.(*conns.Client).VmmAPI
 	vmExtID := d.Get("vm_ext_id")
 
+	getVmByIdRequest := import3.GetVmByIdRequest{
+		ExtId: utils.StringPtr(vmExtID.(string)),
+	}
+	readResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+	if err != nil {
+		return diag.Errorf("error while reading vm : %v", err)
+	}
+	// Extract E-Tag Header
+	args := make(map[string]interface{})
+	args["If-Match"] = getEtagHeader(readResp, conn)
+
 	body := &config.CloneOverrideParams{}
 
 	if name, ok := d.GetOk("name"); ok {
@@ -1266,7 +1277,7 @@ func ResourceNutanixVMCloneV2Create(ctx context.Context, d *schema.ResourceData,
 		ExtId: utils.StringPtr(vmExtID.(string)),
 		Body:  body,
 	}
-	resp, err := conn.VMAPIInstance.CloneVm(ctx, &cloneVmRequest)
+	resp, err := conn.VMAPIInstance.CloneVm(ctx, &cloneVmRequest, args)
 	if err != nil {
 		return diag.Errorf("error while Cloning Vm : %v", err)
 	}

--- a/nutanix/services/vmmv2/resource_nutanix_vms_gc_update_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vms_gc_update_v2.go
@@ -183,6 +183,17 @@ func ResourceNutanixVMGCUpdateV2Create(ctx context.Context, d *schema.ResourceDa
 	conn := meta.(*conns.Client).VmmAPI
 	vmExtID := d.Get("ext_id")
 
+	getVmByIdRequest := import3.GetVmByIdRequest{
+		ExtId: utils.StringPtr(vmExtID.(string)),
+	}
+	readResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+	if err != nil {
+		return diag.Errorf("error while reading vm : %v", err)
+	}
+	// Extract E-Tag Header
+	args := make(map[string]interface{})
+	args["If-Match"] = getEtagHeader(readResp, conn)
+
 	body := &config.GuestCustomizationParams{}
 
 	if configData, ok := d.GetOk("config"); ok {
@@ -193,7 +204,7 @@ func ResourceNutanixVMGCUpdateV2Create(ctx context.Context, d *schema.ResourceDa
 		ExtId: utils.StringPtr(vmExtID.(string)),
 		Body:  body,
 	}
-	resp, err := conn.VMAPIInstance.CustomizeGuestVm(ctx, &customizeGuestVmRequest)
+	resp, err := conn.VMAPIInstance.CustomizeGuestVm(ctx, &customizeGuestVmRequest, args)
 	if err != nil {
 		return diag.Errorf("error while creating Vm's Customize Guest : %v", err)
 	}

--- a/nutanix/services/vmmv2/resource_nutanix_vms_network_device_assign_ip_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vms_network_device_assign_ip_v2.go
@@ -68,12 +68,23 @@ func ResourceNutanixVmsNetworkDeviceAssignIPV2Create(ctx context.Context, d *sch
 		body.IpAddress = expandIPv4Address(ipAddress)
 	}
 
+	getVmByIdRequest := import3.GetVmByIdRequest{
+		ExtId: utils.StringPtr(vmExtID.(string)),
+	}
+	readResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+	if err != nil {
+		return diag.Errorf("error while reading vm : %v", err)
+	}
+	// Extract E-Tag Header
+	args := make(map[string]interface{})
+	args["If-Match"] = getEtagHeader(readResp, conn)
+
 	assignIpByIdRequest := import3.AssignIpByIdRequest{
 		VmExtId: utils.StringPtr(vmExtID.(string)),
 		ExtId:   utils.StringPtr(extID.(string)),
 		Body:    &body,
 	}
-	resp, err := conn.VMAPIInstance.AssignIpById(ctx, &assignIpByIdRequest)
+	resp, err := conn.VMAPIInstance.AssignIpById(ctx, &assignIpByIdRequest, args)
 	if err != nil {
 		return diag.Errorf("error while assigning IP : %v", err)
 	}
@@ -126,11 +137,22 @@ func ResourceNutanixVmsNetworkDeviceAssignIPV2Delete(ctx context.Context, d *sch
 	vmExtID := d.Get("vm_ext_id")
 	extID := d.Get("ext_id")
 
+	getVmByIdRequest := import3.GetVmByIdRequest{
+		ExtId: utils.StringPtr(vmExtID.(string)),
+	}
+	readResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+	if err != nil {
+		return diag.Errorf("error while reading vm : %v", err)
+	}
+	// Extract E-Tag Header
+	args := make(map[string]interface{})
+	args["If-Match"] = getEtagHeader(readResp, conn)
+
 	releaseIpByIdRequest := import3.ReleaseIpByIdRequest{
 		VmExtId: utils.StringPtr(vmExtID.(string)),
 		ExtId:   utils.StringPtr(extID.(string)),
 	}
-	resp, err := conn.VMAPIInstance.ReleaseIpById(ctx, &releaseIpByIdRequest)
+	resp, err := conn.VMAPIInstance.ReleaseIpById(ctx, &releaseIpByIdRequest, args)
 	if err != nil {
 		return diag.Errorf("error while releasing IP : %v", err)
 	}

--- a/nutanix/services/vmmv2/resource_nutanix_vms_network_device_migrate_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vms_network_device_migrate_v2.go
@@ -97,12 +97,23 @@ func ResourceNutanixVmsNetworkDeviceMigrateV2Create(ctx context.Context, d *sche
 		body.IpAddress = expandIPv4Address(ipAddress)
 	}
 
+	getVmByIdRequest := import3.GetVmByIdRequest{
+		ExtId: utils.StringPtr(vmExtID.(string)),
+	}
+	readResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+	if err != nil {
+		return diag.Errorf("error while reading vm : %v", err)
+	}
+	// Extract E-Tag Header
+	args := make(map[string]interface{})
+	args["If-Match"] = getEtagHeader(readResp, conn)
+
 	migrateNicByIdRequest := import3.MigrateNicByIdRequest{
 		VmExtId: utils.StringPtr(vmExtID.(string)),
 		ExtId:   utils.StringPtr(extID.(string)),
 		Body:    &body,
 	}
-	resp, err := conn.VMAPIInstance.MigrateNicById(ctx, &migrateNicByIdRequest)
+	resp, err := conn.VMAPIInstance.MigrateNicById(ctx, &migrateNicByIdRequest, args)
 	if err != nil {
 		return diag.Errorf("error while migrate nic : %v", err)
 	}
@@ -166,12 +177,23 @@ func ResourceNutanixVmsNetworkDeviceMigrateV2Update(ctx context.Context, d *sche
 		body.MigrateType = &p
 	}
 
+	getVmByIdRequest := import3.GetVmByIdRequest{
+		ExtId: utils.StringPtr(vmExtID.(string)),
+	}
+	readResp, err := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+	if err != nil {
+		return diag.Errorf("error while reading vm : %v", err)
+	}
+	// Extract E-Tag Header
+	args := make(map[string]interface{})
+	args["If-Match"] = getEtagHeader(readResp, conn)
+
 	migrateNicByIdRequest := import3.MigrateNicByIdRequest{
 		VmExtId: utils.StringPtr(vmExtID.(string)),
 		ExtId:   utils.StringPtr(extID.(string)),
 		Body:    &body,
 	}
-	resp, err := conn.VMAPIInstance.MigrateNicById(ctx, &migrateNicByIdRequest)
+	resp, err := conn.VMAPIInstance.MigrateNicById(ctx, &migrateNicByIdRequest, args)
 	if err != nil {
 		return diag.Errorf("error while migrate nic : %v", err)
 	}

--- a/nutanix/services/vmmv2/resource_nutanix_vms_shutdown_action_v2.go
+++ b/nutanix/services/vmmv2/resource_nutanix_vms_shutdown_action_v2.go
@@ -86,13 +86,24 @@ func ResourceNutanixVmsShutdownActionV2Create(ctx context.Context, d *schema.Res
 		body.GuestPowerStateTransitionConfig = &gstVal
 	}
 
+	getVmByIdRequest := import3.GetVmByIdRequest{
+		ExtId: utils.StringPtr(vmExtID.(string)),
+	}
+	readResp, errR := conn.VMAPIInstance.GetVmById(ctx, &getVmByIdRequest)
+	if errR != nil {
+		return diag.Errorf("error while reading vm : %v", errR)
+	}
+	// Extract E-Tag Header
+	args := make(map[string]interface{})
+	args["If-Match"] = getEtagHeader(readResp, conn)
+
 	var TaskRef import1.TaskReference
 	//nolint:gocritic // Keeping if-else for clarity in this specific case
 	if action == "shutdown" {
 		shutdownVmRequest := import3.ShutdownVmRequest{
 			ExtId: utils.StringPtr(vmExtID.(string)),
 		}
-		resp, err := conn.VMAPIInstance.ShutdownVm(ctx, &shutdownVmRequest)
+		resp, err := conn.VMAPIInstance.ShutdownVm(ctx, &shutdownVmRequest, args)
 		if err != nil {
 			return diag.Errorf("error while Shutdown VM : %v", err)
 		}
@@ -102,7 +113,7 @@ func ResourceNutanixVmsShutdownActionV2Create(ctx context.Context, d *schema.Res
 			ExtId: utils.StringPtr(vmExtID.(string)),
 			Body:  &body,
 		}
-		resp, err := conn.VMAPIInstance.ShutdownGuestVm(ctx, &shutdownGuestVmRequest)
+		resp, err := conn.VMAPIInstance.ShutdownGuestVm(ctx, &shutdownGuestVmRequest, args)
 		if err != nil {
 			return diag.Errorf("error while Shutdown Guest VM : %v", err)
 		}
@@ -111,7 +122,7 @@ func ResourceNutanixVmsShutdownActionV2Create(ctx context.Context, d *schema.Res
 		rebootVmRequest := import3.RebootVmRequest{
 			ExtId: utils.StringPtr(vmExtID.(string)),
 		}
-		resp, err := conn.VMAPIInstance.RebootVm(ctx, &rebootVmRequest)
+		resp, err := conn.VMAPIInstance.RebootVm(ctx, &rebootVmRequest, args)
 		if err != nil {
 			return diag.Errorf("error while performing Reboot VM  : %v", err)
 		}
@@ -121,7 +132,7 @@ func ResourceNutanixVmsShutdownActionV2Create(ctx context.Context, d *schema.Res
 			ExtId: utils.StringPtr(vmExtID.(string)),
 			Body:  &body,
 		}
-		resp, err := conn.VMAPIInstance.RebootGuestVm(ctx, &rebootGuestVmRequest)
+		resp, err := conn.VMAPIInstance.RebootGuestVm(ctx, &rebootGuestVmRequest, args)
 		if err != nil {
 			return diag.Errorf("error while performing Reboot Guest VM : %v", err)
 		}


### PR DESCRIPTION
# Revert "Remove ETag dependency from VM $action endpoints in AHV V4 APIs" (revert PR #55)

This PR reverts the changes introduced by ideadevice/terraform-provider-nutanix#55 (merge commit `caeba1840341c5b2a19111d84750cb238cf3f1e2`) which removed/changed usage of ETag (If-Match) headers and simplified some power task retry/verification flows in the VMM namespace.

## Reason for revert
- The changes removed pre-action VM re-reads and If-Match header usage for many VMM action endpoints. That introduced risk of regressions in action semantics and task reliability.
- Reverting to the previous behavior lets us restore correctness and acceptance tests while a safer design and validation plan for removing ETag dependencies is prepared.

## What this revert restores
- Reinstates pre-action VM GETs and the use of the `If-Match` (ETag) header for VM action and sub-resource endpoints that PR #55 modified.
- Restores the prior retry/verification behavior for power-on/power-off flows (including any task-waiting and verification re-reads) that were simplified/removed.
- Restores previous behavior for create/delete operations of VM subresources (NICs, Disks, CD-ROMs, GPUs, Serial Ports), and for operations such as Clone, Revert, and CustomizeGuestVm that were affected.

## Files reverted (summary)
- nutanix/services/vmmv2/resource_nutanix_virtual_machine_v2.go  
- nutanix/services/vmmv2/resource_nutanix_ova_vm_deploy_v2.go  
- nutanix/services/vmmv2/resource_nutanix_ngt_insert_iso_v2.go  
- nutanix/services/vmmv2/resource_nutanix_vm_cdrom_insert_eject_v2.go  
- nutanix/services/vmmv2/resource_nutanix_vms_clone_v2.go  
- nutanix/services/vmmv2/resource_nutanix_vms_gc_update_v2.go  
- nutanix/services/vmmv2/resource_nutanix_vms_network_device_assign_ip_v2.go  
- nutanix/services/vmmv2/resource_nutanix_vms_network_device_migrate_v2.go  
- nutanix/services/vmmv2/resource_nutanix_vms_shutdown_action_v2.go  
- nutanix/services/vmmv2/helper.go  
- nutanix/services/vmmv2/helper_test.go

## Testing notes
- Run unit tests and acceptance tests that exercise:
  - VM power operations (powerOn, powerOff, reboot, shutdown, guest shutdown/reboot).
  - CD-ROM operations (insert/eject).
  - NIC operations (create/delete/migrate, assign/release IP).
  - Disk create/delete and updates.
  - GPU, SerialPort create/delete and updates.
  - Clone, Revert, CustomizeGuestVm flows.
- Verify that ETag (If-Match) headers are being supplied where expected and that task wait/verification behaves as prior to PR #55.
- Confirm there are no new compile or lint failures after the revert.

## Merge/Reference
- Original PR: #55 — "Remove ETag dependency from VM $action endpoints in AHV V4 APIs"  
- Merge commit: `caeba1840341c5b2a19111d84750cb238cf3f1e2`
